### PR TITLE
[fixes #458] Temporary fix for fullWMS image/gif

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -656,6 +656,7 @@ public abstract class TileLayer {
 
         Resource resource;
         boolean encode;
+        boolean overrideResource = false;
         for (int i = 0; i < gridPositions.length; i++) {
             final long[] gridPos = gridPositions[i];
             if (Arrays.equals(gridLoc, gridPos)) {
@@ -664,6 +665,9 @@ public abstract class TileLayer {
                 resource = getImageBuffer(WMS_BUFFER2);
                 tileProto.setBlob(resource);
                 encode = true;
+
+                // this is the tile we want to send to client
+                overrideResource = true;
             } else {
                 resource = getImageBuffer(WMS_BUFFER);
                 encode = store;
@@ -693,6 +697,12 @@ public abstract class TileLayer {
                                 tileProto.getStorageBroker().putTransient(tile);
                             } else {
                                 tileProto.getStorageBroker().put(tile);
+
+                                // if GIF then reset blob from written file
+                                if (overrideResource && tileProto.getMimeType().getFormat()
+                                        .equals("image/gif")) {
+                                    tileProto.setBlob(tile.getBlob());
+                                }
                             }
                             tileProto.getStorageObject().setCreated(tile.getCreated());
                         } catch (StorageException e) {

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -656,9 +656,10 @@ public abstract class TileLayer {
 
         Resource resource;
         boolean encode;
-        boolean overrideResource = false;
         for (int i = 0; i < gridPositions.length; i++) {
             final long[] gridPos = gridPositions[i];
+
+            boolean overrideResource = false;
             if (Arrays.equals(gridLoc, gridPos)) {
                 // Is this the one we need to save? then don't use the buffer or it'll be overridden
                 // by the next tile
@@ -700,7 +701,7 @@ public abstract class TileLayer {
 
                                 // if GIF then reset blob from written file
                                 if (overrideResource && tileProto.getMimeType().getFormat()
-                                        .equals("image/gif")) {
+                                        .toLowerCase().startsWith("image/gif")) {
                                     tileProto.setBlob(tile.getBlob());
                                 }
                             }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -535,6 +535,12 @@ public class FileBlobStore implements BlobStore {
                     temp = null;
                 }
             }
+
+            Resource blob = readFile(target);
+            if (blob != null) {
+                // resets blob to handle GIF
+                stObj.setBlob(blob);
+            }
         } finally {
 
             if (temp != null) {


### PR DESCRIPTION
* Will reset blob with FileResource when new tile have been written to file system
* Will use FileResource when sending tile to client to avoid issue in ByteArrayResource