### PR TITLE
#282 - Option to Normalize case of String and Regex Parameter Filters

### DIFF
--- a/documentation/en/user/source/configuration/layers/parameterfilters.rst
+++ b/documentation/en/user/source/configuration/layers/parameterfilters.rst
@@ -153,3 +153,23 @@ The resulting parameter filter would be:
      </regexParameterFilter>
    </parameterFilters>
 
+Case normalization
+------------------
+
+You can normalize the case of a Regular Expression or String rule to upper or lower case by adding a ``normalize`` element.  This takes a ``case`` and an optional ``locale``.  ``case`` may be ``NONE`` for no normalization, ``UPPER`` for upper case, or ``LOWER`` for lower case.  ``locale`` may be any Java locale identifier supported by the JVM and the JVM default locale will be used if not specified.
+
+.. code-block:: xml
+
+   <parameterFilters>
+     <regexParameterFilter>
+       <key>styles</key>
+       <defaultValue></defaultValue>
+       <normalize>
+         <case>UPPER</case>
+	 <locale>en_CA</locale> <!-- Canadian English locale-->
+       <regex>^(|polygon|population)$</regex>
+     </regexParameterFilter>
+   </parameterFilters>
+
+If upper or lower case normalization is used, matching with legal values will be case insensitive, otherwise it will be case sensitive.  The default value is never normalized.
+

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -124,6 +124,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-integration</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -148,6 +148,11 @@
       <artifactId>mockrunner</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
 
 	<!-- Thijs Brentjens: for security fixes, OWASP library-->
 	<dependency>

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -62,6 +62,7 @@ import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.config.ContextualConfigurationProvider.Context;
 import org.geowebcache.config.meta.ServiceInformation;
