### PR TITLE
Support integration testing with non-AWS S3 endpoints

### DIFF
--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
@@ -97,30 +97,7 @@ public class S3BlobStore implements BlobStore {
         String prefix = config.getPrefix() == null ? "" : config.getPrefix();
         this.keyBuilder = new TMSKeyBuilder(prefix, layers);
 
-        String accessKey = config.getAwsAccessKey();
-        String secretKey = config.getAwsSecretKey();
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-
-        ClientConfiguration clientConfig = new ClientConfiguration();
-        if (null != config.isUseHTTPS()) {
-            clientConfig.setProtocol(config.isUseHTTPS() ? Protocol.HTTPS : Protocol.HTTP);
-        }
-        if (null != config.getMaxConnections() && config.getMaxConnections() > 0) {
-            clientConfig.setMaxConnections(config.getMaxConnections());
-        }
-        clientConfig.setProxyDomain(config.getProxyDomain());
-        clientConfig.setProxyWorkstation(config.getProxyWorkstation());
-        clientConfig.setProxyHost(config.getProxyHost());
-        if (null != config.getProxyPort()) {
-            clientConfig.setProxyPort(config.getProxyPort());
-        }
-        clientConfig.setProxyUsername(config.getProxyUsername());
-        clientConfig.setProxyPassword(config.getProxyPassword());
-        if (null != config.isUseGzip()) {
-            clientConfig.setUseGzip(config.isUseGzip());
-        }
-        log.debug("Initializing AWS S3 connection");
-        this.conn = new AmazonS3Client(awsCredentials, clientConfig);
+        conn = config.buildClient();
 
         try {
             log.debug("Checking access rights to bucket " + bucketName);

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
@@ -24,16 +24,26 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geowebcache.config.BlobStoreConfig;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.StorageException;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+
 /**
  * Plain old java object representing the configuration for an S3 blob store.
  */
 public class S3BlobStoreConfig extends BlobStoreConfig {
+
+    static Log log = LogFactory.getLog(S3BlobStoreConfig.class);
 
     private static final long serialVersionUID = 9072751143836460389L;
 
@@ -311,6 +321,33 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
             return String.format("bucket: %s prefix: %s", bucket, prefix);
         }
         
+    }
+
+    /**
+     * @return {@link AmazonS3Client} constructed from this {@link S3BlobStoreConfig.
+     */
+    public AmazonS3Client buildClient() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        ClientConfiguration clientConfig = new ClientConfiguration();
+        if (null != useHTTPS) {
+            clientConfig.setProtocol(useHTTPS ? Protocol.HTTPS : Protocol.HTTP);
+        }
+        if (null != maxConnections && maxConnections > 0) {
+            clientConfig.setMaxConnections(maxConnections);
+        }
+        clientConfig.setProxyDomain(proxyDomain);
+        clientConfig.setProxyWorkstation(proxyWorkstation);
+        clientConfig.setProxyHost(proxyHost);
+        if (null != proxyPort) {
+            clientConfig.setProxyPort(proxyPort);
+        }
+        clientConfig.setProxyUsername(proxyUsername);
+        clientConfig.setProxyPassword(proxyPassword);
+        if (null != useGzip) {
+            clientConfig.setUseGzip(useGzip);
+        }
+        log.debug("Initializing AWS S3 connection");
+        return new AmazonS3Client(awsCredentials, clientConfig);
     }
 
 }

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
@@ -324,7 +324,7 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
     }
 
     /**
-     * @return {@link AmazonS3Client} constructed from this {@link S3BlobStoreConfig.
+     * @return {@link AmazonS3Client} constructed from this {@link S3BlobStoreConfig}.
      */
     public AmazonS3Client buildClient() {
         AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);


### PR DESCRIPTION
Add support for all S3BlobStoreConfig properties in S3BlobStoreIntegrationTest to permit integration testing against non-AWS S3 endpoints.