### PR TITLE
Upgrade to commons-collections 3.2.2 to address CVE-2015-8103

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -20,7 +20,7 @@
     <commons-io.version>2.1</commons-io.version>
     <commons-dbcp.version>1.3</commons-dbcp.version>
     <commons-lang.version>2.4</commons-lang.version>
-    <commons-collections.version>3.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version> <!-- Updated for security (CVE-2015-8103) binary compatible with 3.1 -->
     <guava.version>17.0</guava.version>
     <jsr305.version>2.0.3</jsr305.version>
     <log4j.version>1.2.14</log4j.version>


### PR DESCRIPTION
* Prevent Java Serialization vulnerability of having cc 3.2.1 and earlier on the classpath
* https://commons.apache.org/proper/commons-collections/security-reports.html

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>