### PR TITLE
Fix #490 Log the result of cache-lookups on the server

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
@@ -243,6 +243,8 @@ public class ConveyorTile extends Conveyor implements TileResponseReceiver {
                 this.setCacheResult(CacheResult.MISS);
             }
 
+            log.info(this.toString() + " " + this.getCacheResult());
+
             return ret;
 
         } catch (StorageException se) {


### PR DESCRIPTION
I'd like advice on the the best way to do this. 

We currently use squid as a tile cache but intend to move to Geowebcache for its protocol support of WMS. 

We would like to log the result of all tile requests - in much the same that we currently do with squid. 

This log output could be controlled (eg. turned-off by default) with a boolean set in config - so that other end-users would not be exposed to the change. However, as a code convention, I don't think logging statements should be wrapped up in conditional logic.

Alternatively, I could use debug() or trace() so that the output is normally suppressed. But, that doesn't seem right either - since it would require us (or someone wanting this information) to set a debug log level as part of our production configuration.

