### PR TITLE
Always select native ImageWriter if available

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -210,7 +210,13 @@ public class ImageMime extends MimeType {
     
     public ImageWriter getImageWriter(RenderedImage image) {
         Iterator<ImageWriter> it = javax.imageio.ImageIO.getImageWritersByFormatName(internalName);
-        ImageWriter writer = it.next();
+        ImageWriter writer = null;
+        while (it.hasNext()) {
+            writer = it.next();
+            if (writer.getClass().toString().startsWith("com.sun.media.imageioimpl")) {
+                break;
+            }
+        }
         return writer;
     }
 


### PR DESCRIPTION
This fixes issue #387: The reader selected when handling the MetaTile is random (https://github.com/GeoWebCache/geowebcache/issues/387)
