### PR TITLE
Fix #466. Fix variable mixup in MimeType.isCompatible

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
@@ -195,10 +195,16 @@ public class MimeType {
         return format.hashCode();
     }
 
-
-
+    /**
+     * Determine whether otherMimeType is compatible with this MimeType. They're compatible if
+     * they're identical, or presumably if otherMimeType has this mime type as a prefix.
+     * @param otherMimeType the mime type to check for compatibility
+     * @return whether otherMimeType is "compatible" with this mime type
+     */
     public boolean isCompatible(String otherMimeType) {
-        return mimeType.equalsIgnoreCase(otherMimeType) || otherMimeType.startsWith(otherMimeType);
+        return mimeType.equalsIgnoreCase(otherMimeType) ||
+            (otherMimeType != null &&
+                otherMimeType.toLowerCase().startsWith(mimeType.toLowerCase()));
     }
     
     @Override

--- a/geowebcache/core/src/test/java/org/geowebcache/mime/ImageMimeTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/mime/ImageMimeTest.java
@@ -17,6 +17,7 @@
 package org.geowebcache.mime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.awt.Color;
@@ -105,5 +106,12 @@ public class ImageMimeTest {
         ImageWriter expectedWriter = expectedMime.getImageWriter(bi);
         // compare by class, these object are not meant to be compared by equality
         assertEquals(expectedWriter.getClass(), jpegPngWriter.getClass());
+    }
+
+    @Test
+    public void testIsCompatileFailsOnXMLMime() {
+        MimeType pngMimeType = ImageMime.jpeg;
+        assertFalse("PNG mime type should not be compatible with XML error.",
+            pngMimeType.isCompatible("application/vnd.ogc.se_xml"));
     }
 }


### PR DESCRIPTION
Backport PR of #467 