### PR TITLE
upgrade master to guava 17.0.

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -87,7 +87,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
 
 
     <!-- Java Advanced Imaging (JAI) -->

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -22,7 +22,8 @@
     <commons-dbcp.version>1.3</commons-dbcp.version>
     <commons-lang.version>2.4</commons-lang.version>
     <commons-collections.version>3.1</commons-collections.version>
-    <guava.version>11.0.1</guava.version>
+    <guava.version>17.0</guava.version>
+    <jsr305.version>2.0.3</jsr305.version>
     <log4j.version>1.2.14</log4j.version>
     <h2.version>1.1.119</h2.version>
     <postgresql.version>8.4-701.jdbc3</postgresql.version>
@@ -97,6 +98,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
It has the jsr305 (javax.annotations) dependency as transitive
now so we have to declare it explicitly.
This is mainly to coordinate the dependency version with downstream projects.
