### PR TITLE
Fixes #445, upgrade imageio-ext version to 1.1.16 (backport 1.9.x)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -33,7 +33,7 @@
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs/>
-    <imageio-ext.version>1.1.10</imageio-ext.version>
+    <imageio-ext.version>1.1.16</imageio-ext.version>
     <hazelcast.version>2.3.1</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
   </properties>


### PR DESCRIPTION
Backport of pull request: https://github.com/GeoWebCache/geowebcache/pull/446