### PR TITLE
Level directory names

### DIFF
--- a/documentation/en/user/source/configuration/layers/arcgistilingschemes.rst
+++ b/documentation/en/user/source/configuration/layers/arcgistilingschemes.rst
@@ -77,6 +77,18 @@ It is also possible to get rid of the standard tiling scheme layout and separate
         <tileCachePath>D:\\arcgistiles\\naturalearth\\</tileCachePath>
       </arcgisLayer>
 
+Levels hex-encoded
+------------------
+Configure whether or not the z-values (levels) should be hex-encoded or not by using the ``hexZoom`` property. Default to false (decimal).
+
+.. code-block:: xml
+
+      <arcgisLayer>
+        <name>naturalearth</name>
+        <tilingScheme>C:\\arcgiscache\\naturalearth\\Layers\\conf.xml</tilingScheme>
+        <hexZoom>true</hexZoom>
+      </arcgisLayer>
+
 OpenLayers Configuration
 ------------------------
 

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/ArcGISCacheLayer.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/ArcGISCacheLayer.java
@@ -62,6 +62,12 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
      */
     private File tileCachePath;
 
+    /**
+     * Optional, configure whether or not the z-values should be hex-encoded or not.
+     * If not provided defaults to false
+     */
+    private Boolean hexZoom;
+
     private transient CacheInfo cacheInfo;
 
     private transient BoundingBox layerBounds;
@@ -106,6 +112,14 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
         this.tileCachePath = tileCachePath;
     }
 
+    public boolean isHexZoom() {
+        return hexZoom;
+    }
+
+    public void setHexZoom(boolean hexZoom) {
+        this.hexZoom = hexZoom;
+    }
+
     /**
      * @see org.geowebcache.layer.TileLayer#initialize(org.geowebcache.grid.GridSetBroker)
      * @return {@code true} if success. Note this method's return type should be void. It's not
@@ -127,6 +141,9 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
                         + "' is set to '" + tileCachePath
                         + "' but the directory either does not exist or is not readable");
             }
+        }
+        if (this.hexZoom == null) {
+            this.hexZoom = false;
         }
         try {
             CacheInfoPersister tilingSchemeLoader = new CacheInfoPersister();
@@ -292,7 +309,7 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
         // bottom-right, and GWC computes tiles in bottom-left to top-right order
         final long y = (coverageMaxY - tileIndex[1]);
 
-        String level = Integer.toHexString(z);
+        String level = (this.hexZoom) ? Integer.toHexString(z) : Integer.toString(z);
         level = zeroPadder(level, 2);
 
         String row = Long.toHexString(y);

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -658,6 +658,14 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="hexZoom" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Optional. Configure whether or not the z-values (levels) should be hex-encoded or not.
+            Defaults to false
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 


### PR DESCRIPTION
Arcgis encodes levels (directory names) in decimal, not hexadecimal

```
$ ls -l _alllayers
total 116
drwxrwxrwx    5 nobody nogroup  4096 oct 29  2012 L00
drwxrwxrwx    6 nobody nogroup  4096 oct 29  2012 L01
drwxrwxrwx    6 nobody nogroup  4096 oct 29  2012 L02
drwxrwxrwx   10 nobody nogroup  4096 oct 29  2012 L03
drwxrwxrwx   16 nobody nogroup  4096 mar 13  2014 L04
drwxrwxrwx   29 nobody nogroup  4096 mar 13  2014 L05
drwxrwxrwx   42 nobody nogroup  4096 mar 13  2014 L06
drwxrwxrwx   74 nobody nogroup  4096 mar 13  2014 L07
drwxrwxrwx   90 nobody nogroup  4096 mar 13  2014 L08
drwxrwxrwx  106 nobody nogroup  4096 mar  3  2014 L09
drwxrwxrwx  162 nobody nogroup  4096 mar  3  2014 L10
drwxrwxrwx  314 nobody nogroup 12288 oct 29  2012 L11
drwxrwxrwx  754 nobody nogroup 24576 oct 29  2012 L12
drwxrwxrwx 1330 nobody nogroup 36864 nov  5  2012 L13
```