### PR TITLE
480 Update pom to jt-utilities 1.0.13

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -114,13 +114,6 @@
     <dependency>
       <groupId>it.geosolutions.jaiext.utilities</groupId>
       <artifactId>jt-utilities</artifactId>
-      <exclusions>
-         <exclusion>
-            <!-- This one depends on JTS, which depends on xerces, which breaks some tests -->
-            <groupId>org.jaitools</groupId>
-            <artifactId>jt-utils</artifactId>
-         </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <gt.version>17-SNAPSHOT</gt.version>
     <jts.version>1.13</jts.version>
+    <jaiext.version>1.0.13</jaiext.version>
     <spring.version>4.2.5.RELEASE</spring.version>
     <restlet.version>1.0.8</restlet.version>
     <xstream.version>1.4.7</xstream.version>
@@ -89,6 +90,18 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.vividsolutions</groupId>
+      <artifactId>jts</artifactId>
+      <version>1.13</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -152,9 +165,9 @@
     </dependency>
 
     <dependency>
-      	<groupId>it.geosolutions.jaiext.utilities</groupId>
-	    <artifactId>jt-utilities</artifactId>
-        <version>1.0.11</version>
+      <groupId>it.geosolutions.jaiext.utilities</groupId>
+      <artifactId>jt-utilities</artifactId>
+      <version>${jaiext.version}</version>
     </dependency>
     
 	<!-- PNG Encoder dependencies -->


### PR DESCRIPTION
Since jai-ext 1.0.13 is not dependant on jaitools, a previous exclusion of a jaitools module in gwc would not be valid anymore (and xerces breaking some tests was back). Therefore, the poms were modified accordingly.