### PR TITLE
Updated servlet-api dependency to 2.5

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <version>2.5</version>
       <scope>provided</scope>
     </dependency>
     


### PR DESCRIPTION
Updated servlet-api dependency to 2.5.  Fixes a NoSuchMethodError when running the Jetty test app from Eclipse.
