### PR TITLE
GEOS-5531 Add missing newlines after <TileMatrixSetLink> in WMTS Capabil...

### DIFF
--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -379,7 +379,7 @@ public class WMTSGetCapabilities {
         for (String gridSetId : layer.getGridSubsets()) {
             GridSubset gridSubset = layer.getGridSubset(gridSetId);
          
-             str.append("    <TileMatrixSetLink>");
+             str.append("    <TileMatrixSetLink>\n");
              str.append("      <TileMatrixSet>" + gridSubset.getName() + "</TileMatrixSet>\n");
              
              if (! gridSubset.fullGridSetCoverage()) {
@@ -398,7 +398,7 @@ public class WMTSGetCapabilities {
                 }
                 str.append("      </TileMatrixSetLimits>\n");
             }
-            str.append("    </TileMatrixSetLink>");
+            str.append("    </TileMatrixSetLink>\n");
          }
      }
      


### PR DESCRIPTION
GEOS-5531

The WMTS GetCapabilities lacks newlines in the XML output for the `<TileMatrixSetLink>`. This should fix that issue so that the capabilities don't look like

```
<TileMatrixSetLink>      <TileMatrixSet>EPSG:2163</TileMatrixSet>
    </TileMatrixSetLink>  </Layer>
```

but rather

```
    <TileMatrixSetLink>
      <TileMatrixSet>EPSG:2163</TileMatrixSet>
    </TileMatrixSetLink>
```
