### PR TITLE
Resolves #444, Allow styles legends info configuration

### DIFF
--- a/documentation/en/user/source/configuration/layers/index.rst
+++ b/documentation/en/user/source/configuration/layers/index.rst
@@ -13,6 +13,7 @@ This section describes how to manually configure layers in GeoWebCache and provi
    projections
    palettes
    parameterfilters
+   styleslegends
    requestfilters
    arcgistilingschemes
    staticcaps

--- a/documentation/en/user/source/configuration/layers/styleslegends.rst
+++ b/documentation/en/user/source/configuration/layers/styleslegends.rst
@@ -1,0 +1,118 @@
+.. _configuration.layers.parameterfilters:
+
+Styles Legends
+==============
+
+In WMTS and WMS services capabilities documents, styles can be associated with a ``<LegendURL>`` element that allows clients to retrieve an image representing the style legend. In the following example we can see the ``<LegendURL>`` element for ``rain`` style (WMS 1.1.0): 
+
+.. code-block:: xml
+
+  <Style>
+    <Name>rain</Name>
+    <LegendURL width="128" height="123">
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost:8080/geoserver/ows?service=WMS&request=GetLegendGraphic&format=image/png&width=128&height=123&layer=topp:states&style=rain"/>
+    </LegendURL>
+  </Style>
+
+When using GeoWebCache integration with GeoServer, styles legends are automatically configured for GeoServer layers. Layers configured using a WMS capabilities document will also have their styles legends automatically configured.
+
+When configuring a layer using the REST interface or through ``geowebcache.xml`` configuration file the user needs to configure the styles legends, otherwise no ``<LegendURL>`` elements will be included in WMS and WMTS services capabilities documents.
+
+Both REST interface and ``geowebcache.xml`` configuration file use the same XML structure. A legend configuration is associated with a certain style in the context of a certain layer, follows a configuration example:
+
+.. code-block:: xml
+
+   <wmsLayer>
+      <name>topp:states</name>
+      <parameterFilters>
+        <stringParameterFilter>
+          <key>STYLES</key>
+          <defaultValue>population</defaultValue>
+          <values>
+            <string>population</string>
+            <string>polygon</string>
+            <string>pophatch</string>
+          </values>
+        </stringParameterFilter>
+      </parameterFilters>
+      <wmsUrl>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
+      </wmsUrl>
+      <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch">
+          <format>image/jpeg</format>
+          <url>http://localhost:8020/geowebcache/wms</url>
+        </legend>
+        <legend style="polygon">
+          <width>50</width>
+          <height>100</height>
+          <format>image/gif</format>
+          <completeUrl>http://localhost/polygon.gif</completeUrl>
+          <minScale>5000</minScale>
+          <maxScale>10000</maxScale>
+        </legend>
+      </legends>
+    </wmsLayer>
+
+The following properties can be used to configure a legend info:
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - style
+     - the style to which this legend belongs 
+   * - width
+     - the width of the legend image 
+   * - height
+     - the height of the legend image
+   * - format
+     - the image format of the legend image
+   * - url
+     - the URL that can be used to retrieve the legend image
+   * - minScale
+     - minimum scale denominator (inclusive) for which this legend image is valid (WMTS only)
+   * - maxScale
+     - maximum scale denominator (exclusive) for which this legend image is valid (WMTS only)
+
+This properties can be provided in several ways using ``<legends>`` and ``<legend>`` elements. Default values for properties ``width``, ``height`` and ``format`` can be configured using respectively attributes ``defaultWidth``, ``defaultHeight`` and ``defaultFormat`` of ``<legends>`` element. The default values can be overridden using elements ``width``, ``height`` and ``format`` inside ``<legend>`` elements.
+
+The ``style`` property value needs to be provided using ``style`` attribute of ``<legend>`` elements. The ``url`` property is a little more complex, if nothing is say the WMS layer base URL will be used to build a WMS ``GetLegendGraphic`` request. Element ``<url>`` can be used to provide another base URL, and this one will be used instead of the layer base URL. Element ``<completeUrl>`` can be used to provide an URL that should be used as is to retrieve the legend image.
+
+Properties ``minScale`` and ``maxScale`` can be provided using the ``<legend>`` element, this properties will only be used by WMTS service.
+
+Looking at the example above, the legend configured for ``population`` style will produce the following legend URL for WMTS:
+
+.. code-block:: xml
+
+  <LegendURL width="20" height="20" format="image/png" 
+    xlink:href="http://localhost:8080/geoserver/topp/wms?service=WMS&amp;request=GetLegendGraphic&amp;format=image/png&amp;width=20&amp;height=20&amp;layer=topp%3Astates&amp;style=population"/>
+
+Note that the layer base URL was used as the base URL for the legend URL. In the example above a different base URL is provided for the legend associated with style ``pophatch`` using the ``<url>`` element. The produced legend URL will look like this for WMTS:
+
+.. code-block:: xml
+
+  <LegendURL width="20" height="20" format="image/png"
+    xlink:href="http://localhost:8020/geowebcache/wms?service=WMS&amp;request=GetLegendGraphic&amp;format=image/jpeg&amp;width=20&amp;height=20&amp;layer=topp%3Astates&amp;style=pophatch"/>
+
+In some situations it may be useful to provide an already complete URL to the legend image (custom vendors parameters, a static image or different protocol). In the example above the legend URL for style ``polygon`` will use an already complete URL and will look like this for WMTS:
+
+.. code-block:: xml
+
+  <LegendURL width="50" height="100" minScaleDenominator="5000" maxScaleDenominator="10000" 
+    format="image/gif" xlink:href="http://localhost/polygon.gif"/>
+
+In WMS the legend URL element for ``polygon`` style will look like this:
+
+.. code-block:: xml
+
+  <LegendURL width="50" height="100">
+      <Format>image/gif</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/polygon.gif"/>
+  </LegendURL>
+
+WMS and WMTS legend URL elements have a different structure and different mandatory elements. In WMTS only properties ``format`` and ``url`` are mandatory. In WMS properties ``width``, ``height``, ``format`` and ``url`` are mandatory.  

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -49,12 +49,13 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.config.ContextualConfigurationProvider.Context;
+import org.geowebcache.config.legends.LegendsRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfoConverter;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.FloatParameterFilter;
@@ -443,6 +444,10 @@ public class XMLConfiguration implements Configuration, InitializingBean {
 
         // xs.alias("layers", List.class);
         xs.alias("wmsLayer", WMSLayer.class);
+
+        // configuration for legends info
+        xs.registerConverter(new LegendsRawInfoConverter());
+        xs.alias("legends", LegendsRawInfo.class);
 
         xs.alias("blobStores", new ArrayList<BlobStoreConfig>().getClass());
         xs.alias("FileBlobStore", FileBlobStoreConfig.class);

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfo.java
@@ -1,0 +1,71 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+/**
+ * Simple container for the information related with a style legends. Builder
+ * {@link LegendInfoBuilder} should be used to create instances of this class.
+ */
+public class LegendInfo {
+
+    private final String styleName;
+    private final Integer width;
+    private final Integer height;
+    private final String format;
+    private final String legendUrl;
+    private final Double minScale;
+    private final Double maxScale;
+
+    LegendInfo(String styleName, Integer width, Integer height,
+               String format, String legendUrl, Double minScale, Double maxScale) {
+        this.styleName = styleName;
+        this.width = width;
+        this.height = height;
+        this.format = format;
+        this.legendUrl = legendUrl;
+        this.minScale = minScale;
+        this.maxScale = maxScale;
+    }
+
+    public String getStyleName() {
+        return styleName;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public String getLegendUrl() {
+        return legendUrl;
+    }
+
+    public Double getMinScale() {
+        return minScale;
+    }
+
+    public Double getMaxScale() {
+        return maxScale;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
@@ -1,0 +1,157 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+import org.geowebcache.util.ServletUtils;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Builder for {@link LegendInfo} instances.
+ */
+public class LegendInfoBuilder {
+
+    private String layerName;
+    private String layerUrl;
+
+    private Integer defaultWidth;
+    private Integer defaultHeight;
+    private String defaultFormat;
+
+    private String styleName;
+    private Integer width;
+    private Integer height;
+    private String format;
+    private String url;
+    private String completeUrl;
+    private Double minScale;
+    private Double maxScale;
+
+    public LegendInfoBuilder withLayerName(String layerName) {
+        this.layerName = layerName;
+        return this;
+    }
+
+    public LegendInfoBuilder withLayerUrl(String layerUrl) {
+        this.layerUrl = layerUrl;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultWidth(Integer defaultWidth) {
+        this.defaultWidth = defaultWidth;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultHeight(Integer defaultHeight) {
+        this.defaultHeight = defaultHeight;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultFormat(String defaultFormat) {
+        this.defaultFormat = defaultFormat;
+        return this;
+    }
+
+    public LegendInfoBuilder withStyleName(String styleName) {
+        this.styleName = styleName;
+        return this;
+    }
+
+    public LegendInfoBuilder withWidth(Integer width) {
+        this.width = width;
+        return this;
+    }
+
+    public LegendInfoBuilder withHeight(Integer height) {
+        this.height = height;
+        return this;
+    }
+
+    public LegendInfoBuilder withFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public LegendInfoBuilder withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public LegendInfoBuilder withCompleteUrl(String completeUrl) {
+        this.completeUrl = completeUrl;
+        return this;
+    }
+
+    public LegendInfoBuilder withMinScale(Double minScale) {
+        this.minScale = minScale;
+        return this;
+    }
+
+    public LegendInfoBuilder withMaxScale(Double maxScale) {
+        this.maxScale = maxScale;
+        return this;
+    }
+
+    public LegendInfo build() {
+        // let's see if we need to really on the default values for width, height and format
+        Integer finalWidth = width == null ? defaultWidth : width;
+        Integer finalHeight = height == null ? defaultHeight : height;
+        String finalFormat = format == null ? defaultFormat : format;
+        // checking mandatory format value
+        checkNotNull(finalFormat, "A legend image format is mandatory.");
+        // default styles can have a NULL name
+        String finalStyleName = styleName == null ? "" : styleName;
+        // building the legend url
+        String finalUrl = buildFinalUrl(finalStyleName, finalWidth, finalHeight, finalFormat);
+        return new LegendInfo(finalStyleName, finalWidth, finalHeight, finalFormat, finalUrl, minScale, maxScale);
+    }
+
+    /**
+     * Helper method that builds the legend get url using the available info.
+     */
+    private String buildFinalUrl(String finalStyleName, Integer finalWidth, Integer finalHeight, String finalFormat) {
+        if (completeUrl != null) {
+            // we have a complete url so let's just return it
+            return completeUrl;
+        }
+        String finalUrl = url == null ? layerUrl : url;
+        // check mandatory values
+        checkNotNull(finalWidth, "A legend width is mandatory.");
+        checkNotNull(finalHeight, "A legend height is mandatory.");
+        checkNotNull(finalUrl, "A legend url is mandatory.");
+        checkNotNull(layerName, "A layer name is mandatory.");
+        return finalUrl + addQuoteMark(finalUrl) +
+                "service=WMS&request=GetLegendGraphic" +
+                "&format=" + finalFormat +
+                "&width=" + finalWidth +
+                "&height=" + finalHeight +
+                "&layer=" + ServletUtils.URLEncode(layerName) +
+                "&style=" + ServletUtils.URLEncode(finalStyleName);
+    }
+
+    /**
+     * Helper method check's if a quote separating the base url from the query parameters
+     * needs to be added to the url or not.
+     */
+    private String addQuoteMark(String finalUrl) {
+        if (finalUrl.indexOf("?") == finalUrl.length() - 1) {
+            // we are good no quote needed
+            return "";
+        }
+        return "?";
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendRawInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendRawInfo.java
@@ -1,0 +1,146 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+/**
+ * Contains the raw information about a style legend as it may appear
+ * in the XML configuration for example.
+ */
+public class LegendRawInfo {
+
+    private String style;
+    private Integer width;
+    private Integer height;
+    private String format;
+    private String url;
+    private String completeUrl;
+    private Double minScale;
+    private Double maxScale;
+
+    public String getStyle() {
+        return style;
+    }
+
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getCompleteUrl() {
+        return completeUrl;
+    }
+
+    public void setCompleteUrl(String completeUrl) {
+        this.completeUrl = completeUrl;
+    }
+
+    public Double getMinScale() {
+        return minScale;
+    }
+
+    public void setMinScale(Double minScale) {
+        this.minScale = minScale;
+    }
+
+    public Double getMaxScale() {
+        return maxScale;
+    }
+
+    public void setMaxScale(Double maxScale) {
+        this.maxScale = maxScale;
+    }
+
+    /**
+     * Build the concrete legend information using the provided layer information and defaults values.
+     */
+    public LegendInfo getLegendInfo(String layerName, String layerUrl, Integer defaultWidth, Integer defaultHeight, String defaultFormat) {
+        return new LegendInfoBuilder()
+                .withLayerName(layerName)
+                .withLayerUrl(layerUrl)
+                .withDefaultWidth(defaultWidth)
+                .withDefaultHeight(defaultHeight)
+                .withDefaultFormat(defaultFormat)
+                .withStyleName(style)
+                .withWidth(width)
+                .withHeight(height)
+                .withFormat(format)
+                .withUrl(url)
+                .withCompleteUrl(completeUrl)
+                .withMinScale(minScale)
+                .withMaxScale(maxScale)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        LegendRawInfo that = (LegendRawInfo) other;
+        if (style != null ? !style.equals(that.style) : that.style != null) return false;
+        if (width != null ? !width.equals(that.width) : that.width != null) return false;
+        if (height != null ? !height.equals(that.height) : that.height != null) return false;
+        if (format != null ? !format.equals(that.format) : that.format != null) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (completeUrl != null ? !completeUrl.equals(that.completeUrl) : that.completeUrl != null) return false;
+        if (minScale != null ? !minScale.equals(that.minScale) : that.minScale != null) return false;
+        return maxScale != null ? maxScale.equals(that.maxScale) : that.maxScale == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = style != null ? style.hashCode() : 0;
+        result = 31 * result + (width != null ? width.hashCode() : 0);
+        result = 31 * result + (height != null ? height.hashCode() : 0);
+        result = 31 * result + (format != null ? format.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (completeUrl != null ? completeUrl.hashCode() : 0);
+        result = 31 * result + (minScale != null ? minScale.hashCode() : 0);
+        result = 31 * result + (maxScale != null ? maxScale.hashCode() : 0);
+        return result;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfo.java
@@ -1,0 +1,79 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Container for raw legends and the related default values.
+ */
+public class LegendsRawInfo {
+
+    private Integer defaultWidth;
+    private Integer defaultHeight;
+    private String defaultFormat;
+
+    private List<LegendRawInfo> legendsRawInfo = new ArrayList<>();
+
+    public Integer getDefaultWidth() {
+        return defaultWidth;
+    }
+
+    public void setDefaultWidth(Integer defaultWidth) {
+        this.defaultWidth = defaultWidth;
+    }
+
+    public Integer getDefaultHeight() {
+        return defaultHeight;
+    }
+
+    public void setDefaultHeight(Integer defaultHeight) {
+        this.defaultHeight = defaultHeight;
+    }
+
+    public String getDefaultFormat() {
+        return defaultFormat;
+    }
+
+    public void setDefaultFormat(String defaultFormat) {
+        this.defaultFormat = defaultFormat;
+    }
+
+    public void addLegendRawInfo(LegendRawInfo legendRawInfo) {
+        legendsRawInfo.add(legendRawInfo);
+    }
+
+    public List<LegendRawInfo> getLegendsRawInfo() {
+        return legendsRawInfo;
+    }
+
+    /**
+     * Builds the concrete legends info for each raw legend info using the provided layer information.
+     * The returned map index the legend info per layer.
+     */
+    public Map<String, LegendInfo> getLegendsInfo(String layerName, String layerUrl) {
+        Map<String, LegendInfo> legendsInfo = new HashMap<>();
+        for (LegendRawInfo legendRawInfo : legendsRawInfo) {
+            legendsInfo.put(legendRawInfo.getStyle(),
+                    legendRawInfo.getLegendInfo(layerName, layerUrl, defaultWidth, defaultHeight, defaultFormat));
+        }
+        return legendsInfo;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfoConverter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfoConverter.java
@@ -1,0 +1,137 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * XML converter for {@link LegendsRawInfo}.
+ */
+public class LegendsRawInfoConverter implements Converter {
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        LegendsRawInfo legendsRawInfo = (LegendsRawInfo) source;
+        // encode default values
+        writer.addAttribute("defaultWidth", String.valueOf(legendsRawInfo.getDefaultWidth()));
+        writer.addAttribute("defaultHeight", String.valueOf(legendsRawInfo.getDefaultHeight()));
+        writer.addAttribute("defaultFormat", String.valueOf(legendsRawInfo.getDefaultFormat()));
+        // encode legends information
+        for (LegendRawInfo legendRawInfo : legendsRawInfo.getLegendsRawInfo()) {
+            writer.startNode("legend");
+            writer.addAttribute("style", legendRawInfo.getStyle());
+            encodeAttribute(writer, "width", legendRawInfo.getWidth());
+            encodeAttribute(writer, "height", legendRawInfo.getHeight());
+            encodeAttribute(writer, "format", legendRawInfo.getFormat());
+            encodeAttribute(writer, "url", legendRawInfo.getUrl());
+            encodeAttribute(writer, "completeUrl", legendRawInfo.getCompleteUrl());
+            encodeAttribute(writer, "minScale", legendRawInfo.getMinScale());
+            encodeAttribute(writer, "maxScale", legendRawInfo.getMaxScale());
+            writer.endNode();
+        }
+    }
+
+    private void encodeAttribute(HierarchicalStreamWriter writer, String name, Object value) {
+        if (value == null) {
+            return;
+        }
+        writer.startNode(name);
+        writer.setValue(value.toString());
+        writer.endNode();
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        // setting the defaults based on legends element attributes
+        legendsRawInfo.setDefaultWidth(toInteger(reader.getAttribute("defaultWidth")));
+        legendsRawInfo.setDefaultHeight(toInteger(reader.getAttribute("defaultHeight")));
+        legendsRawInfo.setDefaultFormat(reader.getAttribute("defaultFormat"));
+        // parsing all legends information
+        while(reader.hasMoreChildren()) {
+            reader.moveDown();
+            legendsRawInfo.addLegendRawInfo(parseLegendRawInfo(reader));
+            reader.moveUp();
+        }
+        return legendsRawInfo;
+    }
+
+    /**
+     * Helper method that converts a non NULL string value to an integer.
+     */
+    private Integer toInteger(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        return Integer.valueOf(rawValue);
+    }
+
+    /**
+     * Helper method that converts a non NULL string value to an double.
+     */
+    private Double toDouble(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        return Double.valueOf(rawValue);
+    }
+
+    /**
+     * Helper method that retrieves from the reader a legend raw information.
+     */
+    private LegendRawInfo parseLegendRawInfo(HierarchicalStreamReader reader) {
+        LegendRawInfo legendRawInfo = new LegendRawInfo();
+        legendRawInfo.setStyle(reader.getAttribute("style"));
+        while(reader.hasMoreChildren()) {
+            reader.moveDown();
+            switch(reader.getNodeName()) {
+                case "width":
+                    legendRawInfo.setWidth(toInteger(reader.getValue()));
+                    break;
+                case "height":
+                    legendRawInfo.setHeight(toInteger(reader.getValue()));
+                    break;
+                case "format":
+                    legendRawInfo.setFormat(reader.getValue());
+                    break;
+                case "url":
+                    legendRawInfo.setUrl(reader.getValue());
+                    break;
+                case "completeUrl":
+                    legendRawInfo.setCompleteUrl(reader.getValue());
+                    break;
+                case "minScale":
+                    legendRawInfo.setMinScale(toDouble(reader.getValue()));
+                    break;
+                case "maxScale":
+                    legendRawInfo.setMaxScale(toDouble(reader.getValue()));
+                    break;
+            }
+            reader.moveUp();
+        }
+        return legendRawInfo;
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(LegendsRawInfo.class);
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
 import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.request.RequestFilter;
@@ -243,14 +244,27 @@ public abstract class TileLayer {
 
     /**
      * Returns legend info indexed by style.
+     * @deprecated please use method {@link #getLayerLegendsInfo()}
+     * @see #getLayerLegendsInfo()
      */
+    @Deprecated
     public Map<String, LegendInfo> getLegendsInfo() {
         return Collections.EMPTY_MAP;
     }
 
     /**
-     * Information container for a style legend.
+     * Returns legend info indexed by style.
      */
+    public Map<String, org.geowebcache.config.legends.LegendInfo> getLayerLegendsInfo() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Information container for a style legend.
+     * @deprecated please use {@link org.geowebcache.config.legends.LegendInfo}
+     * @see org.geowebcache.config.legends.LegendInfo
+     */
+    @Deprecated
     public static class LegendInfo {
 
         public String id;
@@ -263,6 +277,7 @@ public abstract class TileLayer {
     /**
      * Helper constructor for legend info;
      */
+    @Deprecated
     public static LegendInfo createLegendInfo() {
         return new LegendInfo();
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
@@ -33,6 +33,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.config.XMLGridSubset;
 import org.geowebcache.conveyor.Conveyor.CacheResult;
 import org.geowebcache.conveyor.ConveyorTile;
@@ -117,6 +119,8 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
     protected transient String sphericalMercatorOverride;
 
     private transient LockProvider lockProvider;
+
+    private LegendsRawInfo legends;
 
     WMSLayer() {
         //default constructor for XStream
@@ -853,5 +857,20 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
             IOUtils.closeQuietly(is);
         }
         
+    }
+
+    public LegendsRawInfo getLegends() {
+        return legends;
+    }
+
+    public void setLegends(LegendsRawInfo legends) {
+        this.legends = legends;
+    }
+
+    @Override
+    public Map<String, org.geowebcache.config.legends.LegendInfo> getLayerLegendsInfo() {
+        String layerName = wmsLayers == null ? getName() : wmsLayers;
+        return legends == null ? super.getLayerLegendsInfo() :
+                legends.getLegendsInfo(layerName, wmsUrl != null && wmsUrl.length > 0 ? wmsUrl[0] : null);
     }
 }

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -152,6 +152,14 @@
       <wmsUrl>
         <string>http://demo.opengeo.org/geoserver/topp/wms</string>
       </wmsUrl>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -166,6 +174,9 @@
         <string>http://demo.opengeo.org/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
+      <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
+        <legend style=""/>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -206,6 +217,20 @@
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>
       <bgColor>0x0066FF</bgColor>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+          <minScale>5000</minScale>
+          <maxScale>10000</maxScale>
+        </legend>
+        <legend style="raster">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
   </layers>
 

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -717,6 +717,13 @@
               </xs:documentation> 
             </xs:annotation>
           </xs:element>
+          <xs:element type="gwc:legendsType" name="legends" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                Defines legends information for this layer styles.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
         </xs:sequence>
      </xs:extension>
     </xs:complexContent>
@@ -2055,5 +2062,97 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="legendType" mixed="true">
+    <xs:sequence>
+      <xs:element type="xs:integer" name="width" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend width.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:integer" name="height" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend height.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="format" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend format.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="url" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            URL that should be used to produce the legend get URL.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="completeUrl" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Complete URL that should be used as is.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:double" name="minScale" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Minimum scale denominator (inclusive) for which this legend image is valid.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:double" name="maxScale" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Maximum scale denominator (exclusive) for which this legend image is valid.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="style" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          The style that corresponds to this legend.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="legendsType">
+    <xs:sequence>
+      <xs:element type="gwc:legendType" name="legend" maxOccurs="unbounded" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            A style legend definition.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="defaultWidth">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default width that should be used if no legend width is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="defaultHeight">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default height that should be used if no legend height is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="defaultFormat">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default format that should be used if no legend format is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 </xs:schema>

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.config;
 
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;
@@ -18,6 +19,8 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.legends.LegendRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.parameters.StringParameterFilter;
 import org.geowebcache.grid.BoundingBox;
@@ -173,8 +176,35 @@ public class XMLConfigurationTest {
         WMSLayer layer = new WMSLayer(layerName, wmsURL, wmsStyles, wmsLayers, mimeFormats,
                 subSets, parameterFilters, metaWidthHeight, vendorParams, queryable, wmsQueryLayers);
 
-        config.addLayer(layer);
+        // create legends information
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        legendsRawInfo.setDefaultWidth(50);
+        legendsRawInfo.setDefaultHeight(100);
+        legendsRawInfo.setDefaultFormat("image/png");
+        // legend with all values and custom url
+        LegendRawInfo legendRawInfoA = new LegendRawInfo();
+        legendRawInfoA.setStyle("polygon");
+        legendRawInfoA.setWidth(75);
+        legendRawInfoA.setHeight(125);
+        legendRawInfoA.setFormat("image/jpeg");
+        legendRawInfoA.setUrl("http://url");
+        legendRawInfoA.setMinScale(5000D);
+        legendRawInfoA.setMaxScale(10000D);
 
+        // legend with a complete url
+        LegendRawInfo legendRawInfoB = new LegendRawInfo();
+        legendRawInfoB.setStyle("point");
+        legendRawInfoB.setCompleteUrl("http://url");
+        // default style legend
+        LegendRawInfo legendRawInfoC = new LegendRawInfo();
+        legendRawInfoC.setStyle("");
+        // tie the legend information together
+        legendsRawInfo.addLegendRawInfo(legendRawInfoA);
+        legendsRawInfo.addLegendRawInfo(legendRawInfoB);
+        legendsRawInfo.addLegendRawInfo(legendRawInfoC);
+        layer.setLegends(legendsRawInfo);
+
+        config.addLayer(layer);
         config.save();
 
         try {
@@ -201,6 +231,14 @@ public class XMLConfigurationTest {
             assertNotNull(actual);
             assertEquals(new XMLGridSubset(expected), new XMLGridSubset(actual));
         }
+
+        // check legends info
+        assertThat(l.getLegends(), notNullValue());
+        assertThat(l.getLegends().getDefaultWidth(), is(50));
+        assertThat(l.getLegends().getDefaultHeight(), is(100));
+        assertThat(l.getLegends().getDefaultFormat(), is("image/png"));
+        assertThat(l.getLegends().getLegendsRawInfo().size(), is(3));
+        assertThat(l.getLegends().getLegendsRawInfo(), containsInAnyOrder(legendRawInfoA, legendRawInfoB, legendRawInfoC));
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
@@ -1,0 +1,139 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2017
+ */
+package org.geowebcache.config.legends;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+/**
+ * Test styles legends info different combinations.
+ */
+public class LegendInfoBuilderTest {
+
+    @Test
+    public void testWithOnlyDefaults() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .build();
+        assertThat(legendInfo.getWidth(), is(50));
+        assertThat(legendInfo.getHeight(), is(100));
+        assertThat(legendInfo.getFormat(), is("image/png"));
+        assertThat(legendInfo.getStyleName(), is(""));
+        assertThat(legendInfo.getMinScale(), is(nullValue()));
+        assertThat(legendInfo.getMaxScale(), is(nullValue()));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/png&width=50&height=100&layer=layer1&style="));
+    }
+
+    @Test
+    public void testWithValues() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withMinScale(1000.55)
+                .withMaxScale(2000.655)
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getMinScale(), is(1000.55));
+        assertThat(legendInfo.getMaxScale(), is(2000.655));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+
+    @Test
+    public void testWithUrl() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withUrl("http://localhost:9090/image.gif?")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:9090/image.gif?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+
+    @Test
+    public void testWithCompleteUrl() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withCompleteUrl("http://my.server.com/image.gif")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://my.server.com/image.gif"));
+    }
+
+    @Test
+    public void testWithValuesNoDefaults() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withMinScale(50.5)
+                .withMaxScale(80.5)
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getMinScale(), is(50.5));
+        assertThat(legendInfo.getMaxScale(), is(80.5));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+}

--- a/geowebcache/wms/src/main/java/org/geowebcache/config/GetCapabilitiesConfiguration.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/config/GetCapabilitiesConfiguration.java
@@ -30,6 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,9 +48,12 @@ import org.geotools.ows.ServiceException;
 import org.geotools.xml.PreventLocalEntityResolver;
 import org.geotools.xml.XMLHandlerHints;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.parameters.NaiveWMSDimensionFilter;
 import org.geowebcache.filter.parameters.ParameterFilter;
+import org.geowebcache.filter.parameters.StringParameterFilter;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
@@ -62,8 +68,14 @@ import org.geowebcache.layer.wms.WMSHttpHelper;
 import org.geowebcache.layer.wms.WMSLayer;
 
 public class GetCapabilitiesConfiguration implements Configuration {
+
     private static Log log = LogFactory
             .getLog(org.geowebcache.config.GetCapabilitiesConfiguration.class);
+
+    // regex patterns used to parse legends urls parameters
+    private static final Pattern LEGEND_WIDTH_PATTERN = Pattern.compile(".*width=(\\d+).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEGEND_HEIGHT_PATTERN = Pattern.compile(".*height=(\\d+).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEGEND_FORMAT_PATTERN = Pattern.compile(".*format=([^&]+).*", Pattern.CASE_INSENSITIVE);
 
     private GridSetBroker gridSetBroker;
 
@@ -214,6 +226,8 @@ public class GetCapabilitiesConfiguration implements Configuration {
             boolean queryable = layer.isQueryable();
 
             if (name != null) {
+
+                LinkedList<ParameterFilter> paramFilters = new LinkedList<ParameterFilter>();
                 List<StyleImpl> styles = layer.getStyles();
 
                 StringBuffer buf = new StringBuffer();
@@ -228,6 +242,11 @@ public class GetCapabilitiesConfiguration implements Configuration {
                         hasOne = true;
                     }
                     stylesStr = buf.toString();
+                    // set styles parameters
+                    StringParameterFilter stylesParameterFilter = new StringParameterFilter();
+                    stylesParameterFilter.setKey("STYLES");
+                    stylesParameterFilter.setValues(styles.stream().map(StyleImpl::getName).collect(Collectors.toList()));
+                    paramFilters.add(stylesParameterFilter);
                 }
 
                 double minX = layer.getLatLonBoundingBox().getMinX();
@@ -246,7 +265,6 @@ public class GetCapabilitiesConfiguration implements Configuration {
 
                 String[] wmsUrls = { wmsUrl };
 
-                LinkedList<ParameterFilter> paramFilters = new LinkedList<ParameterFilter>();
                 for (Dimension dimension : layer.getDimensions().values()) {
                     Extent dimExtent = layer.getExtent(dimension.getName());
                     paramFilters.add(new NaiveWMSDimensionFilter(dimension, dimExtent));
@@ -287,12 +305,65 @@ public class GetCapabilitiesConfiguration implements Configuration {
                         wmsLayer.setMetadataURLs(convertedMetadataURLs);
                     }
 
+                    // add styles legend information
+                    wmsLayer.setLegends(extractLegendsInfo(styles));
+
                     layers.add(wmsLayer);
                 }
             }
         }
 
         return layers;
+    }
+
+    /**
+     * Helper method that extracts from a legend url the width, height and format parameters.
+     */
+    private LegendsRawInfo extractLegendsInfo(List<StyleImpl> styles) {
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        // setting some acceptable default values
+        legendsRawInfo.setDefaultWidth(20);
+        legendsRawInfo.setDefaultHeight(20);
+        legendsRawInfo.setDefaultFormat("image/png");
+        for (StyleImpl style : styles) {
+            // extracting legend information from each style
+            LegendRawInfo legendRawInfo = new LegendRawInfo();
+            legendRawInfo.setStyle(style.getName());
+            List legendUrls = style.getLegendURLs();
+            if (legendUrls != null && !legendUrls.isEmpty()) {
+                String legendUrl = (String) legendUrls.get(0);
+                // let's see if we can extract width, height and format from the style legend url
+                legendRawInfo.setWidth(extractIntegerParameter(legendUrl, LEGEND_WIDTH_PATTERN));
+                legendRawInfo.setHeight(extractIntegerParameter(legendUrl, LEGEND_HEIGHT_PATTERN));
+                legendRawInfo.setFormat(extractParameter(legendUrl, LEGEND_FORMAT_PATTERN));
+                // setting the complete legend url
+                legendRawInfo.setCompleteUrl(legendUrl);
+            }
+            legendsRawInfo.addLegendRawInfo(legendRawInfo);
+        }
+        return legendsRawInfo;
+    }
+
+    /**
+     * Helper method that simply extracts from the provided url a certain parameter.
+     */
+    private String extractParameter(String url, Pattern pattern) {
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Helper method that simply extracts from the provided url a certain integer parameter.
+     */
+    private Integer extractIntegerParameter(String url, Pattern pattern) {
+        String value = extractParameter(url, pattern);
+        if (value == null) {
+            return null;
+        }
+        return Integer.valueOf(value);
     }
 
     private WMSLayer getLayer(String name, String[] wmsurl, BoundingBox bounds4326,

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
 import org.geowebcache.config.meta.ServiceContact;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.config.meta.ServiceProvider;
@@ -54,6 +55,8 @@ import org.geowebcache.mime.ImageMime;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.util.ServletUtils;
 import org.geowebcache.util.URLMangler;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WMSGetCapabilities {
 
@@ -354,10 +357,11 @@ public class WMSGetCapabilities {
                 }
 
                 List<String> styles = getStyles(layer.getParameterFilters());
+                Map<String, LegendInfo> legendsInfo = layer.getLayerLegendsInfo();
                 for (String format : formats) {
                     for (String style : styles) {
                         try {
-                            capabilityVendorSpecificTileset(xml, layer, grid, format, style);
+                            capabilityVendorSpecificTileset(xml, layer, grid, format, style, legendsInfo.get(style));
                         } catch (GeoWebCacheException e) {
                             log.error(e.getMessage());
                         }
@@ -393,7 +397,7 @@ public class WMSGetCapabilities {
     }
 
     private void capabilityVendorSpecificTileset(XMLBuilder xml, TileLayer layer,
-            GridSubset grid, String formatStr, String styleName) throws GeoWebCacheException, IOException {
+            GridSubset grid, String formatStr, String styleName, LegendInfo legendInfo) throws GeoWebCacheException, IOException {
 
         String srsStr = grid.getSRS().toString();
         StringBuilder resolutionsStr = new StringBuilder();
@@ -415,9 +419,43 @@ public class WMSGetCapabilities {
         xml.simpleElement("Height", Integer.toString(grid.getTileHeight()), true);
         xml.simpleElement("Format", formatStr, true);
         xml.simpleElement("Layers", layer.getName(), true);
-        xml.simpleElement("Styles", ServletUtils.URLEncode(styleName), true);
+        xml.indentElement("Styles");
+        xml.indentElement("Style");
+        xml.simpleElement("ows:Identifier", ServletUtils.URLEncode(styleName), true);
+        encodeStyleLegendGraphic(xml, legendInfo);
+        xml.endElement();
 
         xml.endElement();
+        xml.endElement();
+    }
+
+    /**
+     * XML encodes the provided legend information. If the provided information legend is NULL
+     * nothing is done.
+     */
+    private void encodeStyleLegendGraphic(XMLBuilder xml, LegendInfo legendInfo) throws IOException {
+        if (legendInfo == null) {
+            // nothing to do
+            return;
+        }
+        // validate legend info (this attributes are mandatory for WMS 1.1.0, 1.1.1 and 1.3.0)
+        checkNotNull(legendInfo.getWidth(), "Legend with is mandatory in WMS (1.1.0, 1.1.1 and 1.3.0).");
+        checkNotNull(legendInfo.getHeight(), "Legend height is mandatory in WMS (1.1.0, 1.1.1 and 1.3.0).");
+        checkNotNull(legendInfo.getFormat(), "Legend format is mandatory in WMS (1.1.0, 1.1.1 and 1.3.0).");
+        checkNotNull(legendInfo.getLegendUrl(), "Legend URL is mandatory in WMS (1.1.0, 1.1.1 and 1.3.0).");
+        xml.indentElement("LegendURL");
+        // add with and height attributes
+        xml.attribute("width", String.valueOf(legendInfo.getWidth()));
+        xml.attribute("height", String.valueOf(legendInfo.getHeight()));
+        // add format element
+        xml.simpleElement("Format", legendInfo.getFormat(), true);
+        // add online resource element
+        xml.indentElement("OnlineResource");
+        xml.attribute("xlink:type", "simple");
+        xml.attribute("xlink:href", legendInfo.getLegendUrl());
+        xml.endElement("OnlineResource");
+        // close legend URL element
+        xml.endElement("LegendURL");
     }
 
     private void capabilityLayerOuter(XMLBuilder xml) throws IOException {

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
@@ -6,7 +6,6 @@ import static org.easymock.classextension.EasyMock.replay;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
 
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -21,9 +20,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.easymock.classextension.EasyMock;
+import org.geowebcache.config.legends.LegendRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.config.meta.ServiceInformation;
+import org.geowebcache.filter.parameters.StringParameterFilter;
+import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubset;
-import org.geowebcache.layer.AbstractTileLayer;
+import org.geowebcache.grid.GridSubsetFactory;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.layer.wms.WMSLayer;
@@ -63,13 +66,36 @@ public class WMSGetCapabilitiesTest {
         expect(servInfo.getFees()).andStubReturn("NONE");
         expect(servInfo.getAccessConstraints()).andStubReturn("NONE");
         expect(tld.getServiceInformation()).andStubReturn(servInfo);
-        
-        // Creating an advertised Layer and an unadvertised one
-        HashMap<String, GridSubset> subSets = new HashMap<String, GridSubset>();
-        TileLayer advertisedLayer = new WMSLayer("testAdv", null, null, null,
-                null, subSets, null, null, null, false, null);      
+
+        // creating some styles for the advertised layer
+        StringParameterFilter stylesParameterFilter = new StringParameterFilter();
+        stylesParameterFilter.setKey("STYLES");
+        stylesParameterFilter.setValues(Arrays.asList("style1", "style2"));
+        // create grid sets for this layer
+        Map<String, GridSubset> subSets = new HashMap<>();
+        GridSubset gridSubSet = GridSubsetFactory.createGridSubSet(new GridSetBroker(true, true).get("EPSG:4326"));
+        subSets.put(gridSubSet.getName(), gridSubSet);
+        // create the layer
+        WMSLayer advertisedLayer = new WMSLayer("testAdv", null, "style,style2", null,
+                null, subSets, Collections.singletonList(stylesParameterFilter), null, null, false, null);
         advertisedLayer.setEnabled(true);
         advertisedLayer.setAdvertised(true);
+        // add legends info to the advertised layer
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        legendsRawInfo.setDefaultWidth(50);
+        legendsRawInfo.setDefaultHeight(100);
+        legendsRawInfo.setDefaultFormat("image/png");
+        LegendRawInfo legendRawInfo1 = new LegendRawInfo();
+        legendRawInfo1.setStyle("style1");
+        legendRawInfo1.setUrl("htp://localhost:8080/geoserver");
+        LegendRawInfo legendRawInfo2 = new LegendRawInfo();
+        legendRawInfo2.setStyle("style2");
+        legendRawInfo2.setUrl("htp://localhost:8080/geoserver");
+        // tie legend information together
+        legendsRawInfo.addLegendRawInfo(legendRawInfo1);
+        legendsRawInfo.addLegendRawInfo(legendRawInfo2);
+        advertisedLayer.setLegends(legendsRawInfo);
+
         TileLayer unAdvertisedLayer = new WMSLayer("testNotAdv", null, null, null,
                 null, subSets, null, null, null, false, null); 
         unAdvertisedLayer.setEnabled(true);
@@ -100,6 +126,18 @@ public class WMSGetCapabilitiesTest {
         
         assertThat(xml, containsString("testAdv"));
         assertThat(xml, not(containsString("testNotAdv")));
+
+        // check for legends URL for style 1
+        assertThat(document.getDocumentElement(), HasXPath.hasXPath("/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/" +
+                "TileSet/Styles/Style[Identifier='style1']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
+                "/OnlineResource[@type='simple'][@href='htp://localhost:8080/geoserver?service=WMS&request=GetLegendGraphic&" +
+                "format=image/png&width=50&height=100&layer=testAdv&style=style1']"));
+
+        // check for legends URL for style 2
+        assertThat(document.getDocumentElement(), HasXPath.hasXPath("/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/" +
+                "TileSet/Styles/Style[Identifier='style2']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
+                "/OnlineResource[@type='simple'][@href='htp://localhost:8080/geoserver?service=WMS&request=GetLegendGraphic&" +
+                "format=image/png&width=50&height=100&layer=testAdv&style=style2']"));
         
         EasyMock.verify(tld, servReq, response, servInfo);
     }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -17,21 +17,10 @@
  */
 package org.geowebcache.service.wmts;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendInfoBuilder;
 import org.geowebcache.config.meta.ServiceContact;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.config.meta.ServiceProvider;
@@ -51,6 +40,21 @@ import org.geowebcache.mime.MimeType;
 import org.geowebcache.stats.RuntimeStats;
 import org.geowebcache.util.ServletUtils;
 import org.geowebcache.util.URLMangler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WMTSGetCapabilities {
     
@@ -491,19 +495,40 @@ public class WMTSGetCapabilities {
         	return;
         }
      }
-     
+
+    /**
+     * Helper method that get layer legends info by merging deprecated
+     * legends info objects with the new ones.
+     */
+     private Map<String, LegendInfo> getLegendsInfo(TileLayer layer) {
+         Map<String, LegendInfo> legendsInfo = new HashMap<>();
+         for (Map.Entry<String, TileLayer.LegendInfo> entry : layer.getLegendsInfo().entrySet()) {
+             // convert deprecated model to new model
+             legendsInfo.put(entry.getKey(), new LegendInfoBuilder()
+                     .withWidth(entry.getValue().width)
+                     .withHeight(entry.getValue().height)
+                     .withFormat(entry.getValue().format)
+                     .withCompleteUrl(entry.getValue().legendUrl)
+                     .withStyleName(entry.getKey())
+                     .build());
+         }
+         // add the new legend info model objects
+         legendsInfo.putAll(layer.getLayerLegendsInfo());
+         return legendsInfo;
+    }
+
      private void layerStyles(XMLBuilder xml, TileLayer layer, List<ParameterFilter> filters) throws IOException {
          String defStyle = layer.getStyles();
-         Map<String, TileLayer.LegendInfo> legendsInfo = layer.getLegendsInfo();
+         Map<String, LegendInfo> legendsInfo = getLegendsInfo(layer);
          if(filters == null) {
              xml.indentElement("Style");
              xml.attribute("isDefault", "true");
              if(defStyle == null) {
-                 xml.simpleElement("ows:Identifier", "", true);
+                 xml.simpleElement("ows:Identifier", "", true); 
              } else {
                  xml.simpleElement("ows:Identifier", TileLayer.encodeDimensionValue(defStyle), true);
              }
-             encodeStyleLegenGraphic(xml, legendsInfo.get(defStyle));
+             encodeStyleLegendGraphic(xml, legendsInfo.get(defStyle));
              xml.endElement("Style");
          } else {
              ParameterFilter stylesFilter = null;
@@ -535,7 +560,7 @@ public class WMTSGetCapabilities {
                          xml.attribute("isDefault", "true");
                      }
                      xml.simpleElement("ows:Identifier", TileLayer.encodeDimensionValue(value), true);
-                     encodeStyleLegenGraphic(xml, legendsInfo.get(value));
+                     encodeStyleLegendGraphic(xml, legendsInfo.get(value));
                      xml.endElement();
                  }
              } else {
@@ -544,25 +569,41 @@ public class WMTSGetCapabilities {
                 xml.attribute("isDefault", "true");
                 xml.simpleElement("ows:Identifier", "", true);
                 if (defStyle != null) {
-                    encodeStyleLegenGraphic(xml, legendsInfo.get(defStyle));
+                    encodeStyleLegendGraphic(xml, legendsInfo.get(defStyle));
                 }
                 xml.endElement();
              }
          }
      }
 
-    private void encodeStyleLegenGraphic(XMLBuilder xml, TileLayer.LegendInfo legendInfo) throws IOException {
+    /**
+     * XML encodes the provided legend information. If the provided information legend is NULL
+     * nothing is done.
+     */
+    private void encodeStyleLegendGraphic(XMLBuilder xml, LegendInfo legendInfo) throws IOException {
         if (legendInfo == null) {
+            // nothing to do
             return;
         }
         xml.indentElement("LegendURL");
-        xml.attribute("width", String.valueOf(legendInfo.width));
-        xml.attribute("height", String.valueOf(legendInfo.height));
-        if (legendInfo.format != null) {
-            xml.attribute("format", legendInfo.format);
+        // validate mandatory attributes
+        checkNotNull(legendInfo.getFormat(), "Legend format is mandatory in WMTS.");
+        checkNotNull(legendInfo.getLegendUrl(), "Legend URL is mandatory in WMTS.");
+        // add mandatory attributes
+        xml.attribute("format", legendInfo.getFormat());
+        xml.attribute("xlink:href", legendInfo.getLegendUrl());
+        // add optional attributes
+        if (legendInfo.getWidth() != null) {
+            xml.attribute("width", String.valueOf(legendInfo.getWidth()));
         }
-        if(legendInfo.legendUrl != null) {
-            xml.attribute("xlink:href", legendInfo.legendUrl);
+        if (legendInfo.getHeight() != null) {
+            xml.attribute("height", String.valueOf(legendInfo.getHeight()));
+        }
+        if (legendInfo.getMinScale() != null) {
+            xml.attribute("minScaleDenominator", String.valueOf(legendInfo.getMinScale()));
+        }
+        if (legendInfo.getMaxScale() != null) {
+            xml.attribute("maxScaleDenominator", String.valueOf(legendInfo.getMaxScale()));
         }
         xml.endElement("LegendURL");
     }

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -36,6 +36,8 @@ import org.custommonkey.xmlunit.Validator;
 import org.geowebcache.GeoWebCacheDispatcher;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.XMLGridSubset;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendInfoBuilder;
 import org.geowebcache.config.meta.ServiceContact;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.config.meta.ServiceProvider;
@@ -167,15 +169,25 @@ public class WMTSServiceTest extends TestCase {
             styles.setKey("STYLES");
             styles.setValues(Arrays.asList("style-a", "style-b"));
             when(tileLayer.getParameterFilters()).thenReturn(Collections.singletonList(styles));
-
+            // add legend info for style-a
+            TileLayer.LegendInfo legendInfo1 = TileLayer.createLegendInfo();
+            legendInfo1.id = "styla-a-legend";
+            legendInfo1.width = 250;
+            legendInfo1.height = 500;
+            legendInfo1.format = "image/jpeg";
+            legendInfo1.legendUrl = "https://some-url?some-parameter=value1&another-parameter=value2";
+            when(tileLayer.getLegendsInfo()).thenReturn(Collections.singletonMap("style-a", legendInfo1));
             // add legend info for style-b
-            TileLayer.LegendInfo legendInfo = TileLayer.createLegendInfo();
-            legendInfo.id = "styla-a-legend";
-            legendInfo.width = 125;
-            legendInfo.height = 130;
-            legendInfo.format = "image/png";
-            legendInfo.legendUrl = "https://some-url?some-parameter=value&another-parameter=value";
-            when(tileLayer.getLegendsInfo()).thenReturn(Collections.singletonMap("style-b", legendInfo));
+            LegendInfo legendInfo2 = new LegendInfoBuilder()
+                    .withStyleName("styla-b-legend")
+                    .withWidth(125)
+                    .withHeight(130)
+                    .withFormat("image/png")
+                    .withCompleteUrl("https://some-url?some-parameter=value3&another-parameter=value4")
+                    .withMinScale(5000D)
+                    .withMaxScale(10000D)
+                    .build();
+            when(tileLayer.getLayerLegendsInfo()).thenReturn(Collections.singletonMap("style-b", legendInfo2));
 
             // add some layer metadata
             MetadataURL metadataURL = new MetadataURL("some-type", "some-format", new URL("http://localhost:8080/some-url"));
@@ -219,10 +231,13 @@ public class WMTSServiceTest extends TestCase {
         assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer[ows:Identifier='mockLayer'])", doc));
         assertEquals("2", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:Style/ows:Identifier)", doc));
         assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:Style[ows:Identifier='style-a'])", doc));
+        // checking that style-a has the correct legend url
+        assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:Style[ows:Identifier='style-a']/wmts:LegendURL" +
+                "[@width='250'][@height='500'][@format='image/jpeg'][@xlink:href='https://some-url?some-parameter=value1&another-parameter=value2'])", doc));
         // checking that style-b has the correct legend url
         assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:Style[ows:Identifier='style-b']/wmts:LegendURL" +
-                "[@width='125'][@height='130'][@format='image/png']" +
-                "[@xlink:href='https://some-url?some-parameter=value&another-parameter=value'])", doc));
+                "[@width='125'][@height='130'][@format='image/png'][@minScaleDenominator='5000.0'][@maxScaleDenominator='10000.0']" +
+                "[@xlink:href='https://some-url?some-parameter=value3&another-parameter=value4'])", doc));
         // checking that the layer has an associated metadata URL
         assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:MetadataURL[@type='some-type'][wmts:Format='some-format'])", doc));
         assertEquals("1", xpath.evaluate("count(//wmts:Contents/wmts:Layer/wmts:MetadataURL[@type='some-type']" +


### PR DESCRIPTION
This PR extend GWC to allow the configuration of styles legends information. Check the following issue and mailing list discussion for more details:

- **associated issue**: https://github.com/GeoWebCache/geowebcache/issues/444
- **mailing list discussion**: https://sourceforge.net/p/geowebcache/mailman/message/35501601

Previous ``LegendInfo`` class was deprecated. New tests cases were added when needed and existing ones extended if needed. Documentation was also extended.
