### PR TITLE
[Issue#246] Upgrade ImageIO-Ext version from 1.1.9 to 1.1.10

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -32,7 +32,7 @@
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs></maven.test.jvmargs>
-    <imageio-ext.version>1.1.9</imageio-ext.version>
+    <imageio-ext.version>1.1.10</imageio-ext.version>
   </properties>
   
   <repositories>


### PR DESCRIPTION
This pull request is related to the following Issue: https://github.com/GeoWebCache/geowebcache/issues/246. 
