### PR TITLE
#298 Add IntegerParameterFilter

### DIFF
--- a/documentation/en/user/source/configuration/layers/parameterfilters.rst
+++ b/documentation/en/user/source/configuration/layers/parameterfilters.rst
@@ -5,10 +5,11 @@ Parameter Filters
 
 Parameter filters provide templates for extracting arbitrary parameters from requests. This allows using GeoWebCache in scenarios such as time series data, multiple styles for the same layer or with CQL filters set by the client.
 
-There are three types of parameter filters:
+There are four types of parameter filters:
 
 #. **String filters** (``<stringParameterFilter>``)
-#. **Numerical filters** (``<floatParameterFilter>``)
+#. **Floating point number filters** (``<floatParameterFilter>``)
+#. **Integer filters** (``<integerParameterFilter>``)
 #. **Regular expression filters**  (``<regexParameterFilter>``)
 
 A given layer can have multiple types of parameter filters.
@@ -62,8 +63,8 @@ The resulting parameter filter would be:
      </stringParameterFilter>
    </parameterFilters>
 
-Numerical filter
-----------------
+Floating point filter
+---------------------
 
 Similar to a string filter, GeoWebCache can also recognize a list of numerical values for a given key.  If the value requested matches one of the values specified in the filter, the request will proceed.
 
@@ -91,25 +92,77 @@ This information is presented in the following schema inside the ``<wmsLayer>`` 
      </floatParameterFilter>
    </parameterFilters>
 
-For example, given a parameter called "year" (assuming this was recognized by the WMS), where the allowed values are "1999" and "2006" and the default value being "2006", the filter would be:
+For example, given a parameter called ``elevation``, where the allowed values are ``-42.5``, ``0``, and ``100`` and the default value being ``100``, the filter would be:
 
 .. code-block:: xml
 
    <parameterFilters>
      <floatParameterFilter>
-       <key>year</key>
-       <defaultValue>2006</defaultValue>
+       <key>elevation</key>
+       <defaultValue>-42.5</defaultValue>
        <values>
-         <float>1999</float>
-         <float>2006</float>
+         <float>42.5</float>
+         <float>0</float>
+         <float>100</float>
        </values>
-       <threshold>1</threshold>
+       <threshold>50</threshold>
      </floatParameterFilter>
    </parameterFilters>
 
-Note also the above example sets a threshold of 1.  A value that is within the threshold of any of the allowed values will still proceed, albeit rounded to one of the allowed values.  So in this example, a value of "1997" would be successfully requested as "1996", but a value of "2002" will fail.
+Note also the above example sets a threshold of ``50``.  A value that is within the threshold of any of the allowed values will still proceed, albeit rounded to one of the allowed values.  So in this example, a value of ``75`` would be successfully requested as ``100.0``, but a value of ``200`` will fail.
 
 Thresholds are also valuable when managing possible floating point rounding errors.  For example, if your data has accuracy down to the sixth decimal place, you may want to use a threshold of ``1e-6`` to ensure proper matching.
