### PR TITLE
specify infoMimeFormats pr layer and add support for JSON feature info

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/AbstractTileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/AbstractTileLayer.java
@@ -59,6 +59,8 @@ public abstract class AbstractTileLayer extends TileLayer {
     protected LayerMetaInformation metaInformation;
 
     protected List<String> mimeFormats;
+    
+    protected List<String> infoMimeFormats;
 
     protected List<FormatModifier> formatModifiers;
 
@@ -94,6 +96,8 @@ public abstract class AbstractTileLayer extends TileLayer {
     protected transient boolean saveExpirationHeaders;
 
     protected transient List<MimeType> formats;
+    
+    protected transient List<MimeType> infoFormats;
 
     protected transient Map<String, GridSubset> subSets;
 
@@ -243,6 +247,24 @@ public abstract class AbstractTileLayer extends TileLayer {
             gwce.printStackTrace();
         }
 
+        try {
+            // mimetypes for info
+            this.infoFormats = new ArrayList<MimeType>();
+            if (infoMimeFormats != null) {
+                for (String fmt : infoMimeFormats) {
+                	infoFormats.add(MimeType.createFromFormat(fmt));
+                }
+            }
+            if (infoFormats.size() == 0) {
+            	infoFormats.add(MimeType.createFromFormat("text/plain"));
+            	infoFormats.add(MimeType.createFromFormat("text/html"));
+            	infoFormats.add(MimeType.createFromFormat("application/vnd.ogc.gml"));
+            }
+        } catch (GeoWebCacheException gwce) {
+            log.error(gwce.getMessage());
+            gwce.printStackTrace();
+        }
+        
         if (subSets == null) {
             subSets = new HashMap<String, GridSubset>();
         }
@@ -373,7 +395,7 @@ public abstract class AbstractTileLayer extends TileLayer {
     public List<String> getMimeFormats() {
         return mimeFormats == null ? null : new ArrayList<String>(mimeFormats);
     }
-
+    
     /**
      * 
      * @return array with supported MIME types
@@ -383,6 +405,19 @@ public abstract class AbstractTileLayer extends TileLayer {
         return formats;
     }
 
+    public List<String> getInfoMimeFormats() {
+        return infoMimeFormats == null ? null : new ArrayList<String>(infoMimeFormats);
+    }
+
+    /**
+     * 
+     * @return array with supported MIME types for information
+     */
+    @Override
+    public List<MimeType> getInfoMimeTypes() {
+        return infoFormats;
+    }
+    
     @Override
     public int getExpireClients(int zoomLevel) {
         return getExpiration(this.expireClientsList, zoomLevel);

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -233,6 +233,12 @@ public abstract class TileLayer {
     public abstract List<MimeType> getMimeTypes();
 
     /**
+     * 
+     * @return array with supported MIME types for information
+     */
+    public abstract List<MimeType> getInfoMimeTypes();
+    
+    /**
      * Gets the expiration time to be declared to clients.
      * @param zoomLevel integer zoom level at which to consider the expiration rules
      * @return integer duration in seconds

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
@@ -27,6 +27,9 @@ public class ApplicationMime extends MimeType {
             "application/bil32", "bil32", "bil32",
             "application/bil32", false);
     
+    public static final ApplicationMime json = new ApplicationMime(
+            "application/json", "json", "json",
+            "application/json", false);
     
     private ApplicationMime(String mimeType, String fileExtension, 
                 String internalName, String format, boolean noop) {
@@ -43,6 +46,8 @@ public class ApplicationMime extends MimeType {
             return bil16;
         } else if (formatStr.equalsIgnoreCase(bil32.format)) {
             return bil32;
+        } else if (formatStr.equalsIgnoreCase(json.format)) {
+            return json;
         }
         
         return null;
@@ -53,6 +58,8 @@ public class ApplicationMime extends MimeType {
             return bil16;
         } else if (fileExtension.equals(bil32.fileExtension)) {
             return bil32;
+        } else if (fileExtension.equals(json.fileExtension)) {
+            return json;
         }
         
         return null;

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -197,6 +197,15 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="infoMimeFormats" type="gwc:MimeFormats" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            List of formats to be supported for GetFeatureInfo. These must be known to
+            GeoWebCache. Legal values are
+            text/plain, text/html, application/vnd.ogc.gml and application/json 
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="formatModifiers" type="gwc:formatModifiers" minOccurs="0">
         <xs:annotation>
           <xs:documentation xml:lang="en">

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
@@ -276,10 +276,36 @@ public class WMSGetCapabilities {
     }
 
     private void capabilityRequestGetFeatureInfo(StringBuilder str) {
+    	
+        // Find all the info formats we support
+        Iterable<TileLayer> layerIter = tld.getLayerList();
+
+        HashSet<String> formats = new HashSet<String>();
+
+        for (TileLayer layer : layerIter) {
+            if (!layer.isEnabled()) {
+                continue;
+            }
+            if (layer.getMimeTypes() != null) {
+                Iterator<MimeType> mimeIter = layer.getInfoMimeTypes().iterator();
+                while (mimeIter.hasNext()) {
+                    MimeType mime = mimeIter.next();
+                    formats.add(mime.getFormat());
+                }
+            } else {
+                formats.add("text/plain");
+                formats.add("text/html");
+                formats.add("application/vnd.ogc.gml");
+            }
+
+        }
+
+    	
         str.append("    <GetFeatureInfo>\n");
-        str.append("      <Format>text/plain</Format>\n");
-        str.append("      <Format>text/html</Format>\n");
-        str.append("      <Format>application/vnd.ogc.gml</Format>\n");
+        Iterator<String> formatIter = formats.iterator();
+        while (formatIter.hasNext()) {
+            str.append("      <Format>" + formatIter.next() + "</Format>\n");
+        }
         str.append("      <DCPType>\n");
         str.append("        <HTTP>\n");
         str.append("        <Get>\n");

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
@@ -314,6 +314,11 @@ public class WMSService extends Service {
             throw new GeoWebCacheException("The info_format parameter ("
                     + values.get("info_format") + ")is missing or not recognized.");
         }
+        
+        if (mimeType != null && !tl.getInfoMimeTypes().contains(mimeType)) {
+            throw new GeoWebCacheException("The info_format parameter ("
+                    + values.get("info_format") + ") is not supported.");
+        }
 
         ConveyorTile gfiConv = new ConveyorTile(sb, tl.getName(), gridSubset.getName(), null,
                 mimeType, null, tile.servletReq, tile.servletResp);

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -334,13 +334,12 @@ public class WMTSGetCapabilities {
      }
      
      private void layerInfoFormats(StringBuilder str, TileLayer layer) {
-         // TODO properly
-         if(layer.isQueryable()) {
-             str.append("    <InfoFormat>text/plain</InfoFormat>\n");
-             str.append("    <InfoFormat>text/html</InfoFormat>\n");
-             str.append("    <InfoFormat>application/vnd.ogc.gml</InfoFormat>\n");
+         if (layer.isQueryable()) {
+             Iterator<MimeType> mimeIter = layer.getInfoMimeTypes().iterator();
+        	 while (mimeIter.hasNext()) {
+        		 str.append("    <InfoFormat>"+mimeIter.next().getFormat()+"</InfoFormat>\n");
+        	 }
          }
-         
      }
      
      private void layerDimensions(StringBuilder str, TileLayer layer, List<ParameterFilter> filters) {


### PR DESCRIPTION
In a wmsLayer cache, I want to have support for GetFeatureInfo with application/json only. This pull request adds support for an optional infoMimeFormats-element for each wmsLayer. This information is checked upon during request and included in the capabilities output.

```
<wmsLayer>
 ....
  <infoMimeFormats>
    <string>application/json</string>
  </infoMimeFormats>
</wmsLayer>
```
