### PR TITLE
GeoRSS CLOSE_WAIT

### DIFF
--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSReaderFactory.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSReaderFactory.java
@@ -52,6 +52,7 @@ class GeoRSSReaderFactory {
         HttpClient httpClient = builder.buildClient();
 
         GetMethod getMethod = new GetMethod(url.toString());
+        getMethod.setRequestHeader("Connection", "close");
         if (builder.isDoAuthentication()) {
             getMethod.setDoAuthentication(true);
             httpClient.getParams().setAuthenticationPreemptive(true);


### PR DESCRIPTION
A GeoWebCache configured with a geoRssFeed might end up with lots of connections in CLOSE_WAIT state. One possible solution is to send the request header Connection with value close when fetching the GeoRSS.