+import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.FloatParameterFilter;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.parameters.RegexParameterFilter;
@@ -513,10 +514,11 @@ public class XMLConfiguration implements Configuration {
         xs.alias("parameterFilters", new ArrayList<ParameterFilter>().getClass());
         xs.alias("parameterFilter", ParameterFilter.class);
         xs.alias("seedRequest", SeedRequest.class);
-
+        
+        xs.processAnnotations(CaseNormalizer.class);
+        xs.processAnnotations(StringParameterFilter.class);
+        xs.processAnnotations(RegexParameterFilter.class);
         xs.alias("floatParameterFilter", FloatParameterFilter.class);
-        xs.alias("regexParameterFilter", RegexParameterFilter.class);
-        xs.alias("stringParameterFilter", StringParameterFilter.class);
 
         xs.alias("formatModifier", FormatModifier.class);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
@@ -1,0 +1,91 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2015
+ */
+package org.geowebcache.filter.parameters;
+
+import java.util.Locale;
+
+import com.google.common.base.Function;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+public class CaseNormalizer implements Function<String, String>{
+    public static enum Case {
+        NONE(){
+            @Override
+            public String apply(String input, Locale loc) {
+                return input;
+            }
+            
+        },
+        UPPER {
+            @Override
+            public String apply(String input, Locale loc) {
+                return input.toUpperCase(loc);
+            }
+        },
+        LOWER {
+            @Override
+            public String apply(String input, Locale loc) {
+                return input.toLowerCase(loc);
+            }
+        }
+        ;
+        abstract public String apply(String input, Locale loc);
+    }
+    
+    @XStreamAlias("case")
+    Case kase;
+    Locale locale;
+    
+    public CaseNormalizer() {
+        this((Case) null);
+    }
+    
+    public CaseNormalizer(Case kase) {
+        this(kase, (Locale) null);
+    }
+    
+    public CaseNormalizer(Case kase, Locale locale) {
+        super();
+        this.kase = kase;
+        this.locale = locale;
+    }
+    
+    /**
+     * Apply normalisation to given string.  Guaranteed to be idempotent.
+     * @param input
+     * @return The normalised string.
+     */
+    public String apply(String input) {
+        return getCase().apply(input, getLocale());
+    }
+    
+    public Case getCase() {
+        if(kase==null) {
+            return Case.NONE;
+        } else {
+            return kase;
+        }
+    }
+    
+    public Locale getLocale() {
+        if (locale==null) {
+            return Locale.getDefault();
+        } else {
+            return locale;
+        }
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
@@ -1,0 +1,50 @@
+package org.geowebcache.filter.parameters;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+
+public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
+    
+    private CaseNormalizer normalize;
+    
+    public CaseNormalizingParameterFilter() {
+        super();
+    }
+    
+    public CaseNormalizingParameterFilter(String key, String defaultValue) {
+        super(key, defaultValue);
+    }
+    
+    public abstract List<String> getValues();
+    
+    public CaseNormalizingParameterFilter(String key) {
+        super(key);
+    }
+    
+    public CaseNormalizer getNormalize() {
+        if(normalize!=null) {
+            return normalize;
+        } else {
+            return new CaseNormalizer();
+        }
+    }
+    
+    public void setNormalize(CaseNormalizer normalize) {
+        this.normalize = normalize;
+    }
+    
+    @Override
+    public  @Nullable List<String> getLegalValues() {
+        List<String> values = getValues();
+        if(values == null) {
+            return null;
+        } else {
+            return Lists.transform(values, getNormalize());
+        }
+    }
+    
+}

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -987,6 +987,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="normalize" type="gwc:CaseNormalize" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+	    Case normalization rule for this filter.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="regex" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en">
@@ -1074,11 +1081,37 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="normalize" type="gwc:CaseNormalize" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+	    Case normalization rule for this filter.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="values" type="gwc:StringList">
         <xs:annotation>
           <xs:documentation xml:lang="en">
             A list of strings that represent possible values. These are case
             sensitive.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CaseNormalize">
+    <xs:sequence>
+      <xs:element name="case" type="xs:string">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+	    The case to normalize to: NONE for no normalization, UPPER for upper case, LOWER for lower case.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="locale" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+	    The locale to use when normalizing the case.  For instance: "en" for English, "en_CA" for Canadian English.
           </xs:documentation>
         </xs:annotation>
       </xs:element>

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
@@ -1,0 +1,271 @@
+package org.geowebcache.filter.parameters;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.custommonkey.xmlunit.XMLAssert;
+import org.geowebcache.filter.parameters.CaseNormalizer.Case;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.thoughtworks.xstream.XStream;
+
+public class RegexParameterFilterTest {
+    
+    private RegexParameterFilter filter;
+    private XStream xs;
+    
+    @Before
+    public void setUp() {
+        filter = new RegexParameterFilter();
+        filter.setKey("TEST");
+        filter.setRegex("foo|Bar|BAZ");
+        filter.setDefaultValue("Default");
+        
+        xs = new XStream();
+        xs.processAnnotations(CaseNormalizer.class);
+        xs.processAnnotations(RegexParameterFilter.class);
+    }
+    
+    @Test
+    public void testBasic() throws Exception {
+        assertThat(filter.getNormalize(), allOf(
+                hasProperty("case", equalTo(Case.NONE)),
+                hasProperty("locale", equalTo(Locale.getDefault()))));
+        
+        assertThat(filter.getLegalValues(), nullValue());
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeUpper() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
+        
+        assertThat(filter.getLegalValues(), nullValue());
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toUpperCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toUpperCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeLower() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.LOWER, Locale.ENGLISH));
+        
+        assertThat(filter.getLegalValues(), nullValue());
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeLocale() throws Exception {
+        filter.setRegex("f\u0131o|B\u0131r|BIZ");
+        
+        filter.setNormalize(new CaseNormalizer(Case.LOWER, Locale.forLanguageTag("tr")));
+        
+        assertThat(filter.getLegalValues(), nullValue());
+        
+        for(String test: Arrays.asList("f\u0131o", "B\u0131r", "BIZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.forLanguageTag("tr"))));
+        }
+        for(String test: Arrays.asList("F\u0131o", "FIO", "B\u0131R", "b\u0131r", "BIR", "BIz", "b\u0131z")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.forLanguageTag("tr"))));
+        }
+        for(String test: Arrays.asList("f\u0131oo", "f\u0131", "B\u0131", "BB\u0131rr", "BI", "BBIZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    @Test
+    public void testToXMLNullNormalizer() throws Exception {
+        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <regex>foo|Bar|BAZ</regex>\n"+
+                "</regexParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLDefaultNormalizer() throws Exception {
+        filter.setNormalize(new CaseNormalizer());
+        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <normalize/>\n"+
+                "  <regex>foo|Bar|BAZ</regex>\n"+
+                "</regexParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLNoneNormalizer() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.NONE));
+        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+                                 "  <key>TEST</key>\n"+
+                                 "  <defaultValue>Default</defaultValue>\n"+
+                                 "  <normalize>\n"+
+                                 "    <case>NONE</case>\n"+
+                                 "  </normalize>\n"+
+                                 "  <regex>foo|Bar|BAZ</regex>\n"+
+                                 "</regexParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLUpperCanadianEnglish() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.CANADA));
+        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+                                 "  <key>TEST</key>\n"+
+                                 "  <defaultValue>Default</defaultValue>\n"+
+                                 "  <normalize>\n"+
+                                 "    <case>UPPER</case>\n"+
+                                 "    <locale>en_CA</locale>\n"+
+                                 "  </normalize>\n"+
+                                 "  <regex>foo|Bar|BAZ</regex>\n"+
+                                 "</regexParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testFromXMLUpperCanadianEnglish() throws Exception {
+        Object o = xs.fromXML(
+            "<regexParameterFilter>\n"+
+            "  <key>TEST</key>\n"+
+            "  <defaultValue>Default</defaultValue>\n"+
+            "  <normalize>\n"+
+            "    <case>UPPER</case>\n"+
+            "    <locale>en_CA</locale>\n"+
+            "  </normalize>\n"+
+            "  <regex>foo|Bar|BAZ</regex>\n"+
+            "</regexParameterFilter>");
+        
+        assertThat(o, instanceOf(RegexParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.UPPER)),
+                hasProperty("locale", is(Locale.CANADA))
+                )));
+        assertThat(o, hasProperty("regex", equalTo("foo|Bar|BAZ")));
+    }
+    
+    @Test
+    public void testFromXMLIdentifiersCaseInsensitive() throws Exception {
+        Object o = xs.fromXML(
+            "<regexParameterFilter>\n"+
+            "  <key>TEST</key>\n"+
+            "  <defaultValue>Default</defaultValue>\n"+
+            "  <normalize>\n"+
+            "    <case>uPPer</case>\n"+
+            "    <locale>EN_ca</locale>\n"+
+            "  </normalize>\n"+
+            "  <regex>foo|Bar|BAZ</regex>\n"+
+            "</regexParameterFilter>");
+        
+        assertThat(o, instanceOf(RegexParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.UPPER)),
+                hasProperty("locale", is(Locale.CANADA))
+                )));
+        assertThat(o, hasProperty("regex", equalTo("foo|Bar|BAZ")));
+    }
+    
+    @Test
+    public void testFromXMLDefaultNormalize() throws Exception {
+        // important for backward compatibility with older config files
+        Object o = xs.fromXML(
+                "<regexParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <regex>foo|Bar|BAZ</regex>\n"+
+                "</regexParameterFilter>");
+        
+        assertThat(o, instanceOf(RegexParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.NONE))
+                )));
+        assertThat(o, hasProperty("regex", equalTo("foo|Bar|BAZ")));
+    }
+
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
@@ -1,0 +1,297 @@
+package org.geowebcache.filter.parameters;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.custommonkey.xmlunit.XMLAssert;
+import org.geowebcache.filter.parameters.CaseNormalizer.Case;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.thoughtworks.xstream.XStream;
+
+public class StringParameterFilterTest {
+    
+    private StringParameterFilter filter;
+    private XStream xs;
+    
+    @Before
+    public void setUp() {
+        filter = new StringParameterFilter();
+        filter.setKey("TEST");
+        filter.setValues(Arrays.asList("foo", "Bar", "BAZ"));
+        filter.setDefaultValue("Default");
+        
+        xs = new XStream();
+        xs.processAnnotations(CaseNormalizer.class);
+        xs.processAnnotations(StringParameterFilter.class);
+    }
+    
+    @Test
+    public void testBasic() throws Exception {
+        assertThat(filter.getNormalize(), allOf(
+                hasProperty("case", equalTo(Case.NONE)),
+                hasProperty("locale", equalTo(Locale.getDefault()))));
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("foo", "Bar", "BAZ"));
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeUpper() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("FOO", "BAR", "BAZ"));
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toUpperCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toUpperCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeLower() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.LOWER, Locale.ENGLISH));
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("foo", "bar", "baz"));
+        
+        for(String test: Arrays.asList("foo", "Bar", "BAZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("Foo", "FOO", "BaR", "bar", "BAR", "BAz", "baz")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.ENGLISH)));
+        }
+        for(String test: Arrays.asList("fooo", "fo", "Ba", "BBarr", "BA", "BBAZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testNormalizeLocale() throws Exception {
+        filter.setValues(Arrays.asList("f\u0131o", "B\u0131r", "BIZ"));
+        
+        filter.setNormalize(new CaseNormalizer(Case.LOWER, Locale.forLanguageTag("tr")));
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("f\u0131o", "b\u0131r", "b\u0131z"));
+        
+        for(String test: Arrays.asList("f\u0131o", "B\u0131r", "BIZ")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.forLanguageTag("tr"))));
+        }
+        for(String test: Arrays.asList("F\u0131o", "FIO", "B\u0131R", "b\u0131r", "BIR", "BIz", "b\u0131z")) {
+            assertThat(filter.applies(test), is(true));
+            assertThat(filter.apply(test), equalTo(test.toLowerCase(Locale.forLanguageTag("tr"))));
+        }
+        for(String test: Arrays.asList("f\u0131oo", "f\u0131", "B\u0131", "BB\u0131rr", "BI", "BBIZ")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testToXMLNullNormalizer() throws Exception {
+        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <values>\n"+
+                "    <string>foo</string>\n"+
+                "    <string>Bar</string>\n"+
+                "    <string>BAZ</string>\n"+
+                "  </values>\n"+
+                "</stringParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLDefaultNormalizer() throws Exception {
+        filter.setNormalize(new CaseNormalizer());
+        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <normalize/>\n"+
+                "  <values>\n"+
+                "    <string>foo</string>\n"+
+                "    <string>Bar</string>\n"+
+                "    <string>BAZ</string>\n"+
+                "  </values>\n"+
+                "</stringParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLNoneNormalizer() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.NONE));
+        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+                                 "  <key>TEST</key>\n"+
+                                 "  <defaultValue>Default</defaultValue>\n"+
+                                 "  <normalize>\n"+
+                                 "    <case>NONE</case>\n"+
+                                 "  </normalize>\n"+
+                                 "  <values>\n"+
+                                 "    <string>foo</string>\n"+
+                                 "    <string>Bar</string>\n"+
+                                 "    <string>BAZ</string>\n"+
+                                 "  </values>\n"+
+                                 "</stringParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testToXMLUpperCanadianEnglish() throws Exception {
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.CANADA));
+        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+                                 "  <key>TEST</key>\n"+
+                                 "  <defaultValue>Default</defaultValue>\n"+
+                                 "  <normalize>\n"+
+                                 "    <case>UPPER</case>\n"+
+                                 "    <locale>en_CA</locale>\n"+
+                                 "  </normalize>\n"+
+                                 "  <values>\n"+
+                                 "    <string>foo</string>\n"+
+                                 "    <string>Bar</string>\n"+
+                                 "    <string>BAZ</string>\n"+
+                                 "  </values>\n"+
+                                 "</stringParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testFromXMLUpperCanadianEnglish() throws Exception {
+        Object o = xs.fromXML(
+            "<stringParameterFilter>\n"+
+            "  <key>TEST</key>\n"+
+            "  <defaultValue>Default</defaultValue>\n"+
+            "  <normalize>\n"+
+            "    <case>UPPER</case>\n"+
+            "    <locale>en_CA</locale>\n"+
+            "  </normalize>\n"+
+            "  <values>\n"+
+            "    <string>foo</string>\n"+
+            "    <string>Bar</string>\n"+
+            "    <string>BAZ</string>\n"+
+            "  </values>\n"+
+            "</stringParameterFilter>");
+        
+        assertThat(o, instanceOf(StringParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.UPPER)),
+                hasProperty("locale", is(Locale.CANADA))
+                )));
+        assertThat(o, hasProperty("values", containsInAnyOrder("foo", "Bar", "BAZ")));
+    }
+    
+    @Test
+    public void testFromXMLIdentifiersCaseInsensitive() throws Exception {
+        Object o = xs.fromXML(
+            "<stringParameterFilter>\n"+
+            "  <key>TEST</key>\n"+
+            "  <defaultValue>Default</defaultValue>\n"+
+            "  <normalize>\n"+
+            "    <case>uPPer</case>\n"+
+            "    <locale>EN_ca</locale>\n"+
+            "  </normalize>\n"+
+            "  <values>\n"+
+            "    <string>foo</string>\n"+
+            "    <string>Bar</string>\n"+
+            "    <string>BAZ</string>\n"+
+            "  </values>\n"+
+            "</stringParameterFilter>");
+        
+        assertThat(o, instanceOf(StringParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.UPPER)),
+                hasProperty("locale", is(Locale.CANADA))
+                )));
+        assertThat(o, hasProperty("values", containsInAnyOrder("foo", "Bar", "BAZ")));
+    }
+    
+    @Test
+    public void testFromXMLDefaultNormalize() throws Exception {
+        // important for backward compatibility with older config files
+        Object o = xs.fromXML(
+            "<stringParameterFilter>\n"+
+            "  <key>TEST</key>\n"+
+            "  <defaultValue>Default</defaultValue>\n"+
+            "  <values>\n"+
+            "    <string>foo</string>\n"+
+            "    <string>Bar</string>\n"+
+            "    <string>BAZ</string>\n"+
+            "  </values>\n"+
+            "</stringParameterFilter>");
+        
+        assertThat(o, instanceOf(StringParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("normalize", allOf(
+                instanceOf(CaseNormalizer.class),
+                hasProperty("case", is(Case.NONE))
+                )));
+        assertThat(o, hasProperty("values", containsInAnyOrder("foo", "Bar", "BAZ")));
+    }
+}

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -14,7 +14,7 @@
     <jts.version>1.13</jts.version>
     <spring.version>3.1.1.RELEASE</spring.version>
     <restlet.version>1.0.8</restlet.version>
-    <xstream.version>1.4.3</xstream.version>
+    <xstream.version>1.4.7</xstream.version>
     <acegi.version>1.0.7</acegi.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.1</commons-io.version>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -234,6 +234,7 @@
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
     </dependency>
     
     <!-- Spring dependencies -->

--- a/geowebcache/wmts/pom.xml
+++ b/geowebcache/wmts/pom.xml
@@ -34,6 +34,7 @@
      <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Implements #282.  StringParameterFilter and RegexParameterFilter can now take a CaseNormalizer which can convert to Upper or Lower case and which can be configured with a locale.

Config files that don't specify the normalizer are accepted and default to not normalizing.