### PR TITLE
#198 - Optional output folder for cache

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -653,6 +653,8 @@ public abstract class TileLayer {
                                 tileProto.getGridSetId(), tileProto.getMimeType().getFormat(),
                                 tileProto.getParameters(), resource);
                         tile.setCreated(requestTime);
+                        
+                        tile.setOutputFolder(tileProto.getStorageObject().getOutputFolder());
 
                         try {
                             if (tileProto.isMetaTileCacheOnly()) {

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
@@ -130,6 +130,8 @@ class SeedTask extends GWCTask {
             ConveyorTile tile = new ConveyorTile(storageBroker, layerName, tr.getGridSetId(), gridLoc,
                     tr.getMimeType(), fullParameters, null, null);
 
+            tile.getStorageObject().setOutputFolder(tr.getOutputFolder());
+            
             for (int fetchAttempt = 0; fetchAttempt <= tileFailureRetryCount; fetchAttempt++) {
                 try {
                     checkInterrupted();

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
@@ -120,6 +120,14 @@ public class TileObject extends StorageObject implements Serializable{
         return layer_name;
     }
 
+    public void setOutputFolder(String outputFolder) {
+        this.outputFolder = outputFolder;
+    }
+    public String getOutputFolder() {
+        return outputFolder;
+    }
+    private String outputFolder = null;
+    
     public Map<String, String> getParameters() {
         return parameters;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
@@ -157,6 +157,17 @@ public class TileRange {
         return parameters;
     }
 
+    /**
+     * @return the OutputFolder
+     */
+    public void setOutputFolder(String outputFolder) {
+        this.outputFolder = outputFolder;
+    }
+    public String getOutputFolder() {
+        return outputFolder;
+    }
+    private String outputFolder = null;
+    
     public long[] rangeBounds(final int zoomLevel) {
         if (zoomLevel < zoomStart) {
             throw new IllegalArgumentException(zoomLevel + " < zoomStart (" + zoomStart + ")");

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
@@ -76,7 +76,12 @@ public class FilePathGenerator {
 
         String fileExtension = mimeType.getFileExtension();
 
-        path.append(cacheRoot);
+        // Override to customize the rootPath by one optional user directory.
+        String pathRoot = cacheRoot;
+        String optionalPath = tile.getOutputFolder();
+        if (optionalPath!=null && optionalPath.length()>0) pathRoot = optionalPath;
+        path.append(pathRoot);
+        
         path.append(File.separatorChar);
         appendFiltered(tile.getLayerName(), path);
         path.append(File.separatorChar);

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/SeedFormRestlet.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/SeedFormRestlet.java
@@ -188,6 +188,8 @@ public class SeedFormRestlet extends GWCRestlet {
 
         makeBboxFields(doc);
 
+        makeOptionalOutputFolder(doc);
+        
         makeSubmit(doc);
 
         makeFormFooter(doc);
@@ -319,6 +321,14 @@ public class SeedFormRestlet extends GWCRestlet {
 
     }
 
+    private void makeOptionalOutputFolder(StringBuilder doc) {
+        
+        doc.append("<tr><td valign=\"top\">Output cache path:</td><td>\n");
+        makeTextInput(doc, "OutputFolder", 64);
+        doc.append("</br>These are optional.");
+        doc.append("</td></tr>\n");                
+    }
+    
     private void makeTextInput(StringBuilder doc, String id, int size) {
         doc.append("<input name=\"" + id + "\" type=\"text\" size=\"" + size + "\" />\n");
     }
@@ -767,6 +777,9 @@ public class SeedFormRestlet extends GWCRestlet {
 
         TileRange tr = TileBreeder.createTileRange(sr, tl);
 
+        String outputFolder = form.getFirst("OutputFolder").getValue();        
+        tr.setOutputFolder(outputFolder);
+        
         GWCTask[] tasks;
         try {
             tasks = seeder.createTasks(tr, tl, sr.getType(), sr.getThreadCount(),


### PR DESCRIPTION
Implements the possibility to indicate the output folder cache different
from default.

You could then execute seed tasks from several machines saving the
result to the final output cache. If you divide the generation cache in
non-overlapping areas, the generation elapsed time can be reduced
considerably.