### PR TITLE
#378, Stopping and restarting disk quota at runtime can lead to thread exhaustion

### DIFF
--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
@@ -31,7 +31,7 @@ public class QueuedUsageStatsConsumer implements Callable<Long>, Serializable {
     /**
      * Default number of milliseconds before cached/aggregated quota update is saved to the store
      */
-    private static final long DEFAULT_SYNC_TIMEOUT = 10000;
+    private static final long DEFAULT_SYNC_TIMEOUT = 100;
 
     /**
      * Default number of per TileSet aggregated quota updates before ensuring they're synchronized
@@ -103,6 +103,11 @@ public class QueuedUsageStatsConsumer implements Callable<Long>, Serializable {
                         + " finished due to interrupted thread.");
                 break;
             }
+            
+            if(terminate) {
+                log.debug("Exiting on explicit termination request: " + getClass().getSimpleName());
+                break;
+            }
 
             try {
                 /*
@@ -144,6 +149,8 @@ public class QueuedUsageStatsConsumer implements Callable<Long>, Serializable {
     private final int[] pageIndexTarget = new int[3];
 
     private final StringBuilder pageIdTarget = new StringBuilder(128);
+
+    private boolean terminate = false;
 
     /**
      * 
@@ -224,5 +231,9 @@ public class QueuedUsageStatsConsumer implements Callable<Long>, Serializable {
         aggregatedPendingUpdates.lastCommitTime = System.currentTimeMillis();
         aggregatedPendingUpdates.numAggregations = 0;
         aggregatedPendingUpdates.pages.clear();
+    }
+    
+    public void shutdown() {
+        this.terminate = true;
     }
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/UsageStatsMonitor.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/UsageStatsMonitor.java
@@ -114,7 +114,7 @@ public class UsageStatsMonitor {
             throw new IllegalStateException("Called awaitTermination but the "
                     + "UsageStatsMonitor is not shutting down");
         }
-        executorService.awaitTermination(10 * 1000, TimeUnit.MILLISECONDS);
+        executorService.awaitTermination(timeout, units);
     }
 
     /**
@@ -137,6 +137,7 @@ public class UsageStatsMonitor {
             }
         }
 
+        usageStatsConsumer.shutdown();
         if (cancel) {
             usageStatsProducer.setCancelled(true);
             executorService.shutdownNow();


### PR DESCRIPTION
This should fix the deadlock observed when the disk quota is being reloaded while tiles are being requested.

I've tried to write a test but it's really hard to make one, one would have to mock a lot of objects and their expected behavior, create a fake tile load, do some shutdowns and restarts in a row, and then check none of the threads got locked up.

The change per se is not that complicated, ideas:

- Never re-create the producer-consumer queue, use the same over and over so that messages are not getting lost during a reload, and the queue cannot get full without sometime to empty it
- Do clean shutdowns when possible, instead of abruptly moving on while the machinery is still running or waiting on timeouts
- Make sure there are no wait operations that can wait indefinitely
- For a few critical bits, add a configuration option so that the administrator can play with different values

I've lowered significantly some waits in the consumers that were part of the cause for the queue clogging up and verified with a benchmark and profiler that the new lower values are not causing the quota mechanism to use significant CPU compared to the actual tile production.

Feedback welcomed.