### PR TITLE
new MIME Types for vector tiles formats

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
@@ -17,6 +17,13 @@
  */
 package org.geowebcache.mime;
 
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
 public class ApplicationMime extends MimeType {
 
     public static final ApplicationMime bil16 = new ApplicationMime(
@@ -37,6 +44,30 @@ public class ApplicationMime extends MimeType {
     public static final ApplicationMime geojson = new ApplicationMime("application/json",
             "geojson", "geojson", "application/json;type=geojson", false);
 
+    public static final ApplicationMime mapboxVector = new ApplicationMime("application/x-protobuf",
+            "pbf", "mapbox-vectortile", "application/x-protobuf;type=mapbox-vector", false);
+
+    private static Set<ApplicationMime> ALL = ImmutableSet.of(bil16, bil32, json, topojson,
+            geojson, mapboxVector);
+
+    private static Map<String, ApplicationMime> BY_FORMAT = Maps.uniqueIndex(ALL,
+            new Function<ApplicationMime, String>() {
+
+                @Override
+                public String apply(ApplicationMime mimeType) {
+                    return mimeType.getFormat();
+                }
+            });
+    
+    private static Map<String, ApplicationMime> BY_EXTENSION = Maps.uniqueIndex(ALL,
+            new Function<ApplicationMime, String>() {
+
+                @Override
+                public String apply(ApplicationMime mimeType) {
+                    return mimeType.getFileExtension();
+                }
+            });
+
     private ApplicationMime(String mimeType, String fileExtension, 
                 String internalName, String format, boolean noop) {
         super(mimeType, fileExtension, internalName, format, false);
@@ -48,34 +79,12 @@ public class ApplicationMime extends MimeType {
     }
 
     protected static ApplicationMime checkForFormat(String formatStr) throws MimeException {
-        if (formatStr.equalsIgnoreCase(bil16.format)) {
-            return bil16;
-        } else if (formatStr.equalsIgnoreCase(bil32.format)) {
-            return bil32;
-        } else if (formatStr.equalsIgnoreCase(topojson.format)) {
-            return topojson;
-        } else if (formatStr.equalsIgnoreCase(geojson.format)) {
-            return geojson;
-        } else if (formatStr.equalsIgnoreCase(json.format)) {
-            return json;
-        }
-        
-        return null;
+        ApplicationMime mimeType = BY_FORMAT.get(formatStr);
+        return mimeType;
     }
     
     protected static ApplicationMime checkForExtension(String fileExtension) throws MimeException {
-        if (fileExtension.equals(bil16.fileExtension)) {
-            return bil16;
-        } else if (fileExtension.equals(bil32.fileExtension)) {
-            return bil32;
-        } else if (fileExtension.equals(topojson.fileExtension)) {
-            return topojson;
-        } else if (fileExtension.equals(geojson.fileExtension)) {
-            return geojson;
-        } else if (fileExtension.equals(json.fileExtension)) {
-            return json;
-        }
-        
-        return null;
+        ApplicationMime mimeType = BY_EXTENSION.get(fileExtension);
+        return mimeType;
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
@@ -31,6 +31,12 @@ public class ApplicationMime extends MimeType {
             "application/json", "json", "json",
             "application/json", false);
     
+    public static final ApplicationMime topojson = new ApplicationMime("application/json",
+            "topojson", "topojson", "application/json;type=topojson", false);
+
+    public static final ApplicationMime geojson = new ApplicationMime("application/json",
+            "geojson", "geojson", "application/json;type=geojson", false);
+
     private ApplicationMime(String mimeType, String fileExtension, 
                 String internalName, String format, boolean noop) {
         super(mimeType, fileExtension, internalName, format, false);
@@ -46,6 +52,10 @@ public class ApplicationMime extends MimeType {
             return bil16;
         } else if (formatStr.equalsIgnoreCase(bil32.format)) {
             return bil32;
+        } else if (formatStr.equalsIgnoreCase(topojson.format)) {
+            return topojson;
+        } else if (formatStr.equalsIgnoreCase(geojson.format)) {
+            return geojson;
         } else if (formatStr.equalsIgnoreCase(json.format)) {
             return json;
         }
@@ -58,6 +68,10 @@ public class ApplicationMime extends MimeType {
             return bil16;
         } else if (fileExtension.equals(bil32.fileExtension)) {
             return bil32;
+        } else if (fileExtension.equals(topojson.fileExtension)) {
+            return topojson;
+        } else if (fileExtension.equals(geojson.fileExtension)) {
+            return geojson;
         } else if (fileExtension.equals(json.fileExtension)) {
             return json;
         }

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -17,7 +17,12 @@
  */
 package org.geowebcache.mime;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 public class ImageMime extends MimeType {
+
+    private static Log log = LogFactory.getLog(org.geowebcache.mime.ImageMime.class);
     
     boolean supportsAlphaChannel;
     
@@ -56,25 +61,35 @@ public class ImageMime extends MimeType {
         this.supportsAlphaBit = alphaBit;
     }
 
-    protected static ImageMime checkForFormat(String formatStr)
-    throws MimeException {
-        String tmpStr = formatStr.substring(6,formatStr.length());
-        
-        if ( tmpStr.equalsIgnoreCase("png")) {
+    protected static ImageMime checkForFormat(String formatStr) throws MimeException {
+        if (!formatStr.startsWith("image/")) {
+            return null;
+        }
+        final String tmpStr = formatStr.substring(6, formatStr.length());
+
+        // TODO Making a special exception, generalize later
+        if (!formatStr.equals("image/png; mode=24bit") && formatStr.contains(";")) {
+            if (log.isDebugEnabled()) {
+                log.debug("Slicing off " + formatStr.split(";")[1]);
+            }
+            formatStr = formatStr.split(";")[0];
+        }
+ 
+        if (tmpStr.equalsIgnoreCase("png")) {
             return png;
-        } else if ( tmpStr.equalsIgnoreCase("jpeg")) {
+        } else if (tmpStr.equalsIgnoreCase("jpeg")) {
             return jpeg;
-        } else if ( tmpStr.equalsIgnoreCase("gif")) {
+        } else if (tmpStr.equalsIgnoreCase("gif")) {
             return gif;
-        } else if ( tmpStr.equalsIgnoreCase("tiff")) {
+        } else if (tmpStr.equalsIgnoreCase("tiff")) {
             return tiff;
-        } else if ( tmpStr.equalsIgnoreCase("png8")) {
+        } else if (tmpStr.equalsIgnoreCase("png8")) {
             return png8;
-        } else if ( tmpStr.equalsIgnoreCase("png24")) {
+        } else if (tmpStr.equalsIgnoreCase("png24")) {
             return png24;
-        } else if ( tmpStr.equalsIgnoreCase("png; mode=24bit")) {
+        } else if (tmpStr.equalsIgnoreCase("png; mode=24bit")) {
             return png_24;
-        } else if ( tmpStr.equalsIgnoreCase("png;%20mode=24bit")) {
+        } else if (tmpStr.equalsIgnoreCase("png;%20mode=24bit")) {
             return png_24;
         }
         return null;

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
@@ -95,45 +95,30 @@ public class MimeType {
      */
     public static MimeType createFromFormat(String formatStr) throws MimeException {
         MimeType mimeType = null;
-        if(formatStr == null) {
+        if (formatStr == null) {
             throw new MimeException("formatStr was not set");
         }
-        
-        // TODO Making a special exception, generalize later
-        if(! formatStr.equals("image/png; mode=24bit") && formatStr.contains(";")) {
-            if(log.isDebugEnabled()) {
-                log.debug("Slicing off "+ formatStr.split(";")[1]);
-            }
-            formatStr = formatStr.split(";")[0];
-        }
-        
-        if (formatStr.length() > 6 
-                && formatStr.substring(0, 6).equalsIgnoreCase("image/")) {
-            mimeType = ImageMime.checkForFormat(formatStr);
-            
-            if(mimeType != null) {
-                return mimeType;
-            }
-        }
- 
-        mimeType = XMLMime.checkForFormat(formatStr);
-        if(mimeType != null) {
+        mimeType = ImageMime.checkForFormat(formatStr);
+        if (mimeType != null) {
             return mimeType;
         }
-        
+        mimeType = XMLMime.checkForFormat(formatStr);
+        if (mimeType != null) {
+            return mimeType;
+        }
+
         mimeType = TextMime.checkForFormat(formatStr);
         if (mimeType != null) {
             return mimeType;
         }
-        
+
         mimeType = ApplicationMime.checkForFormat(formatStr);
-        if(mimeType != null) {
+        if (mimeType != null) {
             return mimeType;
         }
 
         throw new MimeException("Unsupported format request: " + formatStr);
     }
-
 
     /**
      * Get the MIME type object for a given file extension


### PR DESCRIPTION
Make GeoJSON, TopoJSON, and Mapbox Vector Tiles supported tile formats.