### PR TITLE
Fixing double slashes in capabilities when gwc is deploy on root context '/' (Backport 1.6.x)

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/util/NullURLMangler.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/NullURLMangler.java
@@ -5,8 +5,14 @@ import org.apache.commons.lang.StringUtils;
 public class NullURLMangler implements URLMangler {
 
     public String buildURL(String baseURL, String contextPath, String path) {
-        return StringUtils.strip(baseURL, "/") + "/" + StringUtils.strip(contextPath, "/") + "/"
-                + StringUtils.stripStart(path, "/");
+        final String context = StringUtils.strip(contextPath, "/");
+         
+        // if context is root ("/") then don't append it to prevent double slashes ("//") in return URLs  
+        if ( context==null || context.isEmpty() ) {
+            return StringUtils.strip(baseURL, "/") + "/" + StringUtils.strip(path, "/");
+        } else {
+            return StringUtils.strip(baseURL, "/") + "/" + context + "/" + StringUtils.strip(path, "/");
+        }
     }
 
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/util/NullURLManglerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/NullURLManglerTest.java
@@ -25,5 +25,20 @@ public class NullURLManglerTest extends TestCase {
         String url = urlMangler.buildURL("http://foo.example.com/", "foo/", "bar");
         assertEquals("http://foo.example.com/foo/bar", url);
     }
+    
+    public void testBuildRootContext() throws Exception {
+        String url = urlMangler.buildURL("http://foo.example.com/", "/", "/bar");
+        assertEquals("http://foo.example.com/bar", url);
+    }
+    
+    public void testBuildNullContext() throws Exception {
+        String url = urlMangler.buildURL("http://foo.example.com/", null, "/bar");
+        assertEquals("http://foo.example.com/bar", url);
+    }
+
+    public void testBuildEmptyContext() throws Exception {
+        String url = urlMangler.buildURL("http://foo.example.com/", "", "/bar");
+        assertEquals("http://foo.example.com/bar", url);
+    }
 
 }


### PR DESCRIPTION
Backport on the 1.6.x branch of the https://github.com/GeoWebCache/geowebcache/pull/268
