### PR TITLE
Fix GeoTools dependency (should be 18-SNAPSHOT not 18-SNAPSHOT-SNAPSHOT)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -10,7 +10,7 @@
   <url>http://geowebcache.org</url>
 
   <properties>
-    <gt.version>18-SNAPSHOT-SNAPSHOT</gt.version>
+    <gt.version>18-SNAPSHOT</gt.version>
     <jts.version>1.13</jts.version>
     <jaiext.version>1.0.13</jaiext.version>
     <spring.version>4.2.5.RELEASE</spring.version>


### PR DESCRIPTION
This broken GeoTools dependency breaks the GeoWebCache build on master.

Exactly the same mistake was made last time we branched:
https://github.com/GeoWebCache/geowebcache/pull/439/files
https://sourceforge.net/p/geowebcache/mailman/message/35426845/

@smithkm please fix your script.