### PR TITLE
Fix GeoTools dependency (should be 17-SNAPSHOT)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -10,7 +10,7 @@
   <url>http://geowebcache.org</url>
 
   <properties>
-    <gt.version>17-SNAPSHOT-SNAPSHOT</gt.version>
+    <gt.version>17-SNAPSHOT</gt.version>
     <jts.version>1.13</jts.version>
     <spring.version>4.2.5.RELEASE</spring.version>
     <restlet.version>1.0.8</restlet.version>


### PR DESCRIPTION
@smithkm @aaime someone please merge this as the broken GeoTools dependency is breaking the GeoWebCache build (and will break the GeoServer build as soon as @jodygarnett branches and updates versions on master).