### PR TITLE
Resolves #389, allow a different layer name to be advertised

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -113,6 +113,14 @@ public abstract class TileLayer {
     public abstract String getName();
 
     /**
+     * Name that should be used when advertising the layer (for example in a get capabilities result document).
+     * @return
+     */
+    public String getAdvertisedName() {
+        return getName();
+    }
+
+    /**
      * @return {@code true} if the layer is enabled, {@code false} otherwise
      */
     public abstract boolean isEnabled();

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
@@ -451,4 +451,11 @@ public class WMSLayerTest extends TileLayerTest {
         tl.getParameterFilters().addAll(filters);
         return tl;
     }
+
+    @Test
+    public void testAdvertisedName() {
+        WMSLayer layer = createWMSLayer("image/png");
+        // the advertised  name should be equal to the layer name
+        assertEquals(layer.getName(), layer.getAdvertisedName());
+    }
 }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -257,14 +257,14 @@ public class WMTSGetCapabilities {
         LayerMetaInformation layerMeta = layer.getMetaInformation();
 
         if (layerMeta == null) {
-            appendTag(xml, "ows:Title", layer.getName(), null);
+            appendTag(xml, "ows:Title", layer.getAdvertisedName(), null);
         } else {
             appendTag(xml, "ows:Title", layerMeta.getTitle(), null);
             appendTag(xml, "ows:Abstract", layerMeta.getDescription(), null);
         }
 
         layerWGS84BoundingBox(xml, layer);
-        appendTag(xml, "ows:Identifier", layer.getName(), null);
+        appendTag(xml, "ows:Identifier", layer.getAdvertisedName(), null);
         
         // We need the filters for styles and dimensions
         List<ParameterFilter> filters = layer.getParameterFilters();


### PR DESCRIPTION
Associated issue: https://github.com/GeoWebCache/geowebcache/issues/389

This is needed to handle per-workspace services in GeoServer integration with GWC.