### PR TITLE
Use cannonical path for FileManagerTest where applicable

### DIFF
--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/FileManagerTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/FileManagerTest.java
@@ -148,7 +148,7 @@ public final class FileManagerTest extends TestSupport {
         String expectedPath = Utils.buildPath("jpeg-tiles", "wgs84", "africa-dark_borders", "zoom-11", "ranges-7000_4000.sqlite");
         FileManager fileManager = new FileManager(getRootDirectory(), pathTemplate, 2000, 1000);
         File file = fileManager.getFile(tile);
-        assertThat(file.getPath(), is(getRootDirectoryPath() + File.separator + expectedPath));
+        assertThat(file.getCanonicalPath(), is(getRootDirectoryPath() + File.separator + expectedPath));
     }
 
     @Test


### PR DESCRIPTION
GeoWebCache fails FileManagerTest.testPathTemplateWithTileObject() on OS X, due to confusion between `/private/var/...` and `/var/...`
This fixes that test failure.