### PR TITLE
minor XMLConfiguration.java log message fix

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -195,12 +195,12 @@ public class XMLConfiguration implements Configuration {
         if (configFileDirectory.startsWith("/") || configFileDirectory.contains(":\\")
                 || configFileDirectory.startsWith("\\\\")) {
 
-            log.info("Provided cache directory as absolute path '" + configFileDirectory + "'");
+            log.info("Provided configuration directory as absolute path '" + configFileDirectory + "'");
             this.configDirectory = new File(configFileDirectory);
         } else {
 
             String baseDir = context.getServletContext().getRealPath("");
-            log.info("Provided cache directory relative to servlet context '" + baseDir + "': "
+            log.info("Provided configuration directory relative to servlet context '" + baseDir + "': "
                     + configFileDirectory);
             this.configDirectory = new File(baseDir, configFileDirectory);
         }


### PR DESCRIPTION
change log message from cache- to configuration directory. this reduces confusion for users with geowebcache.xml outside of the cache directory
