### PR TITLE
Setting compiler encoding to UTF-8.

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -535,6 +535,7 @@
     <configuration>
       <source>1.7</source>
       <target>1.7</target>
+      <encoding>UTF-8</encoding>
     </configuration>
       </plugin>
       


### PR DESCRIPTION
Without this setting compilation becomes platform specific and depends on whatever the encoding for the current locale. 
