### PR TITLE
get rid of 'maxHostConnections must be greater than 0' message 

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/util/HttpClientBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/HttpClientBuilder.java
@@ -23,7 +23,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
-import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpConnectionManager;
@@ -155,8 +154,11 @@ public class HttpClientBuilder {
         HttpConnectionManagerParams params = new HttpConnectionManagerParams();
         params.setSoTimeout(backendTimeoutMillis);
         params.setConnectionTimeout(backendTimeoutMillis);
-        params.setMaxTotalConnections(concurrency);
-        params.setMaxConnectionsPerHost(HostConfiguration.ANY_HOST_CONFIGURATION, concurrency);
+        if (concurrency > 0) {
+            params.setMaxTotalConnections(concurrency);
+            params.setMaxConnectionsPerHost(
+                    HostConfiguration.ANY_HOST_CONFIGURATION, concurrency);
+        }
         
         connectionManager.setParams(params);
 


### PR DESCRIPTION
during GeoRSS poll.

java.lang.IllegalArgumentException: maxHostConnections must be greater than 0
    at org.apache.commons.httpclient.params.HttpConnectionManagerParams.setMaxConnectionsPerHost(HttpConnectionManagerParams.java:104)
    at org.geowebcache.util.HttpClientBuilder.buildClient(HttpClientBuilder.java:159)
    at org.geowebcache.georss.GeoRSSReaderFactory.createReader(GeoRSSReaderFactory.java:52)