+
+Note that the request value produced by the filter will *always* include a decimal point and floating point arithmetic has limitted precision that can means certain values can't be correctly represented.  If you are working with exclusively integer ("whole number") values, it's better to use the ``integerParameterFilter`` instead.
+
+Integer filter
+--------------
+
+This works in much the same way as the floating point filter, but only allows whole numbers, including negatives.
+
+Again, four pieces of information are required:
+
+* **Key** (``<key>``).  This key is not case sensitive.
+* **Default value** (``<defaultValue>``).
+* **List of values** (``<values>``, ``<int>``). 
+* **Threshold** (``<threshold>``).
+
+This information is presented in the following schema inside the ``<wmsLayer>`` tag:
+
+.. code-block:: xml
+
+   <parameterFilters>
+     <integerParameterFilter>
+       <key> ... </key>
+       <defaultValue> ... </defaultValue>
+       <values>
+         <int> ... </int>
+         <int> ... </int>
+         ...
+       </values>
+       <threshold> ... </threshold>
+     </integerParameterFilter>
+   </parameterFilters>
+
+If the paramter were ``dim_year``, where the allowed values are ``1996``, and ``2006`` and the default value being ``2006``, the filter would be:
+
+.. code-block:: xml
+
+   <parameterFilters>
+     <integerParameterFilter>
+       <key>dim_year</key>
+       <defaultValue>2006</defaultValue>
+       <values>
+         <float>1996</float>
+         <float>2006</float>
+       </values>
+       <threshold>2</threshold>
+     </floatParameterFilter>
+   </parameterFilters>
+
+Note also the above example sets a threshold of ``2`` to only cover the specific value listed and one year either side.  So in this example, a value of ``2007`` would be successfully requested as ``2006``, but a value of ``2008`` will fail.
+
+Note that unlike the ``floatParameterFilter``, there is no decimal point in the requested value.
 
 
 Regular expression filter

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -518,7 +518,7 @@ public class XMLConfiguration implements Configuration {
         xs.processAnnotations(CaseNormalizer.class);
         xs.processAnnotations(StringParameterFilter.class);
         xs.processAnnotations(RegexParameterFilter.class);
-        xs.alias("floatParameterFilter", FloatParameterFilter.class);
+        xs.processAnnotations(FloatParameterFilter.class);
 
         xs.alias("formatModifier", FormatModifier.class);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -64,6 +64,7 @@ import org.geowebcache.config.ContextualConfigurationProvider.Context;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.FloatParameterFilter;
+import org.geowebcache.filter.parameters.IntegerParameterFilter;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.parameters.RegexParameterFilter;
 import org.geowebcache.filter.parameters.StringParameterFilter;
@@ -519,6 +520,7 @@ public class XMLConfiguration implements Configuration {
         xs.processAnnotations(StringParameterFilter.class);
         xs.processAnnotations(RegexParameterFilter.class);
         xs.processAnnotations(FloatParameterFilter.class);
+        xs.processAnnotations(IntegerParameterFilter.class);
 
         xs.alias("formatModifier", FormatModifier.class);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
@@ -24,12 +24,15 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+
 import com.google.common.base.Preconditions;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Filter to select the closest floating point value within a threshold.
  */
 @ParametersAreNonnullByDefault
+@XStreamAlias("floatParameterFilter")
 public class FloatParameterFilter extends ParameterFilter {
 
     private static final long serialVersionUID = 4186888723396139208L;
@@ -53,12 +56,19 @@ public class FloatParameterFilter extends ParameterFilter {
             values = new ArrayList<Float>(0);
         }
         if (threshold == null) {
-            threshold = DEFAULT_THRESHOLD;
+            threshold = getDefaultThreshold();
         }
         for(Float value: values) {
             Preconditions.checkNotNull(value, "Value list included a null pointer.");
         }
         return this;
+    }
+
+    /**
+     * @return
+     */
+    protected Float getDefaultThreshold() {
+        return DEFAULT_THRESHOLD;
     }
 
     /**
@@ -94,7 +104,7 @@ public class FloatParameterFilter extends ParameterFilter {
      *            the threshold to set
      */
     public void setThreshold(@Nullable Float threshold) {
-        if(threshold==null) threshold = DEFAULT_THRESHOLD;
+        if(threshold==null) threshold = getDefaultThreshold();
         this.threshold = threshold;
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
@@ -12,7 +12,9 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * 
- * @author Arne Kepp, The Open Planning Project, Copyright 2009
+ * @author Kevin Smith, Boundless, Copyright 2015
+ * 
+ * Based on FloatParameterFilter: Arne Kepp, The Open Planning Project, Copyright 2009
  */
 package org.geowebcache.filter.parameters;
 
@@ -29,7 +31,7 @@ import com.google.common.base.Preconditions;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Filter to select the closest Integering point value within a threshold.
+ * Filter to select the closest Integer value within a threshold.
  */
 @ParametersAreNonnullByDefault
 @XStreamAlias("integerParameterFilter")

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
@@ -1,0 +1,169 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Arne Kepp, The Open Planning Project, Copyright 2009
+ */
+package org.geowebcache.filter.parameters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.base.Preconditions;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Filter to select the closest Integering point value within a threshold.
+ */
+@ParametersAreNonnullByDefault
+@XStreamAlias("integerParameterFilter")
+public class IntegerParameterFilter extends ParameterFilter {
+    
+    
+    private static Integer DEFAULT_THRESHOLD = Integer.valueOf(1);
+
+    // These members get set by XStream
+    private List<Integer> values;
+
+    private Integer threshold;
+
+
+    public IntegerParameterFilter() {
+        super();
+        values = new ArrayList<Integer>(0);
+    }
+
+    protected IntegerParameterFilter readResolve() {
+        super.readResolve();
+        if (values == null) {
+            values = new ArrayList<Integer>(0);
+        }
+        if (threshold == null) {
+            threshold = getDefaultThreshold();
+        }
+        for(Integer value: values) {
+            Preconditions.checkNotNull(value, "Value list included a null pointer.");
+        }
+        return this;
+    }
+
+    /**
+     * @return
+     */
+    protected Integer getDefaultThreshold() {
+        return DEFAULT_THRESHOLD;
+    }
+
+    /**
+     * @return the values the parameter can take.  Altering this list is deprecated and in future 
+     * it will be unmodifiable; use {@link setValues} instead.
+     */
+    public List<Integer> getValues() {
+        // TODO: apply Collections.unmodifiableList(...)
+        return values;
+    }
+
+    /**
+     *  Set the values
+     */
+    public void setValues(List<Integer> values) {
+        Preconditions.checkNotNull(values);
+        for(Integer f: values) {
+            Preconditions.checkNotNull(f);
+        }
+        
+        this.values = new ArrayList<Integer>(values);
+    }
+
+    /**
+     * @return the threshold
+     */
+    public Integer getThreshold() {
+        return threshold;
+    }
+
+    /**
+     * @param threshold
+     *            the threshold to set
+     */
+    public void setThreshold(@Nullable Integer threshold) {
+        if(threshold==null) threshold = getDefaultThreshold();
+        this.threshold = threshold;
+    }
+
+    @Override
+    public String apply(@Nullable String str) throws ParameterException {
+        if (str == null || str.length() == 0) {
+            return getDefaultValue();
+        }
+
+        int val = Integer.parseInt(str);
+        if (values.isEmpty()) {
+            // this is an accept all filter. At least it will match 2.0 and 2.000 as the same value
+            return String.valueOf(val);
+        }
+
+        int best = Integer.MIN_VALUE;
+
+        int bestMismatch = Integer.MAX_VALUE;
+
+        Iterator<Integer> iter = getValues().iterator();
+        while (iter.hasNext()) {
+            int fl = iter.next();
+
+            int mismatch = Math.abs(fl - val);
+            if (mismatch < bestMismatch) {
+                best = fl;
+                bestMismatch = mismatch;
+            }
+        }
+
+        if (threshold != null && threshold > 0 && Math.abs(bestMismatch) < threshold) {
+            return Integer.toString(best);
+        }
+
+        throw new ParameterException("Closest match for " + super.getKey() + "=" + str + " is "
+                + Integer.toString(best) + ", but this exceeds the threshold of "
+                + Integer.toString(threshold));
+    }
+
+    @Override
+    public @Nullable List<String> getLegalValues() {
+        List<String> ret = new LinkedList<String>();
+
+        Iterator<Integer> iter = getValues().iterator();
+        while (iter.hasNext()) {
+            ret.add(Integer.toString(iter.next()));
+        }
+
+        return ret;
+    }
+
+    @Override
+    public IntegerParameterFilter clone() {
+        IntegerParameterFilter clone = new IntegerParameterFilter();
+        clone.setDefaultValue(getDefaultValue());
+        clone.setKey(getKey());
+        if (values != null) {
+            clone.values = new ArrayList<Integer>(values);
+        }
+        clone.setThreshold(this.threshold);
+        return clone;
+    }
+}

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -1058,6 +1058,54 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="IntegerParameterFilter">
+    <xs:sequence>
+      <xs:element name="key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            The key for which the filter should be invoked. The key is NOT
+            casesensitive.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="defaultValue" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            The default value. This value is used When the client does not
+            specify
+            the parameter in the request. If you omit this element, the entire parameter
+            wil be omitted if the
+            client does not include it in request.
+
+            This value must be included in the list of values
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="values" type="gwc:IntegerList">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            A list of integers that are possible values. When a
+            client request is
+            received these are scanned linearly and that best match, in terms of smallest
+            absolute
+            difference, is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="threshold" type="xs:integer">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            For a request to be accepted, the difference between the value and
+            the best match
+            must not exceed the threshold specified here. A reasonable value is the largest
+            difference
+            between two adjacent values.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="StringParameterFilter">
     <xs:sequence>
       <xs:element name="key" type="xs:string">
@@ -1127,6 +1175,12 @@
   <xs:complexType name="FloatList">
     <xs:sequence>
       <xs:element name="float" type="xs:float" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="IntegerList">
+    <xs:sequence>
+      <xs:element name="int" type="xs:integer" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2015
+ */
+
 package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
@@ -1,0 +1,127 @@
+package org.geowebcache.filter.parameters;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.custommonkey.xmlunit.XMLAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.thoughtworks.xstream.XStream;
+
+public class FloatParameterFilterTest {
+    
+    private FloatParameterFilter filter;
+    private XStream xs;
+    
+    @Before
+    public void setUp() {
+        filter = new FloatParameterFilter();
+        filter.setKey("TEST");
+        filter.setValues(Arrays.asList(42f, 6.283f, -17.5f));
+        filter.setDefaultValue("Default");
+        filter.setThreshold(0.00001f);
+        
+        xs = new XStream();
+        xs.processAnnotations(CaseNormalizer.class);
+        xs.processAnnotations(FloatParameterFilter.class);
+    }
+    
+    @Test
+    public void testBasic() throws Exception {
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("42.0", "6.283", "-17.5"));
+        
+        for(String test: Arrays.asList("42.0", "6.283", "-17.5", "42", "6.2830", "-1.75e1")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            //assertThat(filter.apply(test), equalTo(test));
+        }
+        for(String test: Arrays.asList("42.0", "42", "4.2e1")) {
+          assertThat(filter.apply(test), equalTo("42.0"));
+        }
+        for(String test: Arrays.asList("42.5", "6.281", "-17.52", "-42.0", "-6.283", "17.5")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    @Test
+    public void testThreshold() throws Exception {
+        filter.setThreshold(15f);;
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("42.0", "6.283", "-17.5"));
+        
+        for(String test: Arrays.asList("42.0", "6.283", "-17.5", "42", "6.2830", "-1.75e1")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+        }
+        for(String test: Arrays.asList("42", "56.99999", "27.00001")) {
+          assertThat(filter.apply(test), equalTo("42.0"));
+        }
+        for(String test: Arrays.asList("6.283", Float.toString(6.283f+15f-0.00001f), Float.toString((6.283f-17.5f)/2+0.000001f))) {
+            assertThat(filter.apply(test), equalTo("6.283"));
+        }
+        for(String test: Arrays.asList("-17.5", Float.toString(-17.5f-15f+0.00001f), Float.toString((6.283f-17.5f)/2-0.000001f))) {
+            assertThat(filter.apply(test), equalTo("-17.5"));
+        }
+        for(String test: Arrays.asList("57", "27", "-42")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should not apply to %0", is(false), test));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testToXML() throws Exception {
+        XMLAssert.assertXMLEqual("<floatParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <values>\n"+
+                "    <float>42.0</float>\n"+
+                "    <float>6.283</float>\n"+
+                "    <float>-17.5</float>\n"+
+                "  </values>\n"+
+                "  <threshold>1.0E-5</threshold>\n"+
+                "</floatParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testFromXML() throws Exception {
+        Object o = xs.fromXML(
+                "<floatParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <values>\n"+
+                "    <float>42</float>\n"+
+                "    <float>6.283</float>\n"+
+                "    <float>-17.5</float>\n"+
+                "  </values>\n"+
+                "  <threshold>0.00001</threshold>\n"+
+                "</floatParameterFilter>");
+        
+        assertThat(o, instanceOf(FloatParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("threshold", equalTo(0.00001f))); // Should be exactly this
+        assertThat(o, hasProperty("values", containsInAnyOrder(42f, 6.283f, -17.5f)));
+    }
+    
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2015
+ */
+
 package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
@@ -1,0 +1,140 @@
+package org.geowebcache.filter.parameters;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.custommonkey.xmlunit.XMLAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.thoughtworks.xstream.XStream;
+
+public class IntegerParameterFilterTest {
+    
+    private IntegerParameterFilter filter;
+    private XStream xs;
+    
+    @Before
+    public void setUp() {
+        filter = new IntegerParameterFilter();
+        filter.setKey("TEST");
+        filter.setValues(Arrays.asList(42, 2, 0, -1, -200));
+        filter.setDefaultValue("Default");
+        filter.setThreshold(1);
+        
+        xs = new XStream();
+        xs.processAnnotations(CaseNormalizer.class);
+        xs.processAnnotations(IntegerParameterFilter.class);
+    }
+    
+    @Test
+    public void testBasic() throws Exception {
+        
+        assertThat(filter.getLegalValues(), containsInAnyOrder("42", "2", "0", "-1", "-200"));
+        
+        for(String test: Arrays.asList("42", "2", "0", "-1", "-200")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo(test));
+        }
+        for(String test: Arrays.asList("43", "41", "3", "1", "-2", "-199", "-201", "-42")) {
+            assertThat(filter.applies(test), is(false));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    @Test
+    public void testThreshold() throws Exception {
+        filter.setThreshold(15);;
+        
+        for(String test: Arrays.asList("42", "2", "0", "-1", "-200")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo(test));
+        }
+        
+        
+        for(String test: Arrays.asList("42", "56", "28")) {
+          assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+          assertThat(filter.apply(test), equalTo("42"));
+        }
+        for(String test: Arrays.asList("2", "16", "1")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo("2"));
+        }
+        for(String test: Arrays.asList("0")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo("0"));
+        }
+        for(String test: Arrays.asList("-1", "-15")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo("-1"));
+        }
+        for(String test: Arrays.asList("-200", "-186", "-214")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should apply to %0", is(true), test));
+            assertThat(filter.apply(test), equalTo("-200"));
+        }
+        for(String test: Arrays.asList("57", "27", "-42", "-100")) {
+            assertThat(filter.applies(test), Matchers.describedAs("Filter should not apply to %0", is(false), test));
+            try {
+                filter.apply(test);
+                fail();
+            } catch (Exception ex) {
+                assertThat(ex, instanceOf(ParameterException.class));
+            }
+        }
+        assertThat(filter.apply(null), equalTo("Default"));
+        assertThat(filter.apply(""), equalTo("Default"));
+    }
+    
+    @Test
+    public void testToXML() throws Exception {
+        XMLAssert.assertXMLEqual("<integerParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <values>\n"+
+                "    <int>42</int>\n"+
+                "    <int>2</int>\n"+
+                "    <int>0</int>\n"+
+                "    <int>-1</int>\n"+
+                "    <int>-200</int>\n"+
+                "  </values>\n"+
+                "  <threshold>1</threshold>\n"+
+                "</integerParameterFilter>", xs.toXML(filter));
+    }
+    
+    @Test
+    public void testFromXML() throws Exception {
+        Object o = xs.fromXML(
+                "<integerParameterFilter>\n"+
+                "  <key>TEST</key>\n"+
+                "  <defaultValue>Default</defaultValue>\n"+
+                "  <values>\n"+
+                "    <int>42</int>\n"+
+                "    <int>2</int>\n"+
+                "    <int>0</int>\n"+
+                "    <int>-1</int>\n"+
+                "    <int>-200</int>\n"+
+                "  </values>\n"+
+                "  <threshold>15</threshold>\n"+
+                "</integerParameterFilter>");
+        
+        assertThat(o, instanceOf(IntegerParameterFilter.class));
+        assertThat(o, hasProperty("key", equalTo("TEST")));
+        assertThat(o, hasProperty("defaultValue", equalTo("Default")));
+        assertThat(o, hasProperty("threshold", equalTo(15)));
+        assertThat(o, hasProperty("values", containsInAnyOrder(42, 2, 0, -1, -200)));
+    }
+    
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
@@ -1,3 +1,19 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2015
+ */
 package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.Matchers.allOf;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2015
+ */
+
 package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.Matchers.allOf;


### PR DESCRIPTION
Implements #298. I chose to make this a separate filter rather than modifying the output of the float filter as use cases where a `.0` would be undesirable are likely to also be harmed by floating point rounding errors.

I initially attempted to extract a common superclass for numeric filters but encountered problems with xstream and so fell back to just copying and modifying the FloatParameterFilter.