### PR TITLE
Support for image/vnd.jpeg-png format for tiles storage and response

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -112,6 +112,18 @@
     </dependency>
 
     <dependency>
+      <groupId>it.geosolutions.jaiext.utilities</groupId>
+      <artifactId>jt-utilities</artifactId>
+      <exclusions>
+         <exclusion>
+            <!-- This one depends on JTS, which depends on xerces, which breaks some tests -->
+            <groupId>org.jaitools</groupId>
+            <artifactId>jt-utils</artifactId>
+         </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
       <version>3.1</version>

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -562,8 +561,8 @@ public class GeoWebCacheDispatcher extends AbstractController {
 
         final CacheResult cacheResult = tile.getCacheResult();
         int httpCode = HttpServletResponse.SC_OK;
-        String mimeType = tile.getMimeType().getMimeType();
         Resource blob = tile.getBlob();
+        String mimeType = tile.getMimeType().getMimeType(blob);
 
         servletResp.setHeader("geowebcache-cache-result", String.valueOf(cacheResult));
         servletResp.setHeader("geowebcache-tile-index", Arrays.toString(tile.getTileIndex()));

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -36,6 +36,7 @@ import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileResponseReceiver;
 import org.geowebcache.mime.ErrorMime;
+import org.geowebcache.mime.MimeType;
 import org.geowebcache.service.ServiceException;
 import org.geowebcache.util.GWCVars;
 import org.geowebcache.util.HttpClientBuilder;
@@ -97,7 +98,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
      */
     @Override
     protected void makeRequest(TileResponseReceiver tileRespRecv, WMSLayer layer,
-            Map<String, String> wmsParams, String expectedMimeType, Resource target)
+            Map<String, String> wmsParams, MimeType expectedMimeType, Resource target)
             throws GeoWebCacheException {
         Assert.notNull(target, "Target resource can't be null");
         Assert.isTrue(target.getSize() == 0, "Target resource is not empty");
@@ -153,7 +154,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
      * @throws GeoWebCacheException
      */
     private void connectAndCheckHeaders(TileResponseReceiver tileRespRecv, URL wmsBackendUrl,
-            Map<String, String> wmsParams, String requestMime, Integer backendTimeout,
+            Map<String, String> wmsParams, MimeType requestMimeType, Integer backendTimeout,
             Resource target) throws GeoWebCacheException {
 
         GetMethod getMethod = null;
@@ -185,7 +186,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
             // Check that we're not getting an error MIME back.
             String responseMime = getMethod.getResponseHeader("Content-Type").getValue();
             if (responseCode != 204 && responseMime != null
-                    && !mimeStringCheck(requestMime, responseMime)) {
+                    && !requestMimeType.isCompatible(responseMime)) {
                 String message = null;
                 if (responseMime.equalsIgnoreCase(ErrorMime.vnd_ogc_se_inimage.getFormat())) {
                     // TODO: revisit: I don't understand why it's trying to create a String message
@@ -212,7 +213,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
                         IOUtils.closeQuietly(stream);
                     }
                 }
-                String msg = "MimeType mismatch, expected " + requestMime + " but got "
+                String msg = "MimeType mismatch, expected " + requestMimeType + " but got "
                         + responseMime + " from " + wmsBackendUrl.toString()
                         + (message == null ? "" : (":\n" + message));
                 tileRespRecv.setError();

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
@@ -26,6 +26,7 @@ import org.geowebcache.grid.GridSubset;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileResponseReceiver;
+import org.geowebcache.mime.MimeType;
 import org.geowebcache.mime.XMLMime;
 import org.geowebcache.util.ServletUtils;
 
@@ -40,16 +41,16 @@ public abstract class WMSSourceHelper {
     private int backendTimetout;
 
     abstract protected void makeRequest(TileResponseReceiver tileRespRecv, WMSLayer layer,
-            Map<String, String> wmsParams, String expectedMimeType, Resource target)
+            Map<String, String> wmsParams, MimeType expectedMime, Resource target)
             throws GeoWebCacheException;
 
     public void makeRequest(WMSMetaTile metaTile, Resource target) throws GeoWebCacheException {
 
         Map<String, String> wmsParams = metaTile.getWMSParams();
         WMSLayer layer = metaTile.getLayer();
-        String format = metaTile.getRequestFormat().getFormat();
+        MimeType mime = metaTile.getRequestFormat();
 
-        makeRequest(metaTile, layer, wmsParams, format, target);
+        makeRequest(metaTile, layer, wmsParams, mime, target);
     }
 
     public void makeRequest(ConveyorTile tile, Resource target) throws GeoWebCacheException {
@@ -83,7 +84,7 @@ public abstract class WMSSourceHelper {
             wmsParams.put("format_options", "mode:superoverlay;overlaymode:auto");
         }
 
-        String mimeType = tile.getMimeType().getMimeType();
+        MimeType mimeType = tile.getMimeType();
         makeRequest(tile, layer, wmsParams, mimeType, target);
     }
 
@@ -123,21 +124,10 @@ public abstract class WMSSourceHelper {
             wmsParams.put("FEATURE_COUNT", featureCount);
         }
         
-        String mimeType = tile.getMimeType().getMimeType();
+        MimeType mimeType = tile.getMimeType();
         Resource target = new ByteArrayResource(2048);
         makeRequest(tile, layer, wmsParams, mimeType, target);
         return target;
-    }
-
-    protected boolean mimeStringCheck(String requestMime, String responseMime) {
-        if (responseMime.equalsIgnoreCase(requestMime)) {
-            return true;
-        } else if (responseMime.startsWith(requestMime)) {
-            return true;
-        } else if (requestMime.startsWith("image/png") && responseMime.startsWith("image/png")) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -17,6 +17,17 @@
  */
 package org.geowebcache.mime;
 
+import java.awt.image.IndexColorModel;
+import java.awt.image.RenderedImage;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.imageio.ImageWriter;
+import javax.media.jai.JAI;
+import javax.media.jai.RenderedOp;
+import javax.media.jai.operator.ExtremaDescriptor;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,7 +40,15 @@ public class ImageMime extends MimeType {
     boolean supportsAlphaBit;
 
     public static final ImageMime png = 
-        new ImageMime("image/png", "png", "png", "image/png", true, true, true);
+        new ImageMime("image/png", "png", "png", "image/png", true, true, true) {
+        
+        /**
+         * Any response mime starting with image/png will do
+         */
+        public boolean isCompatible(String otherMimeType) {
+            return super.isCompatible(otherMimeType) || otherMimeType.startsWith("image/png");
+        };
+    };
 
     public static final ImageMime jpeg = 
         new ImageMime("image/jpeg", "jpeg", "jpeg", "image/jpeg", true, false, false);
@@ -51,6 +70,68 @@ public class ImageMime extends MimeType {
     
     public static final ImageMime dds = 
         new ImageMime("image/dds", "dds", "dds", "image/dds", false, false, false);
+    
+    public static final ImageMime jpegPng = 
+        new ImageMime("image/vnd.jpeg-png", "jpeg-png", "jpeg-png", "image/vnd.jpeg-png", true, true, true) {
+        
+        private static final int JPEG_MAGIC_MASK = 0xffd80000;
+        
+        /**
+         * Returns true if the best format to encode the image is jpeg (the image is rgb, or rgba without any actual
+         * transparency use). This code is duplicated in GeoServer JpegPngRenderedImageMapOutputFormat. Unfortunately
+         * gwc-core does not depend on GeoTools, so we don't have an easy place to share it. On the bright side, it's small.
+         *
+         * @param renderedImage
+         * @param renderingHints
+         * @return
+         */
+        boolean isBestFormatJpeg(RenderedImage renderedImage)
+        {
+            int numBands = renderedImage.getSampleModel().getNumBands();
+            if (numBands == 4 || numBands == 2)
+            {
+                RenderedOp extremaOp = ExtremaDescriptor.create(renderedImage, null, 1, 1, false, 1, JAI.getDefaultInstance().getRenderingHints());
+                double[][] extrema = (double[][]) extremaOp.getProperty("Extrema");
+                double[] mins = extrema[0];
+        
+                return mins[mins.length - 1] == 255; // fully opaque
+            } else if(renderedImage.getColorModel() instanceof IndexColorModel) {
+                // JPEG would still compress a bit better, but in order to figure out
+                // if the image has transparency we'd have to expand to RGB or roll
+                // a new JAI image op that looks for the transparent pixels. Out of scope for the moment
+                return false;
+            } else {
+                // otherwise support RGB or gray
+                return (numBands == 3) || (numBands == 1);
+            }
+        }
+        
+        public ImageWriter getImageWriter(RenderedImage image) {
+            if(isBestFormatJpeg(image)) {
+                return jpeg.getImageWriter(image);
+            } else {
+                return png.getImageWriter(image);
+            }
+        }
+        
+        public String getMimeType(org.geowebcache.io.Resource resource) throws IOException {
+            try(DataInputStream dis = new DataInputStream(resource.getInputStream()))
+            {
+                final int head = dis.readInt();
+                if((head & 0xFFFF0000) == JPEG_MAGIC_MASK) {
+                    return jpeg.getMimeType();
+                } else {
+                    return png.getMimeType();
+                }
+            }
+        };
+        
+        @Override
+            public boolean isCompatible(String otherMimeType) {
+                return jpeg.isCompatible(otherMimeType) || png.isCompatible(otherMimeType);
+            }
+        
+    };
     
     private ImageMime(String mimeType, String fileExtension, 
             String internalName, String format, boolean tiled,
@@ -91,20 +172,11 @@ public class ImageMime extends MimeType {
             return png_24;
         } else if (tmpStr.equalsIgnoreCase("png;%20mode=24bit")) {
             return png_24;
+        } else if(tmpStr.equalsIgnoreCase("vnd.jpeg-png")) {
+            return jpegPng;
         }
         return null;
     }
-
-//    public static ImageMime createFromMimeType(String mimeType) {
-//        ImageMime imageMime = checkForMimeType(mimeType);
-//        if (imageMime == null) {
-//            log.error("Unsupported MIME type: " + mimeType
-//                    + ", falling back to PNG.");
-//            imageMime = new ImageMime("image/png", "png", "png");
-//        }
-//
-//        return imageMime;
-//    }
 
     protected static ImageMime checkForExtension(String fileExtension) 
     throws MimeException {
@@ -122,6 +194,8 @@ public class ImageMime extends MimeType {
             return png24;
         } else if (fileExtension.equalsIgnoreCase("png_24")) {
             return png_24;
+        } else if (fileExtension.equalsIgnoreCase("jpeg-png")) {
+           return jpegPng;
         }
         return null;
     }
@@ -133,15 +207,11 @@ public class ImageMime extends MimeType {
     public boolean supportsAlphaChannel() {
         return supportsAlphaChannel;
     }
+    
+    public ImageWriter getImageWriter(RenderedImage image) {
+        Iterator<ImageWriter> it = javax.imageio.ImageIO.getImageWritersByFormatName(internalName);
+        ImageWriter writer = it.next();
+        return writer;
+    }
 
-//    public static ImageMime createFromExtension(String fileExtension) {
-//        ImageMime imageMime = checkForExtension(fileExtension);
-//        if (imageMime == null) {
-//            log.error("Unsupported MIME type: " + fileExtension
-//                    + ", falling back to PNG.");
-//            imageMime = new ImageMime("image/png", "png", "png");
-//        }
-//
-//        return imageMime;
-//    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
@@ -17,8 +17,11 @@
  */
 package org.geowebcache.mime;
 
+import java.io.IOException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.io.Resource;
 
 public class MimeType {
     protected String mimeType;
@@ -51,6 +54,15 @@ public class MimeType {
      * @return
      */
     public String getMimeType() {
+        return mimeType;
+    }
+    
+    /**
+     * The MIME identifier string for this format.
+     * @return
+     * @throws IOException 
+     */
+    public String getMimeType(Resource resource) throws IOException {
         return mimeType;
     }
     
@@ -181,5 +193,16 @@ public class MimeType {
     
     public int hashCode() {
         return format.hashCode();
+    }
+
+
+
+    public boolean isCompatible(String otherMimeType) {
+        return mimeType.equalsIgnoreCase(otherMimeType) || otherMimeType.startsWith(otherMimeType);
+    }
+    
+    @Override
+    public String toString() {
+        return mimeType;
     }
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/mime/ImageMimeTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/mime/ImageMimeTest.java
@@ -1,0 +1,109 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * (c) 2016 Open Source Geospatial Foundation - all rights reserved 
+ */
+package org.geowebcache.mime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
+
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ImageMimeTest {
+    
+    private BufferedImage indexed;
+    private BufferedImage gray;
+    private BufferedImage rgb;
+    private BufferedImage rgba;
+    private BufferedImage rgba_opaque;
+    private BufferedImage rgba_partial;
+
+    @Before
+    public void prepareImages() {
+        // paletted image
+        indexed = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_INDEXED);
+        // gray one, no transparency
+        gray = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_GRAY);
+        // opaque rgb
+        rgb = new BufferedImage(10, 10, BufferedImage.TYPE_3BYTE_BGR);
+        // transparent rgba
+        rgba = new BufferedImage(10, 10, BufferedImage.TYPE_4BYTE_ABGR);
+        // fully opaque rgba
+        rgba_opaque = new BufferedImage(10, 10, BufferedImage.TYPE_4BYTE_ABGR);
+        Graphics2D graphics = rgba_opaque.createGraphics();
+        graphics.setColor(Color.BLACK);
+        graphics.fillRect(0, 0, 10, 10);
+        graphics.dispose();
+        // partially transparent rgba
+        rgba_partial = new BufferedImage(10, 10, BufferedImage.TYPE_4BYTE_ABGR);
+        graphics = rgba_partial.createGraphics();
+        graphics.setColor(Color.BLACK);
+        graphics.fillRect(0, 0, 10, 5);
+        graphics.dispose();
+    }
+
+    @Test
+    public void testJpegPng() throws MimeException {
+        assertNotNull(MimeType.createFromFormat("image/vnd.jpeg-png"));
+        assertNotNull(MimeType.createFromExtension("jpeg-png"));
+    }
+    
+    @Test
+    public void testJpegPngImageWriter() {
+        assertExpectedWriter(indexed, ImageMime.png);
+        assertExpectedWriter(gray, ImageMime.jpeg);
+        assertExpectedWriter(gray, ImageMime.jpeg);
+        assertExpectedWriter(rgba, ImageMime.png);
+        assertExpectedWriter(rgba_opaque, ImageMime.jpeg);
+        assertExpectedWriter(rgba_partial, ImageMime.png);
+    }
+    
+    @Test
+    public void testJpegPngMime() throws IOException {
+        Resource pngImage = getAsResource(indexed, ImageMime.png);
+        assertEquals("image/png", ImageMime.jpegPng.getMimeType(pngImage));
+        Resource jpegImage = getAsResource(rgb, ImageMime.jpeg);
+        assertEquals("image/jpeg", ImageMime.jpegPng.getMimeType(jpegImage));
+    }
+
+    private Resource getAsResource(BufferedImage image, ImageMime mime) throws IOException {
+        ImageWriter writer = mime.getImageWriter(image);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        final MemoryCacheImageOutputStream ios = new MemoryCacheImageOutputStream(os);
+        writer.setOutput(ios);
+        writer.write(image);
+        ios.flush();
+        return new ByteArrayResource(os.toByteArray());
+    }
+
+    private void assertExpectedWriter(BufferedImage bi, ImageMime expectedMime) {
+        ImageWriter jpegPngWriter = ImageMime.jpegPng.getImageWriter(bi);
+        ImageWriter expectedWriter = expectedMime.getImageWriter(bi);
+        // compare by class, these object are not meant to be compared by equality
+        assertEquals(expectedWriter.getClass(), jpegPngWriter.getClass());
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
@@ -49,6 +49,7 @@ import org.geowebcache.layer.TileResponseReceiver;
 import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.layer.wms.WMSMetaTile;
 import org.geowebcache.layer.wms.WMSSourceHelper;
+import org.geowebcache.mime.MimeType;
 import org.geowebcache.seed.GWCTask.TYPE;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.TileObject;
@@ -171,7 +172,7 @@ public class SeedTaskTest extends TestCase {
 
             @Override
             protected void makeRequest(TileResponseReceiver tileRespRecv, WMSLayer layer,
-                    Map<String, String> wmsParams, String expectedMimeType, Resource target)
+                    Map<String, String> wmsParams, MimeType expectedMimeType, Resource target)
                     throws GeoWebCacheException {
                 numCalls++;
                 switch (numCalls) {

--- a/geowebcache/core/src/test/java/org/geowebcache/util/MockWMSSourceHelper.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/MockWMSSourceHelper.java
@@ -24,6 +24,7 @@ import org.geowebcache.layer.TileResponseReceiver;
 import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.layer.wms.WMSMetaTile;
 import org.geowebcache.layer.wms.WMSSourceHelper;
+import org.geowebcache.mime.MimeType;
 
 public class MockWMSSourceHelper extends WMSSourceHelper {
     private Font font = Font.decode("Arial-BOLD-14");
@@ -32,7 +33,7 @@ public class MockWMSSourceHelper extends WMSSourceHelper {
 
     @Override
     protected void makeRequest(TileResponseReceiver tileRespRecv, WMSLayer layer,
-            Map<String, String> wmsParams, String expectedMimeType, Resource target)
+            Map<String, String> wmsParams, MimeType expectedMimeType, Resource target)
             throws GeoWebCacheException {
         long ts = System.currentTimeMillis();
         long[][] tiles;

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -150,6 +150,12 @@
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>
     </dependency>
+
+    <dependency>
+      	<groupId>it.geosolutions.jaiext.utilities</groupId>
+	    <artifactId>jt-utilities</artifactId>
+        <version>1.0.11</version>
+    </dependency>
     
 	<!-- PNG Encoder dependencies -->
 	<dependency>


### PR DESCRIPTION
This work adds one dependency to jai-ext in core, to avoid having to put a verbatim copy of a class in GWC and GeoServer. Unsure about documentation, I could not find a section dedicated to formats.
While I have not tried, it should be possible to use jpeg-png also against a remote server that only supports PNG, the current code is splitting the meta-tile and determining on a tile per tile basis if it should be encoded as PNG or JPEG.