### PR TITLE
match geoserver dependencies and remove dead mortbay repo

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -15,7 +15,7 @@
     <jts.version>1.12</jts.version>
     <spring.version>3.1.1.RELEASE</spring.version>
     <restlet.version>1.0.8</restlet.version>
-    <xstream.version>1.3.1</xstream.version>
+    <xstream.version>1.4.3</xstream.version>
     <acegi.version>1.0.7</acegi.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.1</commons-io.version>
@@ -52,14 +52,6 @@
       <id>codehaus</id>
       <name>Code Haus</name>
       <url>http://repository.codehaus.org</url>
-    </repository>
-    <repository>
-      <id>mortbay</id>
-      <name>mortbay</name>
-      <url>http://www.mortbay.org/maven2/release</url>
-      <snapshots>
-	<enabled>false</enabled>
-      </snapshots>
     </repository>
     <repository>
       <id>maven-restlet</id>
@@ -209,7 +201,7 @@
     <dependency>
       <groupId>com.mockrunner</groupId>
       <artifactId>mockrunner</artifactId>
-      <version>0.3.1</version>
+      <version>0.3.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The mortbay repository is no longer functioning (generating a placeholder page which is saved as a jar corrupting the local repository).

Also updated xstream dependency to match geoserver
