### PR TITLE
checking config enabled/disabled during when loading quota store

### DIFF
--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
@@ -33,7 +33,7 @@ public class QuotaStoreProvider implements ApplicationContextAware, Initializing
     }
 
     public void destroy() throws Exception {
-        store.close();
+        if (store != null) store.close();
     }
 
     public void afterPropertiesSet() throws Exception {
@@ -42,6 +42,9 @@ public class QuotaStoreProvider implements ApplicationContextAware, Initializing
 
     public void reloadQuotaStore() throws IOException, ConfigurationException {
         DiskQuotaConfig config = loader.loadConfig();
+        if (!config.isEnabled()) {
+            return;
+        }
         String quotaStoreName = config.getQuotaStore();
         if(quotaStoreName == null) {
             // the default quota store, for backwards compatibility

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/QuotaStoreProviderTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/QuotaStoreProviderTest.java
@@ -1,0 +1,39 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.geowebcache.diskquota;
+
+import junit.framework.TestCase;
+import static org.easymock.classextension.EasyMock.*;
+
+public class QuotaStoreProviderTest extends TestCase {
+
+    public void testDisabled() throws Exception {
+
+        DiskQuotaConfig config = createMock(DiskQuotaConfig.class);
+        expect(config.isEnabled()).andReturn(false).anyTimes();
+
+        ConfigLoader loader = createMock(ConfigLoader.class);
+        expect(loader.loadConfig()).andReturn(config);
+
+        replay(config, loader);
+
+        QuotaStoreProvider provider = new QuotaStoreProvider(loader);
+        provider.afterPropertiesSet();
+
+        assertNull(provider.getQuotaStore());
+
+        verify(config, loader);
+    }
+}


### PR DESCRIPTION
It seems the jdbc diskquota implementation doesn't respect the GWC_DISKQUOTA_DISABLED flag in that it still attempts a connection to the database. Looking at the bdb implementation it checks the flag and prevents a connection to the database. 

However rather than duplicate this logic in both implementations i figured doing the check at a higher level could also work. 
