### PR TITLE
[fixes #497] Will return empty tile if req bbox do not intersect with source

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -352,9 +352,13 @@ public class GeoWebCacheDispatcher extends AbstractController {
 
         // Check where this should be dispatched
         if (conv.reqHandler == Conveyor.RequestHandler.SERVICE) {
-            // A3 The service object takes it from here
-            service.handleRequest(conv);
-
+            try {
+                // A3 The service object takes it from here
+                service.handleRequest(conv);
+            } catch (OutsideCoverageException e) {
+                // if outside of coverage respond with empty tile
+                writeEmpty((ConveyorTile) conv, e.getMessage());
+            }
         } else {
             ConveyorTile convTile = (ConveyorTile) conv;
 

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/OutsideCoverageException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/OutsideCoverageException.java
@@ -34,4 +34,8 @@ public class OutsideCoverageException extends GeoWebCacheException {
         super("Coverage [minx,miny,maxx,maxy] is " + Arrays.toString(coverage) + ", index [x,y,z] is " + Arrays.toString(index));
     }
 
+    public OutsideCoverageException(String msg) {
+        super(msg);
+    }
+
 }

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
@@ -42,6 +42,7 @@ import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridMismatchException;
 import org.geowebcache.grid.GridSubset;
+import org.geowebcache.grid.OutsideCoverageException;
 import org.geowebcache.grid.SRS;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.ProxyLayer;
@@ -294,6 +295,9 @@ public class WMSService extends Service{
                 wmsFuser.setHintsConfiguration(hintsConfig);
                 try {
                     wmsFuser.writeResponse(tile.servletResp, stats);
+                } catch (OutsideCoverageException e) {
+                    // throw up to handle as empty image
+                    throw e;
                 } catch (Exception e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -374,10 +374,19 @@ public class WMSTileFuser{
         // At worst, we have the best resolution possible
     }
 
-    protected void determineCanvasLayout() {
+    protected void determineCanvasLayout() throws OutsideCoverageException {
         // Find the spatial extent of the tiles needed to cover the desired extent
         srcRectangle = gridSubset.getCoverageIntersection(srcIdx, reqBounds);
         srcBounds = gridSubset.boundsFromRectangle(srcRectangle);
+
+        // Will control that req intersects src at all to avoid #497
+        if (!reqBounds.intersects(srcBounds)) {
+            String msg = String.format("Request BBOX do not intersect with source: req=%s src=%s",
+                    reqBounds.toString(), srcBounds.toString());
+            log.debug(msg);
+
+            throw new OutsideCoverageException(msg);
+        }
 
         // We now have the complete area, lets figure out our offsets
         // Positive means that there is blank space to the first tile,


### PR DESCRIPTION
* Will handle fullWMS request from different scale than supported once, and where request is not intersecting with source bounds, by responding with empty tile