### PR TITLE
Resolves #483, Fix disk quota JDBC store layer gridset deletion (backport 1.10.x)

### DIFF
--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
@@ -270,6 +270,16 @@ public class SQLDialect {
 
     }
 
+    public String getUsedQuotaByLayerGridset(String schema, String layerNameParam, String gridSetParam) {
+        StringBuilder sb = new StringBuilder("SELECT SUM(BYTES) FROM ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILESET WHERE TILESET.LAYER_NAME = :").append(layerNameParam);
+        sb.append(" AND TILESET.GRIDSET_ID = :").append(gridSetParam);
+        return sb.toString();
+    }
+
     public String getRenameLayerStatement(String schema, String oldLayerName, String newLayerName) {
         StringBuilder sb = new StringBuilder("UPDATE ");
         if (schema != null) {

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -42,6 +42,7 @@ import org.geowebcache.diskquota.storage.TileSet;
 import org.geowebcache.diskquota.storage.TileSetVisitor;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.storage.DefaultStorageFinder;
 
 public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
@@ -143,6 +144,11 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
 
         layerDispatcher = new TileLayerDispatcher(new GridSetBroker(true, true), configList);
 
+        // add extra tests gwc configuration
+        InputStream input = this.getClass().getClassLoader().getResourceAsStream("gwc-test-config.xml");
+        XMLConfiguration extraConfig = new XMLConfiguration(input);
+        layerDispatcher.addConfiguration(extraConfig);
+
         tilePageCalculator = new TilePageCalculator(layerDispatcher);
 
         // prepare a connection pool for tests against a H2 database
@@ -192,9 +198,9 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         assertEquals(0, global.getBytes().longValue());
 
         Set<TileSet> tileSets = store.getTileSets();
-        // two formats for topp:states2, four formats and two tilesets for topp:states
+        // two formats for topp:states2, four formats and two tilesets for topp:states, one format and two tilesets for topp:states3
         assertNotNull(tileSets);
-        assertEquals(10, tileSets.size());
+        assertEquals(12, tileSets.size());
 
         // check every possibility
         TileSet tileSet = new TileSet("topp:states", "EPSG:900913", "image/png", null);
@@ -239,9 +245,20 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         assertTrue(tileSets.contains(tileSet));
         assertQuotaZero(tileSet);
 
+        // validate layer topp:states3
+
+        tileSet = new TileSet("topp:states3", "EPSG:4326", "image/png", null);
+        assertTrue(tileSets.contains(tileSet));
+        assertQuotaZero(tileSet);
+
+        tileSet = new TileSet("topp:states3", "EPSG:2163", "image/png", null);
+        assertTrue(tileSets.contains(tileSet));
+        assertQuotaZero(tileSet);
+
         // check the layer wide quotas
         assertQuotaZero("topp:states");
         assertQuotaZero("topp:states2");
+        assertQuotaZero("topp:states3");
 
         // remove one layer from the dispatcher
         Configuration configuration = layerDispatcher.removeLayer("topp:states");
@@ -256,7 +273,7 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
 
         tileSets = store.getTileSets();
         assertNotNull(tileSets);
-        assertEquals(2, tileSets.size());
+        assertEquals(4, tileSets.size());
         tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
         assertTrue(tileSets.contains(tileSet));
         assertQuotaZero(tileSet);
@@ -306,31 +323,55 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
     }
 
     public void testDeleteGridSet() throws InterruptedException {
-        // put some data into the two gridsets
-        String layerName = "topp:states";
-        TileSet tset1 = new TileSet(layerName, "EPSG:4326", "image/jpeg", null);
+        // put some data into four gridsets using two layers
+        String layerName1 = "topp:states";
+        String layerName2 = "topp:states3";
+        TileSet tset1 = new TileSet(layerName1, "EPSG:4326", "image/jpeg", null);
+        TileSet tset2 = new TileSet(layerName1, "EPSG:900913", "image/jpeg", null);
+        TileSet tset3 = new TileSet(layerName2, "EPSG:4326", "image/png", null);
+        TileSet tset4 = new TileSet(layerName1, "EPSG:4326", "image/png", null);
         addToQuotaStore(tset1);
-        TileSet tset2 = new TileSet(layerName, "EPSG:900913", "image/jpeg", null);
         addToQuotaStore(tset2);
+        addToQuotaStore(tset3);
+        addToQuotaStore(tset4);
+        // get the current quotas
         Quota tset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
         Quota tset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
+        Quota tset3Quota = store.getUsedQuotaByTileSetId(tset3.getId());
+        Quota tset4Quota = store.getUsedQuotaByTileSetId(tset4.getId());
         Quota globalQuota = store.getGloballyUsedQuota();
+        // check the current global quota
         Quota sum = new Quota();
         sum.add(tset1Quota);
         sum.add(tset2Quota);
+        sum.add(tset3Quota);
+        sum.add(tset4Quota);
         assertEquals(globalQuota.getBytes(), sum.getBytes());
-        
+        // delete sub gridset 4326 of layer topp:states
         assertEquals(8, countTileSetsByLayerName("topp:states"));
-        store.deleteGridSubset("topp:states", "EPSG:900913");
+        store.deleteGridSubset("topp:states", "EPSG:4326");
         assertEquals(4, countTileSetsByLayerName("topp:states"));
-
+        assertEquals(2, countTileSetsByLayerName("topp:states3"));
         // verify the quota for tset2 got erased and that now the total is equal to tset1
-        tset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
-        tset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
-        assertNotNull(tset2Quota);
-        assertEquals(new BigInteger("0"), tset2Quota.getBytes());
+        Quota newTset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
+        Quota newTset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
+        Quota newTset3Quota = store.getUsedQuotaByTileSetId(tset3.getId());
+        Quota newTset4Quota = store.getUsedQuotaByTileSetId(tset4.getId());
+        // validate test quota 1
+        assertNotNull(newTset1Quota);
+        assertEquals(new BigInteger("0"), newTset1Quota.getBytes());
+        // validate test quota 2
+        assertNotNull(newTset2Quota);
+        assertEquals(tset2Quota.getBytes(), newTset2Quota.getBytes());
+        // validate test quota 3
+        assertNotNull(newTset3Quota);
+        assertEquals(tset3Quota.getBytes(), newTset3Quota.getBytes());
+        // validate test quota 4
+        assertNotNull(newTset4Quota);
+        assertEquals(new BigInteger("0"), newTset4Quota.getBytes());
+        // test the global quota
         globalQuota = store.getGloballyUsedQuota();
-        assertEquals(tset1Quota.getBytes(), globalQuota.getBytes());
+        assertEquals(tset2Quota.getBytes().add(tset3Quota.getBytes()), globalQuota.getBytes());
     }
 
     private void addToQuotaStore(TileSet tset) throws InterruptedException {

--- a/geowebcache/diskquota/jdbc/src/test/resources/gwc-test-config.xml
+++ b/geowebcache/diskquota/jdbc/src/test/resources/gwc-test-config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://geowebcache.org/schema/1.11.0"
+                  xsi:schemaLocation="http://geowebcache.org/schema/1.11.0 http://geowebcache.org/schema/1.11.0/geowebcache.xsd">
+  <version>1.8.0</version>
+  <layers>
+    <wmsLayer>
+      <name>topp:states3</name>
+      <mimeFormats>
+        <string>image/png</string>
+      </mimeFormats>
+      <gridSubsets>
+        <gridSubset>
+          <gridSetName>EPSG:4326</gridSetName>
+        </gridSubset>
+        <gridSubset>
+          <gridSetName>EPSG:2163</gridSetName>
+        </gridSubset>
+      </gridSubsets>
+      <parameterFilters>
+        <stringParameterFilter>
+          <key>STYLES</key>
+          <defaultValue>population</defaultValue>
+        </stringParameterFilter>
+      </parameterFilters>
+      <wmsUrl>
+        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+      </wmsUrl>
+    </wmsLayer>
+  </layers>
+</gwcConfiguration>


### PR DESCRIPTION
Backport of this pull request: https://github.com/GeoWebCache/geowebcache/pull/484

This PR fix the negative disk quota issue and update tests code to make them test the situation that was provoking this issue.

I have manually tested this with the embedded H2 database and with a PostgresSQL database and everything works as expected.

This problem have also been reported in GeoServer: https://osgeo-org.atlassian.net/browse/GEOS-5615.