### PR TITLE
Add getCache accessor to GuavaCacheProvider

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/guava/GuavaCacheProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/guava/GuavaCacheProvider.java
@@ -591,6 +591,10 @@ public class GuavaCacheProvider implements CacheProvider {
         return true;
     }
 
+    public Cache<String, TileObject> getCache() {
+    	return cache;
+    }
+
     /**
      * Internal class representing a concurrent multimap which associates to each Layer name the related {@link TileObject} cache keys. This map is
      * useful when trying to remove a Layer, because it returns quicly all the cached keys of the selected layer, without having to cycle on the cache


### PR DESCRIPTION
This can be useful when using GWC as a library to create and seed one shot tilecaches, for instance to deliver smaller offline dataset packages. With access to the Cache one can populate an in memory blobstore and read it's complete contents to on-the-fly compress it into an OutputStream.