### PR TITLE
Make constants for config lookup publicly visible (backport 1.9.x)

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -101,7 +101,7 @@ import com.thoughtworks.xstream.io.xml.DomReader;
  */
 public class XMLConfiguration implements Configuration, InitializingBean {
     
-    static final String DEFAULT_CONFIGURATION_FILE_NAME = "geowebcache.xml";
+    public static final String DEFAULT_CONFIGURATION_FILE_NAME = "geowebcache.xml";
 
     private static Log log = LogFactory.getLog(org.geowebcache.config.XMLConfiguration.class);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLFileResourceProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLFileResourceProvider.java
@@ -47,7 +47,7 @@ public class XMLFileResourceProvider implements ConfigurationResourceProvider {
 
     private static Log log = LogFactory.getLog(org.geowebcache.config.XMLFileResourceProvider.class);
 
-    static final String GWC_CONFIG_DIR_VAR = "GEOWEBCACHE_CONFIG_DIR";
+    public static final String GWC_CONFIG_DIR_VAR = "GEOWEBCACHE_CONFIG_DIR";
     
     /**
      * Web app context, used to look up {@link XMLConfigurationProvider}s. Will be null if used the


### PR DESCRIPTION
Backport of this pull request: https://github.com/GeoWebCache/geowebcache/pull/491

Associated mailing list discussion:
*  https://sourceforge.net/p/geowebcache/mailman/message/35699123/
* http://osgeo-org.1560.x6.nabble.com/Add-back-the-possibility-to-externalize-GWC-configuration-using-GEOWEBCACHE-CACHE-DIR-td5309333.html