### PR TITLE
specify environment variable GEOWEBCACHE_CONFIG_DIR correctly

### DIFF
--- a/documentation/en/user/source/configuration/storage.rst
+++ b/documentation/en/user/source/configuration/storage.rst
@@ -54,7 +54,7 @@ making sure to edit the path.  As usual, any changes to the servlet configuratio
 Configuration File
 ------------------
 
-The configuration file, :file:`geowebcache.xml`, will be looked for or created in the cache directory by default.  A separate location can be set with the ``GEOWEBCACHE_CACHE_DIR`` variable or property in the same way as decribed above for ``GEOWEBCACHE_CACHE_DIR``.
+The configuration file, :file:`geowebcache.xml`, will be looked for or created in the cache directory by default.  A separate location can be set with the ``GEOWEBCACHE_CONFIG_DIR`` variable or property in the same way as decribed above for ``GEOWEBCACHE_CACHE_DIR``.
 
 BlobStore configuration
 -----------------------


### PR DESCRIPTION
fixes a little error in the documentation regarding the new environment variable GEOWEBCACHE_CONFIG_DIR.  