### PR TITLE
Parameter reverse mapping and truncation.  Fixes  #170, #359, #479

### DIFF
--- a/documentation/en/user/source/rest/masstruncate.rst
+++ b/documentation/en/user/source/rest/masstruncate.rst
@@ -84,7 +84,7 @@ Sample request to truncate all cached tiles for the ``topp:states`` layer using 
 
 .. code-block:: xml 
 
- curl -v -u geowebOST -H "Content-type: text/xml" -d "<truncateLayer><layerName>topp:states</layerName></truncateLayer>"  "http://localhost:8080/geowebcache/rest/masstruncate"
+ curl -v -u geowebcache:secured -X POST -H "Content-type: text/xml" -d "<truncateLayer><layerName>topp:states</layerName></truncateLayer>"  "http://localhost:8080/geowebcache/rest/masstruncate"
 
 Sample response:
 
@@ -110,3 +110,51 @@ Sample response:
  * Connection #0 to host localhost left intact
  * Closing connection #0
  * About to connect() to localhost port 8080 (#0)
+
+Truncate extent across parameters and formats
++++++++++++++++++++++++++++++++++++++++++++++
+
+This will issue truncate jobs within the extent <-100, 40, -99, 41> for each parameter set and format in the ``EPSG:432g`` gridset of layer ``points``.
+
+.. code-block:: xml 
+
+ <truncateExtent>
+   <layerName>points</layerName>
+   <gridSetId>EPSG:4326</gridSetId>
+   <bounds>
+     <coords>
+       <double>-100</double>
+       <double>40</double>
+       <double>-99</double>
+       <double>41</double>
+     </coords>
+   </bounds>
+ </truncateExtent>
+
+Purge orphan parameters from a layer
+++++++++++++++++++++++++++++++++++++
+
+Checks the layer ``points`` for cached tiles that are not accessible to its current parameter filters and truncates them.
+
+.. code-block:: xml 
+
+ <truncateOrphans>
+   <layerName>points</layerName>
+ </truncateOrphans>
+
+Truncate parameter set
+++++++++++++++++++++++++++++++++++++
+
+Checks the layer ``points`` for cached tiles that are not accessible to its current parameter filters and truncates them.  Depending on the Blob Store used, this may be considerably faster than using a regular truncate job.
+
+.. code-block:: xml 
+
+ <truncateParameters>
+   <layerName>points</layerName>
+   <parameters>
+     <entry>
+       <string>STYLES</string>
+       <string>point</string>
+     </entry>
+   </parameters>
+ </truncateParameters>

--- a/documentation/en/user/source/rest/masstruncate.rst
+++ b/documentation/en/user/source/rest/masstruncate.rst
@@ -145,7 +145,7 @@ Checks the layer ``points`` for cached tiles that are not accessible to its curr
 Truncate parameter set
 ++++++++++++++++++++++++++++++++++++
 
-Checks the layer ``points`` for cached tiles that are not accessible to its current parameter filters and truncates them.  Depending on the Blob Store used, this may be considerably faster than using a regular truncate job.
+Checks the layer ``points`` for cached tiles that are not accessible to its current parameter filters and truncates them.  Depending on the Blob Store used, this may be considerably faster than using a regular truncate job.  The File System blob store in particular can use directory deletes which are usually much faster than having GeoWebCache traverse all the tile files to delete them individually.  Depending on the OS/File System a traverse may be done, but it will usually be significantly faster than an application can manage.
 
 .. code-block:: xml 
 

--- a/geowebcache/core/src/main/java/org/geowebcache/UncheckedGeoWebCacheException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/UncheckedGeoWebCacheException.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache;
 
 import java.util.Objects;

--- a/geowebcache/core/src/main/java/org/geowebcache/UncheckedGeoWebCacheException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/UncheckedGeoWebCacheException.java
@@ -1,0 +1,19 @@
+package org.geowebcache;
+
+import java.util.Objects;
+
+public class UncheckedGeoWebCacheException extends RuntimeException {
+    
+    /** serialVersionUID */
+    private static final long serialVersionUID = -7981050129260733945L;
+
+    public UncheckedGeoWebCacheException(GeoWebCacheException cause) {
+        super(cause);
+        Objects.requireNonNull(cause);
+    }
+    
+    @Override
+    public synchronized GeoWebCacheException getCause() {
+        return (GeoWebCacheException) super.getCause();
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreConfig.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreConfig.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
+import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.BlobStoreListener;
 import org.geowebcache.storage.StorageException;
 import org.geowebcache.storage.blobstore.file.FileBlobStore;
@@ -87,7 +88,7 @@ public class FileBlobStoreConfig extends BlobStoreConfig {
     }
 
     @Override
-    public FileBlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider) throws StorageException {
+    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider) throws StorageException {
         checkState(getId() != null, "id not set");
         checkState(isEnabled(),
                 "Can't call FileBlobStoreConfig.createInstance() is blob store is not enabled");

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -18,6 +18,8 @@ package org.geowebcache.filter.parameters;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
+
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -26,6 +28,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 /**
@@ -165,5 +168,24 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         if(defaultValue==null) defaultValue ="";
         return this;
     }
-
+    
+    /**
+     * Is the given value exactly a value that could be produced by the filter.
+     * @param value
+     * @return
+     * @throws ParameterException
+     */
+    public boolean isFilteredValue(final String value) {
+        if(Objects.equal(value, this.getDefaultValue())) {
+            return true;
+        }
+        if(Optional.ofNullable(this.getLegalValues()).map(values->values.contains(value)).orElse(false)) {
+            return true;
+        }
+        try {
+            return Objects.equal(value, this.apply(value));
+        } catch (ParameterException ex) {
+            return false;
+        }
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
@@ -1,0 +1,115 @@
+package org.geowebcache.filter.parameters;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.geowebcache.storage.blobstore.file.FilePathGenerator;
+
+public class ParametersUtils {
+    
+    /**
+     * 
+     * This is not safe to parse as it does not do escaping.  It is used for the parameters ID hash
+     * to maintain compatibility with old caches.  For any other uses, {@link getKVP} is preferred.
+     * 
+     * @param parameters
+     * @return
+     */
+    public static String getLegacyParametersKvp(Map<String, String> parameters) {
+        StringBuilder sb = new StringBuilder();
+        SortedMap<String, String> sorted = new TreeMap<String, String>(parameters);
+        for (Map.Entry<String, String> e : sorted.entrySet()) {
+            if(sb.length() == 0) {
+                sb.append("?");
+            } else {
+                sb.append("&");
+            }
+            sb.append(e.getKey()).append('=').append(e.getValue());
+        }
+        String paramtersKvp = sb.toString();
+        return paramtersKvp;
+    }
+    
+    private static String encUTF8(String s) {
+        try {
+            // This would be much nicer if URLEncoder.encode took a charset object instead of a string
+            return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Standard encoding UTF-8 is missing");
+        }
+    }
+    
+    private static String decUTF8(String s) {
+        try {
+            // This would be much nicer if URLDecoder.decode took a charset object instead of a string
+            return URLDecoder.decode(s, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Standard encoding UTF-8 is missing");
+        }
+    }
+    
+    /**
+     * Create a comparator that compares the results of a function applied to both its arguments.
+     * @param derivation A function taking a T and returning a Comparable
+     * @return A comparator that compares the result of derivation applied to both arguments.
+     */
+    static <T, U extends Comparable<U>> Comparator<T> derivedComparator(Function<T, U> derivation) {
+        return (t1,t2)->derivation.apply(t1).compareTo(derivation.apply(t2));
+    }
+    
+    /**
+     * Turns the parameter list into a sorted KVP string
+     * 
+     * @param parameters
+     * @return
+     */
+    public static String getKvp(Map<String, String> parameters) {
+        return parameters.entrySet().stream()
+            .sorted(derivedComparator(Entry::getKey))
+            .map(e->String.join("=", encUTF8(e.getKey()), encUTF8(e.getValue())))
+            .collect(Collectors.joining("&"));
+    }
+    
+    /**
+     * Turns the a sorted KVP string into a parameter map.
+     * 
+     * This should only be used for parsing strings created by {@link getSafeParametersKvp} not for 
+     * parsing raw query strings
+     * 
+     * @param parameters
+     * @return
+     */
+    public static Map<String, String> getMap(String kvp) {
+        return Arrays.stream(kvp.split("&"))
+            .filter(((Predicate<String>)String::isEmpty).negate())
+            .map(pair->pair.split("=", 2))
+            .collect(Collectors.toMap(p->decUTF8(p[0]), p->decUTF8(p[1])));
+    }
+    
+    
+    /**
+     * Returns the parameters identifier for the given parameters map
+     * @param parameters
+     * @return
+     */
+    public static String getId(Map<String, String> parameters) {
+        if(parameters == null || parameters.size() == 0) {
+            return null;
+        }
+        String parametersKvp = getLegacyParametersKvp(parameters);
+        return FilePathGenerator.buildKey(parametersKvp);
+    }
+    
+    
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
@@ -31,14 +31,15 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.geowebcache.storage.blobstore.file.FilePathGenerator;
+import org.apache.commons.codec.digest.DigestUtils;
 
 public class ParametersUtils {
     
     /**
      * 
-     * This is not safe to parse as it does not do escaping.  It is used for the parameters ID hash
-     * to maintain compatibility with old caches.  For any other uses, {@link getKVP} is preferred.
+     * This should be treated as an opaque Identifier and should not be parsed, it is used to 
+     * to maintain compatibility with old caches.  For any other uses, {@link getKVP} is preferred
+     * as it uses safe escaping of values.
      * 
      * @param parameters
      * @return
@@ -125,7 +126,11 @@ public class ParametersUtils {
             return null;
         }
         String parametersKvp = getLegacyParametersKvp(parameters);
-        return FilePathGenerator.buildKey(parametersKvp);
+        return ParametersUtils.buildKey(parametersKvp);
+    }
+
+    public static String buildKey(String parametersKvp) {
+        return DigestUtils.sha1Hex(parametersKvp);
     }
     
     

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.filter.parameters;
 
 import java.io.UnsupportedEncodingException;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.seed;
 
+import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.Configuration;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
@@ -19,5 +20,5 @@ public interface MassTruncateRequest {
      * @return {@literal true} if successful, {@literal false} otherwise
      * @throws StorageException
      */
-    public boolean doTruncate(StorageBroker sb, Configuration config) throws StorageException;
+    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException, GeoWebCacheException;
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
@@ -1,7 +1,6 @@
 package org.geowebcache.seed;
 
 import org.geowebcache.GeoWebCacheException;
-import org.geowebcache.config.Configuration;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
@@ -20,5 +20,5 @@ public interface MassTruncateRequest {
      * @return {@literal true} if successful, {@literal false} otherwise
      * @throws StorageException
      */
-    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException, GeoWebCacheException;
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder) throws StorageException, GeoWebCacheException;
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.UncheckedGeoWebCacheException;
-import org.geowebcache.config.Configuration;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
@@ -33,7 +32,6 @@ import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 
 import com.google.common.base.Optional;
-import com.sun.media.imageio.stream.StreamSegment;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -69,11 +67,13 @@ public class TruncateBboxRequest implements MassTruncateRequest {
                                 Stream.of((Map<String,String>)null)) // Add null for the default parameters
                 .flatMap(params->allFormats.stream()
                     .map(format->
-                            new SeedRequest(layerName, bounds, gridSetId, 1, minZ, maxZ, format.getMimeType(), GWCTask.TYPE.TRUNCATE, params)))
+                        // Create seed request for each combination of params and format
+                        new SeedRequest(layerName, bounds, gridSetId, 1, minZ, maxZ, 
+                                format.getMimeType(), GWCTask.TYPE.TRUNCATE, params)))
                 .map(request->{
                     try {
                         breeder.seed(layerName, request);
-                        return 1;
+                        return 1; 
                     } catch (GeoWebCacheException e) {
                         throw new UncheckedGeoWebCacheException(e);
                     }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
@@ -1,0 +1,72 @@
+package org.geowebcache.seed;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.UncheckedGeoWebCacheException;
+import org.geowebcache.config.Configuration;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.StorageException;
+
+import com.google.common.base.Optional;
+import com.sun.media.imageio.stream.StreamSegment;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Truncate the tiles within a bounding box for a layer across all parameters and formats
+ * @author smithkm
+ *
+ */
+@XStreamAlias("truncateExtent")
+public class TruncateBboxRequest implements MassTruncateRequest {
+    String layerName;
+    
+    private BoundingBox bounds;
+    
+    private String gridSetId;
+    
+    public TruncateBboxRequest(String layerName, BoundingBox bounds, String gridSetId) {
+        super();
+        this.layerName = layerName;
+        this.bounds = bounds;
+        this.gridSetId = gridSetId;
+    }
+
+    @Override
+    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException, GeoWebCacheException {
+        final Set<Map<String,String>> allParams = sb.getCachedParameters(layerName);
+        final TileLayer tileLayer = config.getTileLayer(layerName);
+        final Collection<MimeType> allFormats = tileLayer.getMimeTypes();
+        final GridSubset subSet = tileLayer.getGridSubset(gridSetId);
+        final int minZ = Optional.fromNullable(subSet.getMinCachedZoom()).or(subSet.getZoomStart());
+        final int maxZ = Optional.fromNullable(subSet.getMaxCachedZoom()).or(subSet.getZoomStop());
+        try {
+            int taskCount = Stream.concat(allParams.stream(), 
+                                Stream.of((Map<String,String>)null)) // Add null for the default parameters
+                .flatMap(params->allFormats.stream()
+                    .map(format->
+                            new SeedRequest(layerName, bounds, gridSetId, 1, minZ, maxZ, format.getMimeType(), GWCTask.TYPE.TRUNCATE, params)))
+                .map(request->{
+                    try {
+                        breeder.seed(layerName, request);
+                        return 1;
+                    } catch (GeoWebCacheException e) {
+                        throw new UncheckedGeoWebCacheException(e);
+                    }
+                })
+                .reduce((x,y)->x+y)
+                .orElse(0);
+            return taskCount>0;
+        } catch (UncheckedGeoWebCacheException e) {
+            throw e.getCause();
+        }
+    }
+
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.seed;
 
 import java.util.Collection;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateBboxRequest.java
@@ -57,9 +57,9 @@ public class TruncateBboxRequest implements MassTruncateRequest {
     }
 
     @Override
-    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException, GeoWebCacheException {
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder) throws StorageException, GeoWebCacheException {
         final Set<Map<String,String>> allParams = sb.getCachedParameters(layerName);
-        final TileLayer tileLayer = config.getTileLayer(layerName);
+        final TileLayer tileLayer = breeder.findTileLayer(layerName);
         final Collection<MimeType> allFormats = tileLayer.getMimeTypes();
         final GridSubset subSet = tileLayer.getGridSubset(gridSetId);
         final int minZ = Optional.fromNullable(subSet.getMinCachedZoom()).or(subSet.getZoomStart());

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
@@ -1,6 +1,5 @@
 package org.geowebcache.seed;
 
-import org.geowebcache.config.Configuration;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
@@ -16,7 +16,7 @@ public class TruncateLayerRequest implements MassTruncateRequest {
 
     String layerName;
 
-    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder) throws StorageException {
         return sb.delete(layerName);
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateLayerRequest.java
@@ -16,7 +16,7 @@ public class TruncateLayerRequest implements MassTruncateRequest {
 
     String layerName;
 
-    public boolean doTruncate(StorageBroker sb, Configuration config) throws StorageException {
+    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
         return sb.delete(layerName);
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
@@ -17,24 +17,20 @@
 
 package org.geowebcache.seed;
 
-import java.util.Map;
-
-import org.geowebcache.config.Configuration;
+import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.NamedMapConverter;
 
 @XStreamAlias("truncateOrphans")
 public class TruncateOrphansRequest implements MassTruncateRequest {
     String layerName;
     
     @Override
-    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
-        final TileLayer layer = config.getTileLayer(layerName);
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder) throws GeoWebCacheException, StorageException {
+        final TileLayer layer = breeder.findTileLayer(layerName);
         return sb.purgeOrphans(layer);
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.seed;
 
 import java.util.Map;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
@@ -1,0 +1,24 @@
+package org.geowebcache.seed;
+
+import java.util.Map;
+
+import org.geowebcache.config.Configuration;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.StorageException;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.NamedMapConverter;
+
+@XStreamAlias("truncateOrphans")
+public class TruncateOrphansRequest implements MassTruncateRequest {
+    String layerName;
+    
+    @Override
+    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
+        final TileLayer layer = config.getTileLayer(layerName);
+        return sb.purgeOrphans(layer);
+    }
+
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateOrphansRequest.java
@@ -24,6 +24,12 @@ import org.geowebcache.storage.StorageException;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+/**
+ * Truncate atiles from a cache where we know they are no longer reachable, or we can't know that 
+ * due to missing metadata.
+ * @author smithkm
+ *
+ */
 @XStreamAlias("truncateOrphans")
 public class TruncateOrphansRequest implements MassTruncateRequest {
     String layerName;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
@@ -24,6 +24,11 @@ import org.geowebcache.storage.StorageException;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+/**
+ * Truncate a particular combination of parameter values from a layer 
+ * @author smithkm
+ *
+ */
 @XStreamAlias("truncateParameters")
 public class TruncateParametersRequest implements MassTruncateRequest {
     String layerName;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.seed;
 
 import java.util.Map;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
@@ -1,0 +1,24 @@
+package org.geowebcache.seed;
+
+import java.util.Map;
+
+import org.geowebcache.config.Configuration;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.StorageException;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.NamedMapConverter;
+
+@XStreamAlias("truncateParameters")
+public class TruncateParametersRequest implements MassTruncateRequest {
+    String layerName;
+    
+    Map<String, String> parameters;
+    
+    @Override
+    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
+        return sb.deleteByParameters(layerName, parameters);
+    }
+
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateParametersRequest.java
@@ -19,13 +19,10 @@ package org.geowebcache.seed;
 
 import java.util.Map;
 
-import org.geowebcache.config.Configuration;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.NamedMapConverter;
 
 @XStreamAlias("truncateParameters")
 public class TruncateParametersRequest implements MassTruncateRequest {
@@ -34,7 +31,7 @@ public class TruncateParametersRequest implements MassTruncateRequest {
     Map<String, String> parameters;
     
     @Override
-    public boolean doTruncate(StorageBroker sb, Configuration config, TileBreeder breeder) throws StorageException {
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder) throws StorageException {
         return sb.deleteByParameters(layerName, parameters);
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListener.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListener.java
@@ -98,5 +98,11 @@ public interface BlobStoreListener {
      * been deleted in the blob store's backend storage.
      */
     void gridSubsetDeleted(String layerName, String gridSetId);
+    
+    /**
+     * Notifies that all tiles for the parameter ID {@code parametersId} of layer {@code layerName} 
+     * have been deleted in the blob store's backend storage.
+     */
+    void parametersDeleted(String layerName, String parametersId);
 
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListenerList.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListenerList.java
@@ -27,31 +27,31 @@ public final class BlobStoreListenerList {
     }
 
     public void sendLayerDeleted(String layerName) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.layerDeleted(layerName);
         });
     }
 
     public void sendLayerRenamed(String oldLayerName, String newLayerName) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.layerRenamed(oldLayerName, newLayerName);
         });
     }
 
     public void sendGridSubsetDeleted(String layerName, String gridSetId) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.gridSubsetDeleted(layerName, gridSetId);
         });
     }
     public void sendParametersDeleted(String layerName, String parametersId) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.parametersDeleted(layerName, parametersId);
         });
     }
 
     public void sendTileDeleted(String layerName, String gridSetId, String blobFormat,
             String parametersId, long x, long y, int z, long length) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.tileDeleted(layerName, gridSetId, blobFormat, parametersId, x, y,
                     z, length);
         });
@@ -72,7 +72,7 @@ public final class BlobStoreListenerList {
     
     public void sendTileStored(String layerName, String gridSetId, String blobFormat,
             String parametersId, long x, long y, int z, long length) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.tileStored(layerName, gridSetId, blobFormat, parametersId, x, y,
                     z, length);
         });
@@ -93,7 +93,7 @@ public final class BlobStoreListenerList {
     
     public void sendTileUpdated(String layerName, String gridSetId, String blobFormat,
             String parametersId, long x, long y, int z, long blobSize, long oldSize) {
-        listeners.stream().forEachOrdered(listener->{
+        listeners.forEach(listener->{
             listener.tileUpdated(layerName, gridSetId, blobFormat, parametersId, x, y,
                     z, blobSize, oldSize);
         });

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListenerList.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreListenerList.java
@@ -27,88 +27,88 @@ public final class BlobStoreListenerList {
     }
 
     public void sendLayerDeleted(String layerName) {
-        if (listeners.size() > 0) {
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).layerDeleted(layerName);
-            }
-        }
+        listeners.stream().forEachOrdered(listener->{
+            listener.layerDeleted(layerName);
+        });
     }
 
     public void sendLayerRenamed(String oldLayerName, String newLayerName) {
-        if (listeners.size() > 0) {
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).layerRenamed(oldLayerName, newLayerName);
-            }
-        }
+        listeners.stream().forEachOrdered(listener->{
+            listener.layerRenamed(oldLayerName, newLayerName);
+        });
     }
 
     public void sendGridSubsetDeleted(String layerName, String gridSetId) {
-        if (listeners.size() > 0) {
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).gridSubsetDeleted(layerName, gridSetId);
-            }
-        }
+        listeners.stream().forEachOrdered(listener->{
+            listener.gridSubsetDeleted(layerName, gridSetId);
+        });
+    }
+    public void sendParametersDeleted(String layerName, String parametersId) {
+        listeners.stream().forEachOrdered(listener->{
+            listener.parametersDeleted(layerName, parametersId);
+        });
     }
 
     public void sendTileDeleted(String layerName, String gridSetId, String blobFormat,
             String parametersId, long x, long y, int z, long length) {
-
-        if (listeners.size() > 0) {
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).tileDeleted(layerName, gridSetId, blobFormat, parametersId, x, y,
-                        z, length);
-            }
-        }
+        listeners.stream().forEachOrdered(listener->{
+            listener.tileDeleted(layerName, gridSetId, blobFormat, parametersId, x, y,
+                    z, length);
+        });
     }
-
+    
     public void sendTileDeleted(final TileObject stObj) {
-        if (listeners.size() > 0) {
-
-            final long[] xyz = stObj.getXYZ();
-            final String layerName = stObj.getLayerName();
-            final String gridSetId = stObj.getGridSetId();
-            final String blobFormat = stObj.getBlobFormat();
-            final String paramsId = stObj.getParametersId();
-            final int blobSize = stObj.getBlobSize();
-
-            sendTileDeleted(layerName, gridSetId, blobFormat, paramsId, xyz[0], xyz[1],
-                    (int) xyz[2], blobSize);
-        }
+        
+        final long[] xyz = stObj.getXYZ();
+        final String layerName = stObj.getLayerName();
+        final String gridSetId = stObj.getGridSetId();
+        final String blobFormat = stObj.getBlobFormat();
+        final String paramsId = stObj.getParametersId();
+        final int blobSize = stObj.getBlobSize();
+        
+        sendTileDeleted(layerName, gridSetId, blobFormat, paramsId, xyz[0], xyz[1],
+                (int) xyz[2], blobSize);
     }
-
-    public void sendTileStored(TileObject stObj) {
-        if (listeners.size() > 0) {
-
-            final long[] xyz = stObj.getXYZ();
-            final String layerName = stObj.getLayerName();
-            final String gridSetId = stObj.getGridSetId();
-            final String blobFormat = stObj.getBlobFormat();
-            final String paramsId = stObj.getParametersId();
-            final int blobSize = stObj.getBlobSize();
-
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).tileStored(layerName, gridSetId, blobFormat, paramsId, xyz[0],
-                        xyz[1], (int) xyz[2], blobSize);
-
-            }
-        }
+    
+    public void sendTileStored(String layerName, String gridSetId, String blobFormat,
+            String parametersId, long x, long y, int z, long length) {
+        listeners.stream().forEachOrdered(listener->{
+            listener.tileStored(layerName, gridSetId, blobFormat, parametersId, x, y,
+                    z, length);
+        });
     }
-
-    public void sendTileUpdated(TileObject stObj, final long oldSize) {
-        if (listeners.size() > 0) {
-            final long[] xyz = stObj.getXYZ();
-            final String layerName = stObj.getLayerName();
-            final String gridSetId = stObj.getGridSetId();
-            final String blobFormat = stObj.getBlobFormat();
-            final String paramsId = stObj.getParametersId();
-
-            final int blobSize = stObj.getBlobSize();
-
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).tileUpdated(layerName, gridSetId, blobFormat, paramsId, xyz[0],
-                        xyz[1], (int) xyz[2], blobSize, oldSize);
-
-            }
-        }
+    
+    public void sendTileStored(final TileObject stObj) {
+        
+        final long[] xyz = stObj.getXYZ();
+        final String layerName = stObj.getLayerName();
+        final String gridSetId = stObj.getGridSetId();
+        final String blobFormat = stObj.getBlobFormat();
+        final String paramsId = stObj.getParametersId();
+        final int blobSize = stObj.getBlobSize();
+        
+        sendTileStored(layerName, gridSetId, blobFormat, paramsId, xyz[0], xyz[1],
+                (int) xyz[2], blobSize);
+    }
+    
+    public void sendTileUpdated(String layerName, String gridSetId, String blobFormat,
+            String parametersId, long x, long y, int z, long blobSize, long oldSize) {
+        listeners.stream().forEachOrdered(listener->{
+            listener.tileUpdated(layerName, gridSetId, blobFormat, parametersId, x, y,
+                    z, blobSize, oldSize);
+        });
+    }
+    
+    public void sendTileUpdated(final TileObject stObj, final long oldSize) {
+        
+        final long[] xyz = stObj.getXYZ();
+        final String layerName = stObj.getLayerName();
+        final String gridSetId = stObj.getGridSetId();
+        final String blobFormat = stObj.getBlobFormat();
+        final String paramsId = stObj.getParametersId();
+        final int blobSize = stObj.getBlobSize();
+        
+        sendTileUpdated(layerName, gridSetId, blobFormat, paramsId, xyz[0], xyz[1],
+                (int) xyz[2], blobSize, oldSize);
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
@@ -19,9 +19,12 @@ package org.geowebcache.storage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -120,62 +123,32 @@ public class CompositeBlobStore implements BlobStore {
 
     @Override
     public boolean delete(String layerName) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            return store(layerName).delete(layerName);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunctionUnsafe(()->store(layerName).delete(layerName));
     }
 
     @Override
     public boolean deleteByGridsetId(String layerName, String gridSetId) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            return store(layerName).deleteByGridsetId(layerName, gridSetId);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunctionUnsafe(()->store(layerName).deleteByGridsetId(layerName, gridSetId));
     }
 
     @Override
     public boolean delete(TileObject obj) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            return store(obj.getLayerName()).delete(obj);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunctionUnsafe(()->store(obj.getLayerName()).delete(obj));
     }
 
     @Override
     public boolean delete(TileRange obj) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            return store(obj.getLayerName()).delete(obj);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunctionUnsafe(()->store(obj.getLayerName()).delete(obj));
     }
 
     @Override
     public boolean get(TileObject obj) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            return store(obj.getLayerName()).get(obj);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunctionUnsafe(()->store(obj.getLayerName()).get(obj));
     }
 
     @Override
     public void put(TileObject obj) throws StorageException {
-        configLock.readLock().lock();
-        try {
-            store(obj.getLayerName()).put(obj);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        readActionUnsafe(()->store(obj.getLayerName()).put(obj));
     }
 
     @Deprecated
@@ -207,18 +180,15 @@ public class CompositeBlobStore implements BlobStore {
      */
     @Override
     public void addListener(BlobStoreListener listener) {
-        configLock.readLock().lock();
-        try {
+        readAction(()->{
             this.listeners.addListener(listener);// save it for later in case setBlobStores is
-                                                 // called
+            // called
             for (LiveStore bs : blobStores.values()) {
                 if (bs.config.isEnabled()) {
                     bs.liveInstance.addListener(listener);
                 }
             }
-        } finally {
-            configLock.readLock().unlock();
-        }
+        });
     }
 
     /**
@@ -226,27 +196,19 @@ public class CompositeBlobStore implements BlobStore {
      */
     @Override
     public boolean removeListener(BlobStoreListener listener) {
-        configLock.readLock().lock();
-
-        boolean removed = false;
-        try {
+        return readFunction(()->{
             this.listeners.removeListener(listener);
-            for (LiveStore bs : blobStores.values()) {
-                if (bs.config.isEnabled()) {
-                    removed |= bs.liveInstance.removeListener(listener);
-                }
-            }
-        } finally {
-            configLock.readLock().unlock();
-        }
-        return removed;
-
+            return blobStores.values().stream()
+                .filter(bs->bs.config.isEnabled())
+                .map(bs->bs.liveInstance.removeListener(listener))
+                .collect(Collectors.reducing((x,y)->x||y)) // Don't use anyMatch or findFirst as we don't want it to shortcut
+                .orElse(false);
+        });
     }
-
+    
     @Override
     public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
-        configLock.readLock().lock();
-        try {
+        return readFunctionUnsafe(()->{
             for (LiveStore bs : blobStores.values()) {
                 BlobStoreConfig config = bs.config;
                 if (config.isEnabled()) {
@@ -255,49 +217,26 @@ public class CompositeBlobStore implements BlobStore {
                     }
                 }
             }
-        } finally {
-            configLock.readLock().unlock();
-        }
-        return false;
+            return false;
+        });
     }
 
     @Override
     public String getLayerMetadata(String layerName, String key) {
-        configLock.readLock().lock();
-        try {
-            return store(layerName).getLayerMetadata(layerName, key);
-        } catch (StorageException e) {
-            throw Throwables.propagate(e);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        return readFunction(()->store(layerName).getLayerMetadata(layerName, key));
     }
 
     @Override
     public void putLayerMetadata(String layerName, String key, String value) {
-        configLock.readLock().lock();
-        try {
+        readAction(()->{
             store(layerName).putLayerMetadata(layerName, key, value);
-        } catch (StorageException e) {
-            throw Throwables.propagate(e);
-        } finally {
-            configLock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public boolean layerExists(String layerName) {
-        configLock.readLock().lock();
-        try {
-            for (LiveStore bs : blobStores.values()) {
-                if (bs.config.isEnabled() && bs.liveInstance.layerExists(layerName)) {
-                    return true;
-                }
-            }
-        } finally {
-            configLock.readLock().unlock();
-        }
-        return false;
+        return readFunction(()->blobStores.values().stream()
+                .anyMatch(bs->bs.config.isEnabled() && bs.liveInstance.layerExists(layerName)));
     }
 
     private BlobStore store(String layerId) throws StorageException {
@@ -432,7 +371,7 @@ public class CompositeBlobStore implements BlobStore {
                 config.setEnabled(true);
                 config.setDefault(true);
                 config.setBaseDirectory(defaultStorageFinder.getDefaultPath());
-                FileBlobStore store;
+                BlobStore store;
                 store = new FileBlobStore(config.getBaseDirectory());
 
                 stores.put(CompositeBlobStore.DEFAULT_STORE_DEFAULT_ID,
@@ -446,4 +385,58 @@ public class CompositeBlobStore implements BlobStore {
         return new ConcurrentHashMap<>(stores);
     }
 
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        return readFunctionUnsafe(()->store(layerName).deleteByParametersId(layerName, parametersId));
+    }
+    
+    @Override
+    public Set<Map<String, String>> getParameters(String layerName) {
+        return readFunction(()-> store(layerName).getParameters(layerName));
+    }
+    
+    @Override
+    public Set<String> getParameterIds(String layerName) {
+        return readFunction(()->store(layerName).getParameterIds(layerName));
+    }
+
+    @FunctionalInterface
+    static interface StorageAction {
+        void run() throws StorageException;
+    }
+    @FunctionalInterface
+    static interface StorageAccessor<T> {
+        T get() throws StorageException;
+    }
+    
+    
+    protected <T> T readFunctionUnsafe(StorageAccessor<T> function) throws StorageException {
+        configLock.readLock().lock();
+        try {
+            return function.get();
+        } finally {
+            configLock.readLock().unlock();
+        }
+    }
+    
+    protected <T> T readFunction(StorageAccessor<T> function) {
+        try {
+            return readFunctionUnsafe(function);
+        } catch (StorageException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+    
+    protected void readActionUnsafe(StorageAction function) throws StorageException {
+        readFunctionUnsafe((StorageAccessor<Void>)()->{function.run();return null;});
+    }
+    
+    protected void readAction(StorageAction function) {
+        readFunction((StorageAccessor<Void>)()->{function.run();return null;});
+    }
+
+    public Map<String,Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        return readFunction(()->store(layerName).getParametersMapping(layerName));
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageBroker.java
@@ -17,9 +17,13 @@
  */
 package org.geowebcache.storage;
 
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayer;
 
 /**
  * Handles cacheable objects (tiles, wfs responses) both in terms of data storage and metadata
@@ -56,6 +60,21 @@ public class DefaultStorageBroker implements StorageBroker {
     public boolean deleteByGridSetId(final String layerName, final String gridSetId)
             throws StorageException {
         return blobStore.deleteByGridsetId(layerName, gridSetId);
+    }
+    
+    public boolean deleteByParameters(final String layerName, final Map<String, String> parameters)
+            throws StorageException {
+        return blobStore.deleteByParameters(layerName, parameters);
+    }
+    
+    public boolean deleteByParametersId(final String layerName, String parametersId)
+            throws StorageException {
+        return blobStore.deleteByParametersId(layerName, parametersId);
+    }
+    @Override
+    public boolean purgeOrphans(final TileLayer layer)
+            throws StorageException {
+        return blobStore.purgeOrphans(layer);
     }
 
     public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
@@ -111,5 +130,15 @@ public class DefaultStorageBroker implements StorageBroker {
      */
     public BlobStore getBlobStore(){
         return blobStore;
+    }
+    
+    @Override
+    public Set<String> getCachedParameterIds(String layerName) throws StorageException {
+        return this.blobStore.getParameterIds(layerName);
+    }
+    
+    @Override
+    public Set<Map<String, String>> getCachedParameters(String layerName) throws StorageException  {
+        return this.blobStore.getParameters(layerName);
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.mime.MimeException;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.blobstore.file.FilePathGenerator;
@@ -161,7 +162,7 @@ public class MetastoreRemover {
 
             private String getParamsSha1(String paramsKvp) {
                 Map<String, String> params = toMap(paramsKvp);
-                return FilePathGenerator.getParametersId(params);
+                return ParametersUtils.getId(params);
             }
 
             /**

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
@@ -76,17 +76,42 @@ public interface StorageBroker {
      * Destroy method for Spring
      */
     public abstract void destroy();
-
+    
+    /**
+     * Get an entry from the layer's metadata map
+     * @param layerName
+     * @param key
+     * @return
+     */
     public abstract String getLayerMetadata(String layerName, String key);
 
+    /**
+     * Add/set an entry in the layer's metadata map
+     * @param layerName
+     * @param key
+     * @return
+     */
     public abstract void putLayerMetadata(String layerName, String key, String value);
 
     public abstract boolean getTransient(TileObject tile);
 
     public abstract void putTransient(TileObject tile);
     
+    /**
+     * Get the set of parameter IDs cached for the given layer
+     * @param layerName
+     * @param key
+     * @return
+     */
     public abstract Set<String> getCachedParameterIds(String layerName) throws StorageException;
     
+    /**
+     * Get the set of map cached for the given layer, for those parameterizations that have reverse
+     * mappings (Created by GWC 1.12 or later)
+     * @param layerName
+     * @param key
+     * @return
+     */
     public abstract Set<Map<String, String>> getCachedParameters(String layerName) throws StorageException;
 
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
@@ -1,5 +1,10 @@
 package org.geowebcache.storage;
 
+import java.util.Map;
+import java.util.Set;
+
+import org.geowebcache.layer.TileLayer;
+
 /**
  * Abstracts and manages the storing of cachable objects and their metadata.
  */
@@ -24,6 +29,26 @@ public interface StorageBroker {
      * @throws StorageException
      */
     public abstract boolean deleteByGridSetId(String layerName, String gridSetId)
+            throws StorageException;
+    
+    /**
+     * Completely deletes the cache for a layer/parameters combination
+     * 
+     * @param layerName
+     * @param removedGridset
+     * @throws StorageException
+     */
+    public abstract boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException;
+    
+    /**
+     * Completely deletes the cache for a layer/parameters combination
+     * 
+     * @param layerName
+     * @param removedGridset
+     * @throws StorageException
+     */
+    public abstract boolean deleteByParameters(String layerName, Map<String,String> parameters)
             throws StorageException;
 
     public abstract boolean rename(String oldLayerName, String newLayerName)
@@ -59,5 +84,19 @@ public interface StorageBroker {
     public abstract boolean getTransient(TileObject tile);
 
     public abstract void putTransient(TileObject tile);
+    
+    public abstract Set<String> getCachedParameterIds(String layerName) throws StorageException;
+    
+    public abstract Set<Map<String, String>> getCachedParameters(String layerName) throws StorageException;
+
+    /**
+     * Purge parameter caches from the layer if they are unreachable by its current parameter 
+     * filters.  The store may purge gridsets and formats as well.  These additional purges may be 
+     * guaranteed in future.
+     * @param layer
+     * @return
+     * @throws StorageException
+     */
+    public abstract boolean purgeOrphans(final TileLayer layer) throws StorageException;
 
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
@@ -30,6 +30,9 @@ import org.geowebcache.io.Resource;
  * object with the data.
  */
 public class TileObject extends StorageObject implements Serializable{
+    /** serialVersionUID */
+    private static final long serialVersionUID = 2204318806003485110L;
+
     public static final String TYPE = "tile";
 
     Resource blob;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
@@ -100,10 +100,18 @@ public class TileObject extends StorageObject implements Serializable{
         return this.gridSetId;
     }
 
+    /**
+     * May be null until this object has been handled by the BlobStore
+     * @return
+     */
     public String getParametersId() {
         return this.parameters_id;
     }
 
+    /**
+     * The BlobStore is responsible for setting this based on the value of {@link getParameters} 
+     * @param parameters_id
+     */
     public void setParametersId(String parameters_id) {
         this.parameters_id = parameters_id;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
@@ -20,8 +20,8 @@ package org.geowebcache.storage;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.mime.MimeType;
-import org.geowebcache.storage.blobstore.file.FilePathGenerator;
 import org.geowebcache.util.ServletUtils;
 
 /**
@@ -57,7 +57,7 @@ public class TileRange {
 
     public TileRange(String layerName, String gridSetId, int zoomStart, int zoomStop,
             long[][] rangeBounds, MimeType mimeType, Map<String, String> parameters) {
-        this(layerName, gridSetId, zoomStart, zoomStop, rangeBounds, mimeType, parameters, FilePathGenerator.getParametersId(parameters));
+        this(layerName, gridSetId, zoomStart, zoomStop, rangeBounds, mimeType, parameters, ParametersUtils.getId(parameters));
     }
 
     public TileRange(String layerName, String gridSetId, int zoomStart, int zoomStop,

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -36,8 +36,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +49,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.commons.collections.BidiMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -73,7 +70,6 @@ import org.geowebcache.util.FileUtils;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.BiMap;
 
 /**
  * See BlobStore interface description for details
@@ -767,14 +763,12 @@ public class FileBlobStore implements BlobStore {
             return false;
         }
         
-        File[] parameterCaches = layerPath.listFiles(new FileFilter() {
-            public boolean accept(File pathname) {
-                if (!pathname.isDirectory()) {
-                    return false;
-                }
-                String dirName = pathname.getName();
-                return dirName.endsWith(parametersId);
+        File[] parameterCaches = layerPath.listFiles((pathname)-> {
+            if (!pathname.isDirectory()) {
+                return false;
             }
+            String dirName = pathname.getName();
+            return dirName.endsWith(parametersId);
         });
         
         for (File parameterCache : parameterCaches) {
@@ -786,20 +780,6 @@ public class FileBlobStore implements BlobStore {
         
         return true;
     }
-    
-    class CarrierException extends RuntimeException {
-        public CarrierException(Throwable cause) {
-            super(cause);
-        }
-        
-        @SuppressWarnings("unchecked")
-        public <T extends Throwable> void propagate(Class<T> klass) throws T {
-            if(klass.isAssignableFrom(this.getCause().getClass())) {
-                throw (T)this.getCause();
-            }
-        }
-    }
-    
     
     private Stream<Path> layerChildStream(final String layerName, DirectoryStream.Filter<Path> filter) throws IOException {
         final File layerPath = getLayerPath(layerName);

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -28,19 +28,35 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.channels.FileChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
+import org.apache.commons.collections.BidiMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.io.FileResource;
 import org.geowebcache.io.Resource;
 import org.geowebcache.mime.MimeException;
@@ -57,6 +73,7 @@ import org.geowebcache.util.FileUtils;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
 
 /**
  * See BlobStore interface description for details
@@ -443,6 +460,7 @@ public class FileBlobStore implements BlobStore {
         final long oldSize = fh.length();
         final boolean existed = oldSize > 0;
         writeFile(fh, stObj, existed);
+        
         // mark the last modification as the tile creation time if set, otherwise
         // we'll leave it to the writing time
         if (stObj.getCreated() > 0) {
@@ -535,6 +553,8 @@ public class FileBlobStore implements BlobStore {
                     temp = null;
                 }
             }
+            
+            persistParameterMap(stObj);
         } finally {
 
             if (temp != null) {
@@ -545,7 +565,16 @@ public class FileBlobStore implements BlobStore {
         }
 
     }
-
+    
+    protected void persistParameterMap(TileObject stObj) {
+        if(Objects.nonNull(stObj.getParametersId())) {
+            putLayerMetadata(
+                    stObj.getLayerName(), 
+                    "parameters."+stObj.getParametersId(), 
+                    ParametersUtils.getKvp(stObj.getParameters()));
+        }
+    }
+    
     public void clear() throws StorageException {
         throw new StorageException("Not implemented yet!");
     }
@@ -602,11 +631,16 @@ public class FileBlobStore implements BlobStore {
         Properties metadata = getLayerMetadata(layerName);
         String value = metadata.getProperty(key);
         if (value != null) {
-            try {
-                value = URLDecoder.decode(value, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            value = urlDecUtf8(value);
+        }
+        return value;
+    }
+
+    private static String urlDecUtf8(String value) {
+        try {
+            value = URLDecoder.decode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
         }
         return value;
     }
@@ -638,7 +672,7 @@ public class FileBlobStore implements BlobStore {
                 }
                 out = new FileOutputStream(metadataFile);
             } catch (FileNotFoundException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException(e);
             }
             try {
                 String comments = "auto generated file, do not edit by hand";
@@ -654,7 +688,7 @@ public class FileBlobStore implements BlobStore {
             }
         }
     }
-
+    
     private Properties getLayerMetadata(final String layerName) {
         final File metadataFile = getMetadataFile(layerName);
         Properties properties = new Properties();
@@ -665,7 +699,7 @@ public class FileBlobStore implements BlobStore {
                 try {
                     in = new FileInputStream(metadataFile);
                 } catch (FileNotFoundException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 try {
                     properties.load(in);
@@ -723,4 +757,102 @@ public class FileBlobStore implements BlobStore {
         return actuallyUsedStorage;
     }
 
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        
+        final File layerPath = getLayerPath(layerName);
+        if (!layerPath.exists() || !layerPath.canWrite()) {
+            log.info(layerPath + " does not exist or is not writable");
+            return false;
+        }
+        
+        File[] parameterCaches = layerPath.listFiles(new FileFilter() {
+            public boolean accept(File pathname) {
+                if (!pathname.isDirectory()) {
+                    return false;
+                }
+                String dirName = pathname.getName();
+                return dirName.endsWith(parametersId);
+            }
+        });
+        
+        for (File parameterCache : parameterCaches) {
+            String target = filteredLayerName(layerName) + "_" + parameterCache.getName();
+            stageDelete(parameterCache, target);
+        }
+        
+        listeners.sendParametersDeleted(layerName, parametersId);
+        
+        return true;
+    }
+    
+    class CarrierException extends RuntimeException {
+        public CarrierException(Throwable cause) {
+            super(cause);
+        }
+        
+        @SuppressWarnings("unchecked")
+        public <T extends Throwable> void propagate(Class<T> klass) throws T {
+            if(klass.isAssignableFrom(this.getCause().getClass())) {
+                throw (T)this.getCause();
+            }
+        }
+    }
+    
+    
+    private Stream<Path> layerChildStream(final String layerName, DirectoryStream.Filter<Path> filter) throws IOException {
+        final File layerPath = getLayerPath(layerName);
+        if (!layerPath.exists()) {
+            return Stream.of();
+        }
+        final DirectoryStream<Path> layerDirStream = Files.newDirectoryStream(layerPath.toPath(), filter);
+        return StreamSupport.stream(layerDirStream.spliterator(),false)
+             .onClose(()->{
+                 try {
+                    layerDirStream.close();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+             });
+    }
+    
+    public boolean isParameterIdCached(String layerName, final String parametersId) throws IOException {
+        try (Stream<Path> layerChildStream = layerChildStream(layerName, (p)-> Files.isDirectory(p) && p.endsWith(parametersId))) {
+            return layerChildStream
+                .findAny()
+                .isPresent();
+        }
+    }
+    
+    @Override
+    public Map<String,Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        Properties p = getLayerMetadata(layerName);
+        return getParameterIds(layerName).stream()
+            .collect(Collectors.toMap(
+                (id)->id,
+                (id)->{
+                    String kvp =p.getProperty("parameters."+id);
+                    if (Objects.isNull(kvp)) { 
+                        return Optional.empty();
+                    }
+                    kvp=urlDecUtf8(kvp);
+                    return Optional.of(ParametersUtils.getMap(kvp));
+                }));
+    }
+    
+    static final int paramIdLength = ParametersUtils.getId(Collections.singletonMap("A", "B")).length();
+    
+    @Override
+    public Set<String> getParameterIds(String layerName) {
+        try (Stream<Path> layerChildStream = layerChildStream(layerName, (p)-> Files.isDirectory(p))) {
+            return layerChildStream
+                .map(p->p.getFileName().toString())
+                .map(s->s.substring(s.lastIndexOf('_')+1))
+                .filter(s->s.length()==paramIdLength) // Zoom level should never be the same length so this should be safe
+                .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
@@ -22,7 +22,6 @@ import static org.geowebcache.storage.blobstore.file.FilePathUtils.*;
 import java.io.File;
 import java.util.Map;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.filter.parameters.ParametersUtils;
@@ -31,6 +30,7 @@ import org.geowebcache.storage.TileObject;
 
 public class FilePathGenerator {
     
+    @SuppressWarnings("unused")
     private static Log log = LogFactory.getLog(FilePathGenerator.class);
     
     String cacheRoot;
@@ -106,8 +106,11 @@ public class FilePathGenerator {
         return tileFile;
     }
 
+    /**
+     * @deprecated Use {@link ParametersUtils#buildKey(String)} instead
+     */
     public static String buildKey(String parametersKvp) {
-        return DigestUtils.shaHex(parametersKvp);
+        return ParametersUtils.buildKey(parametersKvp);
     }
     
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathGenerator.java
@@ -21,12 +21,11 @@ import static org.geowebcache.storage.blobstore.file.FilePathUtils.*;
 
 import java.io.File;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.TileObject;
 
@@ -84,7 +83,7 @@ public class FilePathGenerator {
         String parametersId = tile.getParametersId();
         Map<String, String> parameters = tile.getParameters();
         if (parametersId == null && parameters != null && !parameters.isEmpty()) {
-            parametersId = getParametersId(parameters);
+            parametersId = ParametersUtils.getId(parameters);
             tile.setParametersId(parametersId);
         }
         if(parametersId != null) {
@@ -107,7 +106,7 @@ public class FilePathGenerator {
         return tileFile;
     }
 
-    protected static String buildKey(String parametersKvp) {
+    public static String buildKey(String parametersKvp) {
         return DigestUtils.shaHex(parametersKvp);
     }
     
@@ -115,13 +114,10 @@ public class FilePathGenerator {
      * Returns the parameters identifier for the given parameters map
      * @param parameters
      * @return
+     * @deprecated Use {@link ParametersUtils#getParametersId(Map<String, String>)} instead
      */
     public static String getParametersId(Map<String, String> parameters) {
-        if(parameters == null || parameters.size() == 0) {
-            return null;
-        }
-        String parametersKvp = getParametersKvp(parameters);
-        return buildKey(parametersKvp);
+        return ParametersUtils.getId(parameters);
     }
 
     /**
@@ -129,20 +125,10 @@ public class FilePathGenerator {
      * 
      * @param parameters
      * @return
+     * @deprecated Use {@link ParametersUtils#getParametersKvp(Map<String, String>)} instead
      */
     public static String getParametersKvp(Map<String, String> parameters) {
-        StringBuilder sb = new StringBuilder();
-        SortedMap<String, String> sorted = new TreeMap<String, String>(parameters);
-        for (Map.Entry<String, String> e : sorted.entrySet()) {
-            if(sb.length() == 0) {
-                sb.append("?");
-            } else {
-                sb.append("&");
-            }
-            sb.append(e.getKey()).append('=').append(e.getValue());
-        }
-        String paramtersKvp = sb.toString();
-        return paramtersKvp;
+        return ParametersUtils.getLegacyParametersKvp(parameters);
     }
 
 

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
@@ -17,6 +17,10 @@ package org.geowebcache.storage.blobstore.memory;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -693,6 +697,17 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
                 return store.deleteByGridsetId((String) objs[0], (String) objs[1]);
             }
         },
+        DELETE_PARAMS_ID {
+            @Override
+            public boolean executeOperation(BlobStore store, Object... objs)
+                    throws StorageException {
+                if (objs == null || objs.length < 2 || !(objs[0] instanceof String)
+                        || !(objs[1] instanceof String)) {
+                    return false;
+                }
+                return store.deleteByParametersId((String) objs[0], (String) objs[1]);
+            }
+        },
         DELETE_LAYER {
             @Override
             public boolean executeOperation(BlobStore store, Object... objs)
@@ -741,5 +756,52 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
          */
         public abstract boolean executeOperation(BlobStore store, Object... objs)
                 throws StorageException;
+    }
+
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        componentsStateLock.lock();
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Removing Layer: " + layerName);
+            }
+            // Remove the layer from the cacheProvider
+            cacheProvider.removeLayer(layerName);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Scheduling Parameters: " + parametersId + " removal for Layer: " + layerName);
+            }
+            // Remove selected parameters
+            executorService.submit(new BlobStoreTask(store, BlobStoreAction.DELETE_PARAMS_ID,
+                    layerName, parametersId));
+            return true;
+        } finally {
+            componentsStateLock.unlock();
+        }
+    }
+
+    @Override
+    public Set<Map<String, String>> getParameters(String layerName) throws StorageException {
+        componentsStateLock.lock();
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Getting parameters for Layer: " + layerName);
+            }
+            return store.getParameters(layerName);
+        } finally {
+            componentsStateLock.unlock();
+        }
+    }
+
+    public Map<String,Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        componentsStateLock.lock();
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Getting parameters for Layer: " + layerName);
+            }
+            return store.getParametersMapping(layerName);
+        } finally {
+            componentsStateLock.unlock();
+        }
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
@@ -17,7 +17,6 @@ package org.geowebcache.storage.blobstore.memory;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/NullBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/NullBlobStore.java
@@ -15,10 +15,15 @@
 package org.geowebcache.storage.blobstore.memory;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -107,7 +112,11 @@ public class NullBlobStore implements BlobStore {
         Properties properties = metadataMap.get(layerName);
         if (properties != null) {
             // Returns the property associated to the key
-            return (String) properties.get(key);
+            try {
+                return URLDecoder.decode((String) properties.get(key), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                LOGGER.error(e.getLocalizedMessage(), e);
+            }
         }
         return null;
     }
@@ -135,8 +144,23 @@ public class NullBlobStore implements BlobStore {
         }
     }
     
-	@Override
-	public boolean layerExists(String layerName) {
-		return false;
-	}
+    @Override
+    public boolean layerExists(String layerName) {
+        return false;
+    }
+    
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        return true;
+    }
+
+    @Override
+    public Set<Map<String, String>> getParameters(String layerName) {
+        return Collections.emptySet();
+    }
+
+    public Map<String,Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        return Collections.emptyMap();
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/NullBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/NullBlobStore.java
@@ -17,7 +17,6 @@ package org.geowebcache.storage.blobstore.memory;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.blobstore.file;
 
 import org.geowebcache.storage.AbstractBlobStoreTest;

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
@@ -1,0 +1,17 @@
+package org.geowebcache.blobstore.file;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.geowebcache.storage.blobstore.file.FileBlobStore;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlobStore> {
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        this.store = new FileBlobStore(temp.getRoot().getAbsolutePath());
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FilePathGeneratorTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FilePathGeneratorTest.java
@@ -44,7 +44,7 @@ public class FilePathGeneratorTest extends TestCase {
         Map<String, String> params = new HashMap<String, String>();
         params.put("style", "population");
         TileObject tile = TileObject.createCompleteTileObject("states", new long[] {0, 0, 0}, "EPSG:2163", "png", params, null);
-        String sha1 = DigestUtils.shaHex("?style=population");
+        String sha1 = DigestUtils.sha1Hex("?style=population");
         
 
         // first time, this will also create the path on disk
@@ -64,7 +64,7 @@ public class FilePathGeneratorTest extends TestCase {
         params.put("style", "polygon");
         tile = TileObject.createCompleteTileObject("states", new long[] {0, 0, 0}, "EPSG:2163", "png", params, null);
         path = generator.tilePath(tile, ImageMime.png);
-        sha1 = DigestUtils.shaHex("?style=polygon");
+        sha1 = DigestUtils.sha1Hex("?style=polygon");
         testParameterId(path, sha1, "?style=polygon");
     }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/FileBlobStoreConfigTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/FileBlobStoreConfigTest.java
@@ -23,8 +23,8 @@ import java.io.File;
 
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
+import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.StorageException;
-import org.geowebcache.storage.blobstore.file.FileBlobStore;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,7 +97,7 @@ public class FileBlobStoreConfigTest {
         File root = tmp.getRoot();
         Preconditions.checkState(root.exists() && root.isDirectory());
         config.setBaseDirectory(root.getAbsolutePath());
-        FileBlobStore store = config.createInstance(layers, lockProvider);
+        BlobStore store = config.createInstance(layers, lockProvider);
         assertNotNull(store);
     }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.geowebcache.filter.parameters;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyString;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
@@ -1,0 +1,147 @@
+package org.geowebcache.filter.parameters;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public class ParametersUtilsTest {
+    
+    @Test
+    public void testEmptyToKVP() {
+        String result = ParametersUtils.getKvp(Collections.emptyMap());
+        assertThat(result, isEmptyString());
+    }
+    
+    @Test
+    public void testEmptyToMap() {
+        Map<String, String> result = ParametersUtils.getMap("");
+        assertThat(result.entrySet(), empty());
+    }
+    
+    @Test
+    public void testSingletonToKVP() {
+        String result = ParametersUtils.getKvp(Collections.singletonMap("test", "blah"));
+        assertThat(result, Matchers.equalTo("test=blah"));
+    }
+    
+    @Test
+    public void testSingletonToMap() {
+        Map<String, String> result = ParametersUtils.getMap("test=blah");
+        assertThat(result, hasEntries(
+                entry(equalTo("test"), equalTo("blah"))
+                ));
+    }
+    
+    @Test
+    public void testTwoToKVP() {
+        Map<String,String> parameters = new TreeMap<>();
+        parameters.put("test1", "blah1");
+        parameters.put("test2", "blah2");
+        String result = ParametersUtils.getKvp(parameters);
+        assertThat(result, Matchers.equalTo("test1=blah1&test2=blah2"));
+    }
+    
+    @Test
+    public void testTwoToMap() {
+        Map<String, String> result = ParametersUtils.getMap("test1=blah1&test2=blah2");
+        assertThat(result, hasEntries(
+                entry(equalTo("test1"), equalTo("blah1")),
+                entry(equalTo("test2"), equalTo("blah2"))
+                ));
+    }
+    
+    @Test
+    public void testTwoToKVPSorting() {
+        Map<String,String> parameters = new TreeMap<>((s1,s2)->-s1.compareTo(s2)); // Intentionally make the tree use reverse alphabetical order
+        parameters.put("test1", "blah1");
+        parameters.put("test2", "blah2");
+        String result = ParametersUtils.getKvp(parameters);
+        assertThat(result, Matchers.equalTo("test1=blah1&test2=blah2")); // Should be normal alphabetical order
+    }
+    
+    @Test
+    public void testEqualsToKVP() {
+        Map<String,String> parameters = new TreeMap<>();
+        parameters.put("=test1", "=blah1");
+        parameters.put("te=st2", "bl=ah2");
+        parameters.put("test3=", "blah3=");
+        String result = ParametersUtils.getKvp(parameters);
+        assertThat(result, Matchers.equalTo("%3Dtest1=%3Dblah1&te%3Dst2=bl%3Dah2&test3%3D=blah3%3D"));
+    }
+    
+    @Test
+    public void testEqualsToMap() {
+        Map<String, String> result = ParametersUtils.getMap("%3Dtest1=%3Dblah1&te%3Dst2=bl%3Dah2&test3%3D=blah3%3D");
+        assertThat(result, hasEntries(
+                entry(equalTo("=test1"), equalTo("=blah1")),
+                entry(equalTo("te=st2"), equalTo("bl=ah2")),
+                entry(equalTo("test3="), equalTo("blah3="))
+                ));
+    }
+    
+    @Test
+    public void testAmpToKVP() {
+        Map<String,String> parameters = new TreeMap<>();
+        parameters.put("&test1", "&blah1");
+        parameters.put("te&st2", "bl&ah2");
+        parameters.put("test3&", "blah3&");
+        String result = ParametersUtils.getKvp(parameters);
+        assertThat(result, Matchers.equalTo("%26test1=%26blah1&te%26st2=bl%26ah2&test3%26=blah3%26"));
+    }
+    
+    @Test
+    public void testAmpToMap() {
+        Map<String, String> result = ParametersUtils.getMap("%26test1=%26blah1&te%26st2=bl%26ah2&test3%26=blah3%26");
+        assertThat(result, hasEntries(
+                entry(equalTo("&test1"), equalTo("&blah1")),
+                entry(equalTo("te&st2"), equalTo("bl&ah2")),
+                entry(equalTo("test3&"), equalTo("blah3&"))
+                ));
+    }
+   
+    @SafeVarargs
+    static <K, V> Matcher<Map<K, V>> hasEntries(Matcher<Entry<K, V>>...entryMatchers) {
+        final Matcher<? super Set<Entry<K, V>>> entrySetMatcher = Matchers.containsInAnyOrder(entryMatchers);
+        return new BaseMatcher<Map<K, V>>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof Map) {
+                    return entrySetMatcher.matches(((Map<?,?>) item).entrySet());
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("has entries ");
+                description.appendDescriptionOf(entrySetMatcher);
+            }
+            
+        };
+    }
+    
+    static <K, V> Matcher<Entry<K, V>> entry(Matcher<K> key, Matcher<V> value) {
+        return Matchers.allOf(
+            Matchers.instanceOf(Entry.class),
+            Matchers.hasProperty("key", key),
+            Matchers.hasProperty("value", value));
+    }
+   
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -1,0 +1,126 @@
+package org.geowebcache.seed;
+
+import static org.easymock.EasyMock.anyBoolean;
+import static org.easymock.EasyMock.anyInt;
+import static org.easymock.EasyMock.eq;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.geowebcache.config.Configuration;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.mime.ImageMime;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.TileRange;
+import org.junit.Test;
+
+import org.hamcrest.Matchers;
+import org.hamcrest.integration.EasyMock2Adapter;
+
+import org.easymock.classextension.EasyMock;
+
+public class TruncateBboxRequestTest {
+
+    @SuppressWarnings("unchecked")
+    protected SeedRequest seedRequest(String layerName, String gridSet, String format, int minZ, int maxZ, BoundingBox bounds, Map<String,String> parameters) {
+        EasyMock2Adapter.adapt(allOf(
+                hasProperty("layerName", equalTo(layerName)),
+                hasProperty("gridSetId", equalTo(gridSet)),
+                hasProperty("mimeFormat", equalTo(format)),
+                hasProperty("zoomStart", equalTo(minZ)),
+                hasProperty("zoomStop", equalTo(maxZ)),
+                hasProperty("parameters", equalTo(parameters)),
+                hasProperty("filterUpdate", any(Boolean.class)),
+                hasProperty("threadCount", any(Integer.class)),
+                hasProperty("bounds", equalTo(bounds)),
+                hasProperty("type", any(GWCTask.TYPE.class))
+                ));
+        return null;
+    }
+    @Test
+    public void testDoTruncate() throws Exception{
+        String layerName = "testLayer";
+        BoundingBox bbox = new BoundingBox(0.0, 1.0, 10.0, 11.0);
+        String gridSetName = "testGridset";
+        TruncateBboxRequest request = new TruncateBboxRequest(layerName, bbox, gridSetName);
+        
+        StorageBroker broker = EasyMock.createMock("broker", StorageBroker.class);
+        Configuration config = EasyMock.createMock("config", Configuration.class);
+        TileBreeder breeder = EasyMock.createMock("breeder", TileBreeder.class);
+        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        GridSubset subSet = EasyMock.createMock("subSet", GridSubset.class);
+        
+        GWCTask pngStyle1 = EasyMock.createMock("pngStyle1", GWCTask.class);
+        GWCTask pngStyle2 = EasyMock.createMock("pngStyle2", GWCTask.class);
+        GWCTask jpegStyle1 = EasyMock.createMock("jpegStyle1", GWCTask.class);
+        GWCTask jpegStyle2 = EasyMock.createMock("jpegStyle2", GWCTask.class);
+        
+        final Set<Map<String, String>> allParams = new HashSet<>();
+        allParams.add(Collections.singletonMap("STYLES", "style1"));
+        allParams.add(Collections.singletonMap("STYLES", "style2"));
+        
+        final long[][] coverages = new long[][]{{0,0,0,0,0},{0,0,1,1,1},{0,0,4,4,2}};
+        final int[] metaFactors = new int[]{1,1};
+        
+        // Boring mocks
+        EasyMock.expect(broker.getCachedParameters(layerName))
+            .andStubReturn(Collections.unmodifiableSet(allParams));
+        EasyMock.expect(config.getTileLayer(layerName))
+            .andStubReturn(layer);
+        EasyMock.expect(layer.getGridSubset(gridSetName))
+            .andStubReturn(subSet);
+        EasyMock.expect(layer.getMimeTypes())
+            .andStubReturn(Arrays.asList(ImageMime.png, ImageMime.jpeg));
+        EasyMock.expect(subSet.getMinCachedZoom())
+            .andStubReturn(0);
+        EasyMock.expect(subSet.getMaxCachedZoom())
+            .andStubReturn(2);
+        EasyMock.expect(subSet.getZoomStart())
+            .andStubReturn(0);
+        EasyMock.expect(subSet.getZoomStop())
+            .andStubReturn(2);
+        EasyMock.expect(subSet.getCoverageIntersections(bbox))
+            .andStubReturn(coverages);
+        EasyMock.expect(layer.getMetaTilingFactors())
+            .andStubReturn(metaFactors);
+        EasyMock.expect(subSet.expandToMetaFactors(coverages, metaFactors))
+            .andStubReturn(coverages);
+        EasyMock.expect(layer.getName())
+            .andStubReturn(layerName);
+        
+        // Should issue seed requests for Cartesian product of formats and parameters
+        
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/png", 0, 2, bbox, Collections.singletonMap("STYLES", "style1")));
+        EasyMock.expectLastCall().once();
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/png", 0, 2, bbox, Collections.singletonMap("STYLES", "style2")));
+        EasyMock.expectLastCall().once();
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/png", 0, 2, bbox, null)); // Default
+        EasyMock.expectLastCall().once();
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/jpeg", 0, 2, bbox, Collections.singletonMap("STYLES", "style1")));
+        EasyMock.expectLastCall().once();
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/jpeg", 0, 2, bbox, Collections.singletonMap("STYLES", "style2")));
+        EasyMock.expectLastCall().once();
+        breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/jpeg", 0, 2, bbox, null)); // Default
+        EasyMock.expectLastCall().once();
+        
+        EasyMock.replay(broker, config, breeder, layer, subSet);
+        EasyMock.replay(pngStyle1, pngStyle2, jpegStyle1, jpegStyle2);
+        
+        assertThat(request.doTruncate(broker, config, breeder), is(true));
+        
+        EasyMock.verify(broker, config, breeder, layer, subSet);
+    }
+
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -17,8 +17,6 @@
 
 package org.geowebcache.seed;
 
-import static org.easymock.EasyMock.anyBoolean;
-import static org.easymock.EasyMock.anyInt;
 import static org.easymock.EasyMock.eq;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.any;
@@ -33,17 +31,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.geowebcache.config.Configuration;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.mime.ImageMime;
-import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.StorageBroker;
-import org.geowebcache.storage.TileRange;
 import org.junit.Test;
 
-import org.hamcrest.Matchers;
 import org.hamcrest.integration.EasyMock2Adapter;
 
 import org.easymock.classextension.EasyMock;

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.seed;
 
 import static org.easymock.EasyMock.anyBoolean;

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -74,7 +74,6 @@ public class TruncateBboxRequestTest {
         TruncateBboxRequest request = new TruncateBboxRequest(layerName, bbox, gridSetName);
         
         StorageBroker broker = EasyMock.createMock("broker", StorageBroker.class);
-        Configuration config = EasyMock.createMock("config", Configuration.class);
         TileBreeder breeder = EasyMock.createMock("breeder", TileBreeder.class);
         TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
         GridSubset subSet = EasyMock.createMock("subSet", GridSubset.class);
@@ -94,7 +93,7 @@ public class TruncateBboxRequestTest {
         // Boring mocks
         EasyMock.expect(broker.getCachedParameters(layerName))
             .andStubReturn(Collections.unmodifiableSet(allParams));
-        EasyMock.expect(config.getTileLayer(layerName))
+        EasyMock.expect(breeder.findTileLayer(layerName))
             .andStubReturn(layer);
         EasyMock.expect(layer.getGridSubset(gridSetName))
             .andStubReturn(subSet);
@@ -132,12 +131,12 @@ public class TruncateBboxRequestTest {
         breeder.seed(eq(layerName), seedRequest(layerName, gridSetName, "image/jpeg", 0, 2, bbox, null)); // Default
         EasyMock.expectLastCall().once();
         
-        EasyMock.replay(broker, config, breeder, layer, subSet);
+        EasyMock.replay(broker, breeder, layer, subSet);
         EasyMock.replay(pngStyle1, pngStyle2, jpegStyle1, jpegStyle2);
         
-        assertThat(request.doTruncate(broker, config, breeder), is(true));
+        assertThat(request.doTruncate(broker, breeder), is(true));
         
-        EasyMock.verify(broker, config, breeder, layer, subSet);
+        EasyMock.verify(broker, breeder, layer, subSet);
     }
 
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
@@ -48,8 +48,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.hamcrest.Matchers;
-
 import org.easymock.Capture;
 import org.easymock.classextension.EasyMock;
 
@@ -456,6 +454,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
         assertThat(store.getLayerMetadata("testLayer", "testKey"), equalTo("test%Value"));
     }
     
+    @SuppressWarnings("unchecked")
     @Test
     public void testParameterList() throws Exception {
         Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
@@ -663,15 +662,8 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
         String paramID2 = ParametersUtils.getId(params2);
         final String gridset = "testGridSet";
         final String format = "image/png";
-        TileObject toCache1 = TileObject.createCompleteTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
-        TileObject toCache2 = TileObject.createCompleteTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
         BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
         store.addListener(listener);
-        
-        TileObject fromCache1_1 = TileObject.createQueryTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1);
-        TileObject fromCache2_1 = TileObject.createQueryTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2);
-        TileObject fromCache1_2 = TileObject.createQueryTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1);
-        TileObject fromCache2_2 = TileObject.createQueryTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2);
         
         if(events) {
             listener.tileStored(eq(layerName), eq(gridset), eq(format), eq(paramID1), eq(0L), eq(0L), eq(0), 

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.storage;
 
 import static org.easymock.EasyMock.anyLong;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
@@ -1,0 +1,692 @@
+package org.geowebcache.storage;
+
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.isNull;
+import static org.easymock.classextension.EasyMock.capture;
+import static org.easymock.classextension.EasyMock.eq;
+import static org.easymock.classextension.EasyMock.geq;
+import static org.geowebcache.util.FileMatchers.resource;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.describedAs;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.filter.parameters.StringParameterFilter;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.layer.TileLayer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.hamcrest.Matchers;
+
+import org.easymock.Capture;
+import org.easymock.classextension.EasyMock;
+
+/**
+ * Test to do 
+ */
+public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
+    
+    protected TestClass store;
+    
+    protected boolean events = true;
+    
+    /**
+     * Set up the test store in {@link store}.
+     */
+    @Before
+    public abstract void createTestUnit() throws Exception;
+    
+    /**
+     * Override and add tear down assertions after calling super
+     * @throws Exception
+     */
+    @After
+    public void destroyTestUnit() throws Exception {
+        // Might be null if an Assumption failed during createTestUnit
+        if(Objects.nonNull(store)) {
+            store.destroy();
+        }
+    }
+    
+    @Test
+    public void testEmpty() throws Exception {
+        TileObject fromCache = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        assertThat(store.get(fromCache), equalTo(false));
+        //assertThat(fromCache, hasProperty("status", is(Status.MISS)));
+    }
+    
+    @Test
+    public void testStoreTile() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        final long size = toCache.getBlobSize();
+        TileObject fromCache = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                geq(size) // Some stores have minimum block sizes and so have to pad this
+                );EasyMock.expectLastCall();
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache);
+        
+        EasyMock.verify(listener);
+        
+        assertThat(store.get(fromCache), is(true));
+        //assertThat(fromCache, hasProperty("status", is(Status.HIT)));
+        assertThat(fromCache, hasProperty("blobSize", is((int)size)));
+        
+        assertThat(fromCache, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testStoreTilesInMultipleLayers() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer1",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer2",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        TileObject fromCache1 = TileObject.createQueryTileObject("testLayer1", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer2", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer2", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        
+        if(events) {
+            listener.tileStored(eq("testLayer1"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), geq(size1));
+            listener.tileStored(eq("testLayer2"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), geq(size2));
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        assertThat(fromCache2_1, hasProperty("blobSize", is(0)));
+        
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        
+        assertThat(store.get(fromCache1), is(true));
+        assertThat(fromCache1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testDeleteTile() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject remove = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        TileObject fromCache = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        
+        Capture<Long> sizeCapture = new Capture<>();
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture)
+                );EasyMock.expectLastCall();
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache);
+        EasyMock.verify(listener);
+        long storedSize = 0;
+        if(events) {
+            storedSize=sizeCapture.getValue();
+        }
+        EasyMock.reset(listener);
+        if(events) {
+            listener.tileDeleted(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                eq(storedSize)
+                );EasyMock.expectLastCall();
+        }
+        EasyMock.replay(listener);
+        store.delete(remove);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache), is(false));
+        assertThat(fromCache, hasProperty("blobSize", is(0)));
+    }
+    
+    @Test
+    public void testUpdateTile() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size2 = toCache2.getBlobSize();
+        TileObject fromCache = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", null);
+        
+        Capture<Long> sizeCapture = new Capture<>();
+        if(events){
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture)
+                );EasyMock.expectLastCall();
+        }
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        EasyMock.verify(listener);
+        long storedSize = 0;
+        if(events){
+            storedSize = sizeCapture.getValue();
+        }
+        EasyMock.reset(listener);
+        if(events){
+            listener.tileUpdated(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0),
+                geq(size2),
+                eq(storedSize)
+                );EasyMock.expectLastCall();
+        }
+        EasyMock.replay(listener);
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache), is(true));
+        assertThat(fromCache, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testGridsets() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        TileObject remove = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        TileObject fromCache1_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        TileObject fromCache2_3 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        
+        Capture<Long> sizeCapture1 = new Capture<>();
+        Capture<Long> sizeCapture2 = new Capture<>();
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet1"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture1)
+                );EasyMock.expectLastCall();
+            listener.tileStored(eq("testLayer"), eq("testGridSet2"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture2)
+                );EasyMock.expectLastCall();
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        long storedSize1 = 0;
+        if(events) {
+            storedSize1 = sizeCapture1.getValue();
+        }
+        assertThat(store.get(fromCache1_1), is(true));
+        assertThat(fromCache1_1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1_1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+        EasyMock.reset(listener);
+        if(events) {
+            listener.tileDeleted(eq("testLayer"), eq("testGridSet1"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                eq(storedSize1)
+                );EasyMock.expectLastCall();
+        }
+        EasyMock.replay(listener);
+        store.delete(remove);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+        assertThat(store.get(fromCache2_3), is(true));
+        assertThat(fromCache2_3, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_3, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testDeleteGridset() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        final long size1 = toCache1.getBlobSize();
+        
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet1"), eq("image/png"), eq(null), eq(0L), eq(0L), eq(0), 
+                geq(size1)
+                );EasyMock.expectLastCall();
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        EasyMock.verify(listener);
+        EasyMock.reset(listener);
+        if(events) {
+            listener.gridSubsetDeleted(eq("testLayer"), eq("testGridSet1"));EasyMock.expectLastCall();
+        }
+        EasyMock.replay(listener);
+        assertThat(store.deleteByGridsetId("testLayer", "testGridSet1"), is(true));
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+    }
+    
+    @Test
+    public void testDeleteGridsetDoesntDeleteOthers() throws Exception {
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        
+        TileObject fromCache1_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet1", "image/png", null);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        TileObject fromCache2_3 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet2", "image/png", null);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        store.put(toCache2);
+        assertThat(store.get(fromCache1_1), is(true));
+        assertThat(fromCache1_1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1_1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+        store.deleteByGridsetId("testLayer", "testGridSet1");
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+        assertThat(store.get(fromCache2_3), is(true));
+        assertThat(fromCache2_3, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_3, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    @Test
+    public void testParameters() throws Exception {
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        
+        TileObject remove = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache1_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        TileObject fromCache2_3 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        
+        Capture<Long> sizeCapture1 = new Capture<>();
+        Capture<Long> sizeCapture2 = new Capture<>();
+        Capture<String> pidCapture1 = new Capture<>();
+        Capture<String> pidCapture2 = new Capture<>();
+        if(events){
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), capture(pidCapture1), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture1)
+                );EasyMock.expectLastCall();
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), capture(pidCapture2), eq(0L), eq(0L), eq(0), 
+                capture(sizeCapture2)
+                );EasyMock.expectLastCall();
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        long storedSize1 = 0;
+        if(events) {
+            storedSize1 = sizeCapture1.getValue();
+            // parameter id strings should be non-null and not equal to one another
+            assertThat(pidCapture1.getValue(), notNullValue());
+            assertThat(pidCapture2.getValue(), notNullValue());
+            assertThat(pidCapture2.getValue(), not(pidCapture1.getValue()));
+        }
+        
+        assertThat(store.get(fromCache1_1), is(true));
+        assertThat(fromCache1_1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1_1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+        EasyMock.reset(listener);
+        if(events) {
+            listener.tileDeleted(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(pidCapture1.getValue()), eq(0L), eq(0L), eq(0), 
+                eq(storedSize1)
+                );
+        }
+        EasyMock.replay(listener);
+        store.delete(remove);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+        assertThat(store.get(fromCache2_3), is(true));
+        assertThat(fromCache2_3, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_3, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testMetadata() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), nullValue());
+        store.putLayerMetadata("testLayer", "testKey", "testValue");
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), equalTo("testValue"));
+    }
+    
+    @Test
+    public void testMetadataWithEqualsInKey() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "test=Key"), nullValue());
+        store.putLayerMetadata("testLayer", "test=Key", "testValue");
+        assertThat(store.getLayerMetadata("testLayer", "test=Key"), equalTo("testValue"));
+    }
+    
+    @Test
+    public void testMetadataWithEqualsInValue() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), nullValue());
+        store.putLayerMetadata("testLayer", "testKey", "test=Value");
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), equalTo("test=Value"));
+    }
+    
+    @Test
+    public void testMetadataWithAmpInKey() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "test&Key"), nullValue());
+        store.putLayerMetadata("testLayer", "test&Key", "testValue");
+        assertThat(store.getLayerMetadata("testLayer", "test&Key"), equalTo("testValue"));
+    }
+    
+    @Test
+    public void testMetadataWithAmpInValue() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), nullValue());
+        store.putLayerMetadata("testLayer", "testKey", "test&Value");
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), equalTo("test&Value"));
+    }
+    
+    @Test
+    public void testMetadataWithPercentInKey() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "test%Key"), nullValue());
+        store.putLayerMetadata("testLayer", "test%Key", "testValue");
+        assertThat(store.getLayerMetadata("testLayer", "test%Key"), equalTo("testValue"));
+    }
+    
+    @Test
+    public void testMetadataWithPercentInValue() throws Exception {
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), nullValue());
+        store.putLayerMetadata("testLayer", "testKey", "test%Value");
+        assertThat(store.getLayerMetadata("testLayer", "testKey"), equalTo("test%Value"));
+    }
+    
+    @Test
+    public void testParameterList() throws Exception {
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        
+        assertThat(store.getParameters("testLayer"), empty());
+        store.put(toCache1);
+        assertThat(store.getParameters("testLayer"), containsInAnyOrder(params1));
+        store.put(toCache2);
+        assertThat(store.getParameters("testLayer"), containsInAnyOrder(params1, params2));
+    }
+    
+    @Test
+    public void testParameterIDList() throws Exception {
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        String params1Id = ParametersUtils.getId(params1);
+        String params2Id = ParametersUtils.getId(params2);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        
+        assertThat(store.getParameterIds("testLayer"), empty());
+        store.put(toCache1);
+        assertThat(store.getParameterIds("testLayer"), containsInAnyOrder(params1Id));
+        store.put(toCache2);
+        assertThat(store.getParameterIds("testLayer"), containsInAnyOrder(params1Id, params2Id));
+    }
+    
+    @Test
+    public void testEmptyParameterListIsNotNull() throws Exception {
+        assertThat(store.getParameters("testLayer"), empty());
+    }
+    
+    @Test
+    public void testDeleteByParametersId() throws Exception {
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        String paramID1 = ParametersUtils.getId(params1);
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        String paramID2 = ParametersUtils.getId(params2);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        
+        TileObject fromCache1_1 = TileObject.createQueryTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(paramID1), eq(0L), eq(0L), eq(0), 
+                geq(size1)
+                );
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(paramID2), eq(0L), eq(0L), eq(0), 
+                geq(size2)
+                );
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_1), is(true));
+        assertThat(fromCache1_1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1_1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+        EasyMock.reset(listener);
+        if(events) {
+            listener.parametersDeleted(eq("testLayer"), eq(paramID1));
+        }
+        EasyMock.replay(listener);
+        store.deleteByParametersId("testLayer", paramID1);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+    }
+    @Test
+    public void testDeleteByParametersIdDoesNotDeleteOthers() throws Exception {
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        String paramID1 = ParametersUtils.getId(params1);
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        final long size2 = toCache2.getBlobSize();
+        
+        TileObject fromCache2_3 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        
+        store.put(toCache1);
+        store.put(toCache2);
+        store.deleteByParametersId("testLayer", paramID1);
+        assertThat(store.get(fromCache2_3), is(true));
+        assertThat(fromCache2_3, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_3, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    @Test
+    public void testPurgeOrphans() throws Exception {
+        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        EasyMock.expect(layer.getName()).andStubReturn("testLayer");
+        StringParameterFilter testFilter = new StringParameterFilter();
+        testFilter.setDefaultValue("DEFAULT");
+        testFilter.setKey("testKey");
+        testFilter.setValues(Arrays.asList("testValue2"));
+        EasyMock.expect(layer.getParameterFilters()).andStubReturn(Arrays.asList(testFilter));
+        EasyMock.replay(layer);
+        
+        Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
+        String paramID1 = ParametersUtils.getId(params1);
+        Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
+        String paramID2 = ParametersUtils.getId(params2);
+        TileObject toCache1 = TileObject.createCompleteTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        final long size1 = toCache1.getBlobSize();
+        final long size2 = toCache2.getBlobSize();
+        
+        TileObject fromCache1_1 = TileObject.createQueryTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject("testLayer",  new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params1);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject("testLayer", new long[]{0L, 0L, 0L}, "testGridSet", "image/png", params2);
+        
+        if(events) {
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(paramID1), eq(0L), eq(0L), eq(0), 
+                geq(size1)
+                );
+            listener.tileStored(eq("testLayer"), eq("testGridSet"), eq("image/png"), eq(paramID2), eq(0L), eq(0L), eq(0), 
+                geq(size2)
+                );
+        }
+        
+        EasyMock.replay(listener);
+        
+        store.put(toCache1);
+        assertThat(store.get(fromCache2_1), is(false));
+        store.put(toCache2);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_1), is(true));
+        assertThat(fromCache1_1, hasProperty("blobSize", is((int)size1)));
+        assertThat(fromCache1_1, hasProperty("blob",resource(new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(store.get(fromCache2_2), is(true));
+        assertThat(fromCache2_2, hasProperty("blobSize", is((int)size2)));
+        assertThat(fromCache2_2, hasProperty("blob",resource(new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)))));
+        EasyMock.reset(listener);
+        if(events) {
+            listener.parametersDeleted(eq("testLayer"), eq(paramID1));
+        }
+        EasyMock.replay(listener);
+        store.purgeOrphans(layer);
+        EasyMock.verify(listener);
+        assertThat(store.get(fromCache1_2), is(false));
+        assertThat(fromCache1_2, hasProperty("blobSize", is(0)));
+
+    }
+    
+    protected void cacheTile(String layerName, long x, long y, int z, String gridSetId, String format, 
+            Map<String, String> parameters, String content) throws StorageException{
+        TileObject to = TileObject.createCompleteTileObject(layerName, new long[]{x,y,z}, gridSetId, format, 
+                parameters, new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)));
+        store.put(to);
+    }
+    
+    protected void assertTile(String layerName, long x, long y, int z, String gridSetId, String format, 
+            Map<String, String> parameters, String content) throws StorageException{
+        TileObject to = TileObject.createQueryTileObject(layerName, new long[]{x,y,z}, gridSetId, format, 
+                parameters);
+        assertThat(store.get(to), describedAs("get a tile", is(true)));
+        assertThat(to, hasProperty("blob",resource(new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)))));
+    }
+    
+    protected void assertNoTile(String layerName, long x, long y, int z, String gridSetId, String format, 
+            Map<String, String> parameters) throws StorageException{
+        TileObject to = TileObject.createQueryTileObject(layerName, new long[]{x,y,z}, gridSetId, format, 
+                parameters);
+        assertThat(store.get(to), describedAs("don't get a tile", is(false)));
+        assertThat(to, hasProperty("blob", nullValue()));
+        assertThat(to, hasProperty("blobSize", is(0)));
+    }
+    
+    @Test
+    public void testPurgeOrphansWithDefault() throws Exception {
+        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        final String layerName = "testLayer";
+        final String paramKey = "testKey";
+        
+        EasyMock.expect(layer.getName()).andStubReturn(layerName);
+        StringParameterFilter testFilter = new StringParameterFilter();
+        testFilter.setDefaultValue("DEFAULT");
+        testFilter.setKey(paramKey);
+        testFilter.setValues(Arrays.asList("keep1", "keep2", "keep3"));
+        EasyMock.expect(layer.getParameterFilters()).andStubReturn(Arrays.asList(testFilter));
+        EasyMock.replay(layer);
+        
+        Map<String, String> params1 = Collections.singletonMap(paramKey, "purge1");
+        String paramID1 = ParametersUtils.getId(params1);
+        Map<String, String> params2 = Collections.singletonMap(paramKey, "keep1");
+        String paramID2 = ParametersUtils.getId(params2);
+        final String gridset = "testGridSet";
+        final String format = "image/png";
+        TileObject toCache1 = TileObject.createCompleteTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1, new ByteArrayResource("1,2,4,5,6 test".getBytes(StandardCharsets.UTF_8)));
+        TileObject toCache2 = TileObject.createCompleteTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2, new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
+        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        store.addListener(listener);
+        
+        TileObject fromCache1_1 = TileObject.createQueryTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1);
+        TileObject fromCache2_1 = TileObject.createQueryTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2);
+        TileObject fromCache1_2 = TileObject.createQueryTileObject(layerName,  new long[]{0L, 0L, 0L}, gridset, format, params1);
+        TileObject fromCache2_2 = TileObject.createQueryTileObject(layerName, new long[]{0L, 0L, 0L}, gridset, format, params2);
+        
+        if(events) {
+            listener.tileStored(eq(layerName), eq(gridset), eq(format), eq(paramID1), eq(0L), eq(0L), eq(0), 
+                anyLong()
+                );
+            listener.tileStored(eq(layerName), eq(gridset), eq(format), eq(paramID2), eq(0L), eq(0L), eq(0), 
+                anyLong()
+                );
+            listener.tileStored(eq(layerName), eq(gridset), eq(format), isNull(), eq(0L), eq(0L), eq(0), 
+                anyLong()
+                );
+        }
+        
+        EasyMock.replay(listener);
+        
+        cacheTile(layerName, 0,0,0, gridset, format, params1, "purge");
+        cacheTile(layerName, 0,0,0, gridset, format, params2, "keep param");
+        cacheTile(layerName, 0,0,0, gridset, format, null, "keep default");
+        EasyMock.verify(listener);
+        assertTile(layerName, 0,0,0, gridset, format, params1, "purge");
+        assertTile(layerName, 0,0,0, gridset, format, params2, "keep param");
+        assertTile(layerName, 0,0,0, gridset, format, null, "keep default");
+        EasyMock.reset(listener);
+        if(events) {
+            listener.parametersDeleted(eq(layerName), eq(paramID1));
+        }
+        EasyMock.replay(listener);
+        store.purgeOrphans(layer);
+        EasyMock.verify(listener);
+        assertNoTile(layerName, 0,0,0, gridset, format, params1);
+        assertTile(layerName, 0,0,0, gridset, format, params2, "keep param");
+        assertTile(layerName, 0,0,0, gridset, format, null, "keep default");
+        
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/BlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/BlobStoreTest.java
@@ -38,7 +38,7 @@ public class BlobStoreTest extends TestCase {
     public static final String TEST_BLOB_DIR_NAME = "gwcTestBlobs";
 
     public void testTile() throws Exception {
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
 
         Resource bytes = new ByteArrayResource("1 2 3 4 5 6 test".getBytes());
         long[] xyz = { 1L, 2L, 3L };
@@ -66,7 +66,7 @@ public class BlobStoreTest extends TestCase {
     }
 
     public void testTileDelete() throws Exception {
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
 
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put("a", "x");
@@ -102,7 +102,7 @@ public class BlobStoreTest extends TestCase {
     }
 
     public void testTilRangeDelete() throws Exception {
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
 
         Resource bytes = new ByteArrayResource("1 2 3 4 5 6 test".getBytes());
         Map<String, String> parameters = new HashMap<String, String>();
@@ -173,7 +173,7 @@ public class BlobStoreTest extends TestCase {
     }
 
     public void testRenameLayer() throws Exception {
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
         Resource bytes = new ByteArrayResource("1 2 3 4 5 6 test".getBytes());
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put("a", "x");
@@ -217,7 +217,7 @@ public class BlobStoreTest extends TestCase {
         }
     }
 
-    public FileBlobStore setup() throws Exception {
+    public BlobStore setup() throws Exception {
         File fh = new File(StorageBrokerTest.findTempDir() + File.separator + TEST_BLOB_DIR_NAME);
 
         if (fh.exists()) {
@@ -232,7 +232,7 @@ public class BlobStoreTest extends TestCase {
     }
 
     public void testLayerMetadata() throws Exception {
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
 
         final String layerName = "TestLayer";
         final String key1 = "Test.Metadata.Property_1";

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreTest.java
@@ -108,7 +108,7 @@ public class CompositeBlobStoreTest {
 
         defaultLayer = mock(TileLayer.class);
         when(layers.getTileLayer(eq(DEFAULT_LAYER))).thenReturn(defaultLayer);
-        when(layers.getTileLayer((String) argThat(new NotEq(DEFAULT_LAYER)))).thenThrow(
+        when(layers.getTileLayer((String) argThat(new NotEq<>(DEFAULT_LAYER)))).thenThrow(
                 new GeoWebCacheException("layer not found"));
     }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreWithFilesComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreWithFilesComformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.storage;
 
 import static org.easymock.classextension.EasyMock.not;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreWithFilesComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreWithFilesComformanceTest.java
@@ -1,0 +1,69 @@
+package org.geowebcache.storage;
+
+import static org.easymock.classextension.EasyMock.not;
+import static org.easymock.EasyMock.or;
+import static org.easymock.classextension.EasyMock.createNiceMock;
+import static org.easymock.classextension.EasyMock.eq;
+import static org.easymock.classextension.EasyMock.expect;
+
+import java.util.LinkedList;
+
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.BlobStoreConfig;
+import org.geowebcache.config.XMLConfiguration;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import org.easymock.classextension.EasyMock;
+
+public class CompositeBlobStoreWithFilesComformanceTest extends AbstractBlobStoreTest<CompositeBlobStore> {
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+    
+    private TileLayerDispatcher tld;
+    private DefaultStorageFinder defaultStorageFinder;
+    private XMLConfiguration configuration;
+    private TileLayer defaultLayer;
+    private TileLayer defaultLayer1;
+    private TileLayer defaultLayer2;
+    private LinkedList<BlobStoreConfig> configs;
+
+    private String DEFAULT_LAYER="testLayer";
+    private String DEFAULT_LAYER1="testLayer1";
+    private String DEFAULT_LAYER2="testLayer2";
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        tld = createNiceMock("tld", TileLayerDispatcher.class);
+        defaultStorageFinder = createNiceMock("defaultStorageFinder", DefaultStorageFinder.class);
+        configuration = createNiceMock("configuration", XMLConfiguration.class);
+        
+        configs = new LinkedList<>();
+        expect(configuration.getBlobStores()).andStubReturn(configs);
+        
+        expect(defaultStorageFinder.getDefaultPath()).andStubReturn(
+                temp.getRoot().getAbsolutePath());
+        
+        defaultLayer = createNiceMock("defaultLayer", TileLayer.class);
+        defaultLayer1 = createNiceMock("defaultLayer1", TileLayer.class);
+        defaultLayer2 = createNiceMock("defaultLayer2", TileLayer.class);
+        expect(tld.getTileLayer(eq(DEFAULT_LAYER))).andStubReturn(defaultLayer);
+        expect(tld.getTileLayer(eq(DEFAULT_LAYER1))).andStubReturn(defaultLayer1);
+        expect(tld.getTileLayer(eq(DEFAULT_LAYER2))).andStubReturn(defaultLayer2);
+        expect(tld.getTileLayer(not(or(eq(DEFAULT_LAYER), or(eq(DEFAULT_LAYER1), eq(DEFAULT_LAYER2)))))).andStubThrow(
+                new GeoWebCacheException("layer not found"));
+        
+        EasyMock.replay(tld, defaultStorageFinder, configuration, defaultLayer, defaultLayer1, defaultLayer2);
+        store = new CompositeBlobStore(tld, defaultStorageFinder, configuration);
+    }
+    
+    @Before
+    public void setEvents() throws Exception {
+        this.events = true;
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreComformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.storage.blobstore.memory;
 
 import org.geowebcache.storage.AbstractBlobStoreTest;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreComformanceTest.java
@@ -1,0 +1,55 @@
+package org.geowebcache.storage.blobstore.memory;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.geowebcache.storage.blobstore.memory.MemoryBlobStore;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class MemoryBlobStoreComformanceTest extends AbstractBlobStoreTest<MemoryBlobStore> {
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        this.store = new MemoryBlobStore();
+    }
+    
+    @Before
+    public void setEvents() throws Exception {
+        this.events = false;
+    }
+
+    @Override
+    @Ignore @Test // Memory store can be more relaxed about this. It would be nice to pass this though
+    public void testDeleteGridsetDoesntDeleteOthers() throws Exception {
+        super.testDeleteGridsetDoesntDeleteOthers();
+    }
+    
+    @Override
+    @Ignore @Test // Memory store can be more relaxed about this. It would be nice to pass this though
+    public void testDeleteByParametersIdDoesNotDeleteOthers() throws Exception {
+        super.testDeleteByParametersIdDoesNotDeleteOthers();
+    }
+    
+    @Override
+    @Ignore @Test // TODO For now, this is a limitation of MemoryBlobStore
+    public void testParameterList() throws Exception {
+        super.testParameterList();
+    }
+    
+    @Override
+    @Ignore @Test // TODO For now, this is a limitation of MemoryBlobStore
+    public void testParameterIDList() throws Exception {
+        super.testParameterIDList();
+    }
+    
+    @Override
+    @Ignore @Test // Memory store can be more relaxed about this. It would be nice to pass this though
+    public void testPurgeOrphans() throws Exception {
+        super.testPurgeOrphans();
+    }
+    @Override
+    @Ignore @Test // Memory store can be more relaxed about this. It would be nice to pass this though
+    public void testPurgeOrphansWithDefault() throws Exception {
+        super.testPurgeOrphansWithDefault();
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
+import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.StorageBrokerTest;
 import org.geowebcache.storage.StorageException;
 import org.geowebcache.storage.TileObject;
@@ -112,7 +113,7 @@ public class MemoryBlobStoreTest {
     @Test
     public void testTilePut() throws Exception {
         // Add a fileblobstore to the memory blobstore
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
         cache.clear();
 
         MemoryBlobStore mbs = new MemoryBlobStore();
@@ -157,7 +158,7 @@ public class MemoryBlobStoreTest {
     @Test
     public void testTileDelete() throws Exception {
         // Add a fileblobstore to the memory blobstore
-        FileBlobStore fbs = setup();
+        BlobStore fbs = setup();
         cache.clear();
 
         MemoryBlobStore mbs = new MemoryBlobStore();
@@ -207,7 +208,7 @@ public class MemoryBlobStoreTest {
      * @return a new FileBlobStore
      * @throws Exception
      */
-    private FileBlobStore setup() throws Exception {
+    private BlobStore setup() throws Exception {
         File fh = new File(StorageBrokerTest.findTempDir() + File.separator + TEST_BLOB_DIR_NAME);
 
         if (fh.exists()) {

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreWithFilesComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreWithFilesComformanceTest.java
@@ -1,0 +1,25 @@
+package org.geowebcache.storage.blobstore.memory;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.geowebcache.storage.blobstore.file.FileBlobStore;
+import org.geowebcache.storage.blobstore.memory.MemoryBlobStore;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class MemoryBlobStoreWithFilesComformanceTest extends AbstractBlobStoreTest<MemoryBlobStore> {
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        this.store = new MemoryBlobStore();
+        this.store.setStore(new FileBlobStore(temp.getRoot().getAbsolutePath()));
+    }
+    
+    @Before
+    public void setEvents() throws Exception {
+        this.events = false;
+    }
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreWithFilesComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreWithFilesComformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.storage.blobstore.memory;
 
 import org.geowebcache.storage.AbstractBlobStoreTest;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/NullBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/NullBlobStoreComformanceTest.java
@@ -1,0 +1,92 @@
+package org.geowebcache.storage.blobstore.memory;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.geowebcache.storage.blobstore.memory.NullBlobStore;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class NullBlobStoreComformanceTest extends AbstractBlobStoreTest<NullBlobStore> {
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        this.store = new NullBlobStore();
+    }
+    
+    @Before
+    public void setEvents() throws Exception  {
+        this.events = false;
+    }
+
+    @Override
+    @Ignore @Test
+    public void testStoreTile() throws Exception {
+        super.testStoreTile();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testStoreTilesInMultipleLayers() throws Exception {
+        super.testStoreTilesInMultipleLayers();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testUpdateTile() throws Exception {
+        super.testUpdateTile();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testGridsets() throws Exception {
+        super.testGridsets();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testDeleteGridsetDoesntDeleteOthers() throws Exception {
+        super.testDeleteGridset();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testDeleteByParametersId() throws Exception {
+        super.testDeleteByParametersId();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testParameters() throws Exception {
+        super.testParameters();
+    }
+    
+    @Override
+    @Ignore @Test
+    public void testParameterIDList() throws Exception {
+        super.testParameterIDList();
+    }
+
+    @Override
+    @Ignore @Test
+    public void testParameterList() throws Exception {
+        super.testParameterList();
+    }
+    
+    @Override
+    @Ignore @Test
+    public void testDeleteByParametersIdDoesNotDeleteOthers() throws Exception {
+        super.testDeleteByParametersIdDoesNotDeleteOthers();
+    }
+    
+    @Override
+    @Ignore @Test
+    public void testPurgeOrphans() throws Exception {
+        super.testPurgeOrphans();
+    }
+    
+    @Override
+    @Ignore @Test
+    public void testPurgeOrphansWithDefault() throws Exception {
+        super.testPurgeOrphansWithDefault();
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/NullBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/NullBlobStoreComformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.storage.blobstore.memory;
 
 import org.geowebcache.storage.AbstractBlobStoreTest;

--- a/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.util;
 
 import static org.hamcrest.Matchers.both;

--- a/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
@@ -1,0 +1,273 @@
+package org.geowebcache.util;
+
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.Callable;
+
+import org.apache.commons.io.IOUtils;
+import org.geowebcache.io.Resource;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public class FileMatchers {
+    private FileMatchers() {throw new IllegalStateException();};
+    
+    /**
+     * Matcher for a file that exists
+     * @return
+     */
+    public static Matcher<File> exists() {
+        return new BaseMatcher<File>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof File) {
+                    return ((File) item).exists();
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("file that exists");
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(item instanceof File) {
+                    description.appendValue(item);
+                    description.appendText(" does not exist");
+                } else {
+                    description.appendValue(item);
+                    description.appendText(" was not a File object");
+                }
+            }
+        };
+    }
+    
+    /**
+     * Matcher for a regular (non-directory) file
+     * @return
+     */
+    public static Matcher<File> file() {
+        return new BaseMatcher<File>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof File) {
+                    return ((File) item).isFile();
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("file that is a file (Not a directory)");
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(item instanceof File) {
+                    if(((File) item).exists()) {
+                        description.appendValue(item);
+                        description.appendText(" is a directory");
+                    } else {
+                        description.appendValue(item);
+                        description.appendText(" does not exist");
+                    }
+                } else {
+                    description.appendValue(item);
+                    description.appendText(" was not a File object");
+                }
+            }
+        };
+    }
+    
+    /**
+     * Matcher for a directory
+     * @return
+     */
+    public static Matcher<File> directory() {
+        return new BaseMatcher<File>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof File) {
+                    return ((File) item).isDirectory();
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("file that is a directory");
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(item instanceof File) {
+                    if(((File) item).exists()) {
+                        description.appendValue(item);
+                        description.appendText(" is not a directory");
+                    } else {
+                        description.appendValue(item);
+                        description.appendText(" does not exist");
+                    }
+                } else {
+                    description.appendValue(item);
+                    description.appendText(" was not a File object");
+                }
+            }
+        };
+    }
+    
+    /**
+     * Matcher for a directory's contents
+     * @return
+     */
+    public static Matcher<File> directoryContaining(Matcher<Iterable<File>> filesMatcher) {
+        return new BaseMatcher<File>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof File) {
+                    return ((File) item).isDirectory() && filesMatcher.matches(((File) item).listFiles());
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("directory that contains ");
+                description.appendDescriptionOf(filesMatcher);
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(! (item instanceof File)) {
+                    description.appendValue(item);
+                    description.appendText(" was not a File object");
+                } else if(! ((File) item).exists()) {
+                    description.appendValue(item);
+                    description.appendText(" does not exist");
+                } else if(! ((File) item).isDirectory()) {
+                    description.appendValue(item);
+                    description.appendText(" is not a directory");
+                } else {
+                    description.appendValue(item);
+                    description.appendText(" had files ");
+                    filesMatcher.describeMismatch(((File) item).listFiles(), description);
+                }
+            }
+        };
+    }
+    
+    public static Matcher<File> directoryEmpty() {
+        return directoryContaining(Matchers.emptyIterableOf(File.class));
+    }
+    
+    /**
+     * Matcher for last modified time
+     * @param timeMatcher
+     * @return
+     */
+    public static Matcher<File> lastModified(final Matcher<Long> timeMatcher) {
+        return new BaseMatcher<File>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof File) {
+                    return timeMatcher.matches(((File) item).lastModified());
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("file last modified ");
+                description.appendDescriptionOf(timeMatcher);
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(item instanceof File) {
+                    if(((File) item).exists()) {
+                        description.appendValue(item);
+                        description.appendText(" had modification time ");
+                        timeMatcher.describeMismatch(((File) item).lastModified(), description);
+                    } else {
+                        description.appendValue(item);
+                        description.appendText(" does not exist");
+                    }
+                } else {
+                    description.appendValue(item);
+                    description.appendText(" was not a File object");
+                }
+            }
+            
+        };
+    }
+    
+    /**
+     * Executes the given {@link Callable} and then returns a matcher for values of 
+     * {@link System.currentTimeMillis} during the execution.
+     * @param stuffToDo
+     * @return
+     * @throws any exceptions thrown by stuffToDo
+     */
+    public static Matcher<Long> whileRunning(Callable<Void> stuffToDo) throws Exception {
+        final long start = System.currentTimeMillis();
+        stuffToDo.call();
+        final long end = System.currentTimeMillis();
+        return both(greaterThan(start)).and(lessThan(end));
+    }
+    
+    public static Matcher<Resource> resource(final Resource expected) {
+        return new BaseMatcher<Resource>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof Resource) {
+                    try(
+                        InputStream itemStream = ((Resource) item).getInputStream();
+                        InputStream expectedStream = expected.getInputStream();
+                    ) {
+                        return IOUtils.contentEquals(itemStream, expectedStream);
+                    } catch (IOException e) {
+                        return false;
+                    } 
+                } else {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Resource with content equal to that given");
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                if(item instanceof Resource) {
+                    description.appendText("did not match given Resource");
+                } else {
+                    description.appendText("was not a Resource");
+                }
+            }
+            
+        };
+    }
+}

--- a/geowebcache/diskquota/bdb/pom.xml
+++ b/geowebcache/diskquota/bdb/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>gwc-diskquota</artifactId>
     <version>1.12-SNAPSHOT</version><!-- GWC VERSION -->
   </parent>
-  <groupId>org.geowebcache</groupId>
   <artifactId>gwc-diskquota-bdb</artifactId>
   <packaging>jar</packaging>
   <name>Disk Quota management module - BerkeleyDB backend</name>
@@ -48,9 +47,13 @@
     <dependency>
       <groupId>org.geowebcache</groupId>
       <artifactId>gwc-core</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
@@ -50,8 +50,6 @@ import org.geowebcache.diskquota.storage.TilePageCalculator;
 import org.geowebcache.diskquota.storage.TileSet;
 import org.geowebcache.diskquota.storage.TileSetVisitor;
 import org.geowebcache.storage.DefaultStorageFinder;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.util.Assert;
 

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
@@ -54,6 +55,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.util.Assert;
 
+import com.google.common.base.Objects;
 import com.sleepycat.je.CursorConfig;
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.LockMode;
@@ -247,7 +249,7 @@ public class BDBQuotaStore implements QuotaStore {
                             + "' as it does not exist anymore...");
                     // do not call issue since we're already running on the transaction thread here
                     try {
-                        new DeleteLayer(layerName).call(transaction);
+                        new Deleter(layerName, ts->true).call(transaction);
                     } catch (Exception e) {
                         log.warn("Error deleting disk quota information for layer '" + layerName
                                 + "'", e);
@@ -402,14 +404,34 @@ public class BDBQuotaStore implements QuotaStore {
         }
     }
 
-    private class DeleteLayer implements Callable<Void> {
+    /**
+     * @see org.geowebcache.diskquota.QuotaStore#deleteLayer(java.lang.String)
+     */
+    public void deleteLayer(final String layerName) {
+        Assert.notNull(layerName);
+        issue(new Deleter(layerName, ts->true));
+    }
+
+    public void deleteGridSubset(String layerName, String gridSetId) {
+        issue(new Deleter(layerName, ts->Objects.equal(ts.getGridsetId(),gridSetId)));
+    }
+    
+    public void deleteParameters(String layerName, String parametersId) {
+        issue(new Deleter(layerName, ts->Objects.equal(ts.getParametersId(),parametersId)));
+    }
+    
+
+    
+    private class Deleter implements Callable<Void> {
 
         private final String layerName;
-
-        public DeleteLayer(String layerName) {
+        Predicate<TileSet> shouldDelete;
+        
+        public Deleter(String layerName, Predicate<TileSet> shouldDelete) {
             this.layerName = layerName;
+            this.shouldDelete = shouldDelete;
         }
-
+        
         public Void call() throws Exception {
             Transaction transaction = entityStore.getEnvironment().beginTransaction(null, null);
             try {
@@ -421,85 +443,29 @@ public class BDBQuotaStore implements QuotaStore {
             }
             return null;
         }
-
+        
         public void call(Transaction transaction) {
-
-            EntityCursor<TileSet> tileSets = tileSetsByLayer.entities(transaction, layerName, true,
-                    layerName, true, null);
+            EntityCursor<TileSet> tileSets = tileSetsByLayer.entities(transaction, layerName,
+                    true, layerName, true, null);
+            TileSet tileSet;
+            Quota freed;
+            Quota global;
             try {
-                TileSet tileSet;
-                Quota freed;
-                Quota global;
                 while (null != (tileSet = tileSets.next())) {
-                    freed = usedQuotaByTileSetId
-                            .get(transaction, tileSet.getId(), LockMode.DEFAULT);
-                    global = usedQuotaByTileSetId.get(transaction, GLOBAL_QUOTA_NAME,
-                            LockMode.DEFAULT);
-
-                    tileSets.delete();
-                    global.subtract(freed.getBytes());
-                    usedQuotaById.put(transaction, global);
+                    if (shouldDelete.test(tileSet)) {
+                        freed = usedQuotaByTileSetId.get(transaction, tileSet.getId(),
+                                LockMode.DEFAULT);
+                        global = usedQuotaByTileSetId.get(transaction, GLOBAL_QUOTA_NAME,
+                                LockMode.DEFAULT);
+                        
+                        tileSets.delete();
+                        global.subtract(freed.getBytes());
+                        usedQuotaById.put(transaction, global);
+                    }
                 }
             } finally {
                 tileSets.close();
             }
-        }
-
-    }
-
-    /**
-     * @see org.geowebcache.diskquota.QuotaStore#deleteLayer(java.lang.String)
-     */
-    public void deleteLayer(final String layerName) {
-        Assert.notNull(layerName);
-        issue(new DeleteLayer(layerName));
-    }
-
-    public void deleteGridSubset(String layerName, String gridSetId) {
-        issue(new DeleteLayerGridSubset(layerName, gridSetId));
-    }
-
-    private class DeleteLayerGridSubset implements Callable<Void> {
-
-        private final String layerName;
-
-        private final String gridSetId;
-
-        public DeleteLayerGridSubset(String layerName, String gridSetId) {
-            this.layerName = layerName;
-            this.gridSetId = gridSetId;
-        }
-
-        public Void call() {
-            Transaction transaction = entityStore.getEnvironment().beginTransaction(null, null);
-            try {
-                EntityCursor<TileSet> tileSets = tileSetsByLayer.entities(transaction, layerName,
-                        true, layerName, true, null);
-                TileSet tileSet;
-                Quota freed;
-                Quota global;
-                try {
-                    while (null != (tileSet = tileSets.next())) {
-                        if (tileSet.getGridsetId().equals(gridSetId)) {
-                            freed = usedQuotaByTileSetId.get(transaction, tileSet.getId(),
-                                    LockMode.DEFAULT);
-                            global = usedQuotaByTileSetId.get(transaction, GLOBAL_QUOTA_NAME,
-                                    LockMode.DEFAULT);
-
-                            tileSets.delete();
-                            global.subtract(freed.getBytes());
-                            usedQuotaById.put(transaction, global);
-                        }
-                    }
-                } finally {
-                    tileSets.close();
-                }
-                transaction.commit();
-            } catch (RuntimeException e) {
-                transaction.abort();
-                throw e;
-            }
-            return null;
         }
     }
 
@@ -533,7 +499,7 @@ public class BDBQuotaStore implements QuotaStore {
             Transaction transaction = entityStore.getEnvironment().beginTransaction(null, null);
             try {
                 copyTileSets(transaction);
-                DeleteLayer deleteCommand = new DeleteLayer(oldLayerName);
+                Deleter deleteCommand = new Deleter(oldLayerName, ts->true);
                 deleteCommand.call(transaction);
                 transaction.commit();
             } catch (RuntimeException e) {

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.InputStream;
@@ -21,7 +20,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -44,18 +42,14 @@ import org.geowebcache.diskquota.storage.TileSet;
 import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
-import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.util.FileMatchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
-import com.sun.media.imageio.stream.StreamSegment;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -1,5 +1,15 @@
 package org.geowebcache.diskquota;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -11,12 +21,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import junit.framework.TestCase;
-
-import org.apache.commons.io.FileUtils;
+import org.easymock.Capture;
 import org.easymock.classextension.EasyMock;
 import org.geowebcache.config.Configuration;
 import org.geowebcache.config.XMLConfiguration;
@@ -30,11 +41,28 @@ import org.geowebcache.diskquota.storage.SystemUtils;
 import org.geowebcache.diskquota.storage.TilePage;
 import org.geowebcache.diskquota.storage.TilePageCalculator;
 import org.geowebcache.diskquota.storage.TileSet;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.DefaultStorageFinder;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.util.FileMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
-public class BDBQuotaStoreTest extends TestCase {
+import com.sun.media.imageio.stream.StreamSegment;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public class BDBQuotaStoreTest {
 
     private BDBQuotaStore store;
 
@@ -45,42 +73,60 @@ public class BDBQuotaStoreTest extends TestCase {
     TileLayerDispatcher layerDispatcher;
 
     DefaultStorageFinder cacheDirFinder;
+    
+    StorageBroker storageBroker;
 
-    File targetDir;
+    @Rule
+    public TemporaryFolder targetDir = new TemporaryFolder();
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
-    @Override
+    Map<String, Set<String>> parameterIdsMap;
+    Map<String, Set<Map<String, String>>> parametersMap;
+    
+    @Before
     public void setUp() throws Exception {
-        targetDir = new File("target", "mockStore" + Math.random());
-        FileUtils.deleteDirectory(targetDir);
-        targetDir.mkdirs();
 
         cacheDirFinder = EasyMock.createMock(DefaultStorageFinder.class);
-        EasyMock.expect(cacheDirFinder.getDefaultPath()).andReturn(targetDir.getAbsolutePath())
+        EasyMock.expect(cacheDirFinder.getDefaultPath()).andReturn(targetDir.getRoot().getAbsolutePath())
                 .anyTimes();
         EasyMock.expect(
                 cacheDirFinder.findEnvVar(EasyMock.eq(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED)))
                 .andReturn(null).anyTimes();
         EasyMock.replay(cacheDirFinder);
 
+        Capture<String> layerNameCap = new Capture<>();
+        storageBroker = EasyMock.createMock(StorageBroker.class);
+        EasyMock.expect(storageBroker.getCachedParameterIds(EasyMock.capture(layerNameCap)))
+            .andStubAnswer(()->parameterIdsMap.getOrDefault(
+                    layerNameCap.getValue(),
+                    Collections.singleton(null)));
+        EasyMock.replay(storageBroker);
+        parametersMap = new HashMap<>();
+        parametersMap.put("topp:states", Stream.of(
+                "STYLE=&SOMEPARAMETER=",
+                "STYLE=population&SOMEPARAMETER=2.0")
+                    .map(ParametersUtils::getMap)
+                    .collect(Collectors.toSet()));
+        parameterIdsMap= parametersMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, 
+                        e->e.getValue().stream()
+                            .map(ParametersUtils::getKvp)
+                            .collect(Collectors.toSet())
+                        ));
         XMLConfiguration xmlConfig = loadXMLConfig();
         LinkedList<Configuration> configList = new LinkedList<Configuration>();
         configList.add(xmlConfig);
 
         layerDispatcher = new TileLayerDispatcher(new GridSetBroker(true, true), configList);
 
-        tilePageCalculator = new TilePageCalculator(layerDispatcher);
+        tilePageCalculator = new TilePageCalculator(layerDispatcher, storageBroker);
 
         store = new BDBQuotaStore(cacheDirFinder, tilePageCalculator);
         store.startUp();
         testTileSet = tilePageCalculator.getTileSetsFor("topp:states2").iterator().next();
-    }
-
-    public void tearDown() {
-        try {
-            store.close();
-            FileUtils.deleteDirectory(targetDir);
-        } catch (Exception e) {
-        }
     }
 
     private XMLConfiguration loadXMLConfig() {
@@ -96,42 +142,34 @@ public class BDBQuotaStoreTest extends TestCase {
         return xmlConfig;
     }
 
+    @Test
     public void testInitialization() throws Exception {
-        Set<TileSet> tileSets = store.getTileSets();
-        assertNotNull(tileSets);
-        assertEquals(10, tileSets.size());
-
-        TileSet tileSet = new TileSet("topp:states", "EPSG:900913", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "image/gif", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml",
-                null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/gif", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml",
-                null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
+        String[] paramIds = parameterIdsMap.get("topp:states").toArray(new String[2]);
+        assertThat(store, hasProperty("tileSets", containsInAnyOrder(
+                new TileSet("topp:states", "EPSG:900913", "image/png", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "image/jpeg", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "image/gif", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml",
+                        paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/png", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/jpeg", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/gif", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml",
+                        paramIds[0]),
+                
+                new TileSet("topp:states", "EPSG:900913", "image/png", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "image/jpeg", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "image/gif", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml",
+                        paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/png", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/jpeg", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/gif", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml",
+                        paramIds[1]),
+                
+                new TileSet("topp:states2", "EPSG:2163", "image/png", null),
+                new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null))));
 
         // remove one layer from the dispatcher
         Configuration configuration = layerDispatcher.removeLayer("topp:states");
@@ -142,15 +180,11 @@ public class BDBQuotaStoreTest extends TestCase {
         // the layer was removed programmatically through StorageBroker.deleteLayer
         store.close();
         store.startUp();
-
-        tileSets = store.getTileSets();
-        assertNotNull(tileSets);
-        assertEquals(2, tileSets.size());
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
+        
+        assertThat(store, hasProperty("tileSets", containsInAnyOrder(
+                new TileSet("topp:states2", "EPSG:2163", "image/png", null),
+                new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null)
+                )));
     }
 
     /**
@@ -159,6 +193,7 @@ public class BDBQuotaStoreTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testPageStatsGathering() throws Exception {
         final MockSystemUtils sysUtils = new MockSystemUtils();
         sysUtils.setCurrentTimeMinutes(10);
@@ -182,14 +217,13 @@ public class BDBQuotaStoreTest extends TestCase {
                 .singleton(payload));
         List<PageStats> allStats = result.get();
         PageStats stats = allStats.get(0);
-        float fillFactor = stats.getFillFactor();
-        assertEquals(1.0f, fillFactor, 1e-6);
-
-        int lastAccessTimeMinutes = stats.getLastAccessTimeMinutes();
-        assertEquals(sysUtils.currentTimeMinutes(), lastAccessTimeMinutes);
-
-        float frequencyOfUsePerMinute = stats.getFrequencyOfUsePerMinute();
-        assertEquals(100f, frequencyOfUsePerMinute);
+        
+        assertThat(stats, hasProperty("fillFactor", closeTo(1.0f, 1e-6f)));
+        
+        assertThat(stats, hasProperty("lastAccessTimeMinutes", 
+                equalTo(sysUtils.currentTimeMinutes())));
+        
+        assertThat(stats, hasProperty("frequencyOfUsePerMinute", closeTo(100f, 1e-6f)));
 
         // now 1 minute later...
         sysUtils.setCurrentTimeMinutes(sysUtils.currentTimeMinutes() + 2);
@@ -203,103 +237,161 @@ public class BDBQuotaStoreTest extends TestCase {
         allStats = result.get();
         stats = allStats.get(0);
 
-        lastAccessTimeMinutes = stats.getLastAccessTimeMinutes();
-        assertEquals(11, lastAccessTimeMinutes);
+        assertThat(stats, hasProperty("lastAccessTimeMinutes", equalTo(11)));
 
-        frequencyOfUsePerMinute = stats.getFrequencyOfUsePerMinute();
-        float expected = 55.0f;// the 100 previous + the 10 added now / the 2 minutes that elapsed
-        assertEquals(expected, frequencyOfUsePerMinute, 1e-6f);
+        assertThat(stats, hasProperty("frequencyOfUsePerMinute", 
+                closeTo(55.0f, // the 100 previous + the 10 added now / the 2 minutes that elapsed
+                        1e-6f)));
     }
 
+    @Test
     public void testGetGloballyUsedQuota() throws InterruptedException {
-        Quota usedQuota = store.getGloballyUsedQuota();
-        assertNotNull(usedQuota);
-        assertEquals(0, usedQuota.getBytes().intValue());
+        store.getGloballyUsedQuota().getBytes();
+        assertThat(store, hasProperty("globallyUsedQuota", quotaEmpty()));
 
         String layerName = tilePageCalculator.getLayerNames().iterator().next();
         TileSet tileSet = tilePageCalculator.getTileSetsFor(layerName).iterator().next();
-
-        final String tileSetId = tileSet.getId();
 
         Quota quotaDiff = new Quota(BigInteger.valueOf(1000));
         Collection<PageStatsPayload> tileCountDiffs = Collections.emptySet();
         store.addToQuotaAndTileCounts(tileSet, quotaDiff, tileCountDiffs);
 
-        usedQuota = store.getGloballyUsedQuota();
-        assertNotNull(usedQuota);
-        assertEquals(1000, usedQuota.getBytes().intValue());
+        assertThat(store, hasProperty("globallyUsedQuota", bytes(1000)));
 
         quotaDiff = new Quota(BigInteger.valueOf(-500));
         store.addToQuotaAndTileCounts(tileSet, quotaDiff, tileCountDiffs);
 
-        usedQuota = store.getGloballyUsedQuota();
-        assertNotNull(usedQuota);
-        assertEquals(500, usedQuota.getBytes().intValue());
+        assertThat(store, hasProperty("globallyUsedQuota", bytes(500)));
     }
 
-    public void testDeleteLayer() throws InterruptedException {
-        String layerName = tilePageCalculator.getLayerNames().iterator().next();
-        // make sure the layer is there and has stuff
-        Quota usedQuota = store.getUsedQuotaByLayerName(layerName);
-        assertNotNull(usedQuota);
-
-        TileSet tileSet = tilePageCalculator.getTileSetsFor(layerName).iterator().next();
-        TilePage page = new TilePage(tileSet.getId(), 0, 0, (byte) 0);
-        store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
-        // page.setNumHits(10);
-        // page.setLastAccessTime(System.currentTimeMillis());
-        // store.addHitsAndSetAccesTime(page);
-
-        assertNotNull(store.getTileSetById(tileSet.getId()));
-
-        store.deleteLayer(layerName);
-
-        // cascade deleted?
-        assertNull(store.getLeastRecentlyUsedPage(Collections.singleton(layerName)));
-        usedQuota = store.getUsedQuotaByLayerName(layerName);
-        assertNotNull(usedQuota);
-        assertEquals(0L, usedQuota.getBytes().longValue());
+    
+    @Test
+    public void testDeleteGridset() throws InterruptedException {
+        String layerName = "topp:states";
+        String gridSetId = "EPSG:4326";
+        
+        long quotaToDelete = tilePageCalculator.getTileSetsFor(
+                layerName).stream()
+            .filter(ts->ts.getGridsetId().equals(gridSetId))
+            .map(ts->{
+                Quota quotaDiff = new Quota(42, StorageUnit.MiB);
+                try {
+                    store.addToQuotaAndTileCounts(ts, quotaDiff, Collections.emptySet());
+                    TilePage page = new TilePage(ts.getId(), 0, 0, (byte) 0);
+                    store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
+                    return 42;
+                } catch (InterruptedException e) {
+                    throw new AssertionError("Unexpected Exception",e);
+                }
+            })
+            .collect(Collectors.summingLong(mb->mb*1024*1024));
+        assertThat(quotaToDelete, greaterThan(0L));
+        long quotaToKeep = tilePageCalculator.getTileSetsFor(layerName).stream()
+            .filter(ts->!ts.getGridsetId().equals(gridSetId))
+            .map(ts->{
+                Quota quotaDiff = new Quota(10, StorageUnit.MiB);
+                try {
+                    store.addToQuotaAndTileCounts(ts, quotaDiff, Collections.emptySet());
+                    TilePage page = new TilePage(ts.getId(), 0, 0, (byte) 0);
+                    store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
+                    return 10;
+                } catch (InterruptedException e) {
+                    throw new AssertionError("Unexpected Exception",e);
+                }
+            })
+            .collect(Collectors.summingLong(mb->mb*1024*1024));
+        assertThat(quotaToKeep, greaterThan(0L));
+        
+        assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToDelete+quotaToKeep));
+        
+        store.deleteGridSubset(layerName, gridSetId);
+        
+        assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToKeep));
+    }
+    
+    @Test
+    public void testDeleteParameters() throws InterruptedException {
+        String layerName = "topp:states";
+        String parametersId = parameterIdsMap.get(layerName).iterator().next();
+        
+        long quotaToDelete = tilePageCalculator.getTileSetsFor(
+                layerName).stream()
+            .filter(ts->ts.getParametersId().equals(parametersId))
+            .map(ts->{
+                Quota quotaDiff = new Quota(42, StorageUnit.MiB);
+                try {
+                    store.addToQuotaAndTileCounts(ts, quotaDiff, Collections.emptySet());
+                    TilePage page = new TilePage(ts.getId(), 0, 0, (byte) 0);
+                    store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
+                    return 42;
+                } catch (InterruptedException e) {
+                    throw new AssertionError("Unexpected Exception",e);
+                }
+            })
+            .collect(Collectors.summingLong(mb->mb*1024*1024));
+        assertThat(quotaToDelete, greaterThan(0L));
+        long quotaToKeep = tilePageCalculator.getTileSetsFor(layerName).stream()
+            .filter(ts->!ts.getParametersId().equals(parametersId))
+            .map(ts->{
+                Quota quotaDiff = new Quota(10, StorageUnit.MiB);
+                try {
+                    store.addToQuotaAndTileCounts(ts, quotaDiff, Collections.emptySet());
+                    TilePage page = new TilePage(ts.getId(), 0, 0, (byte) 0);
+                    store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
+                    return 10;
+                } catch (InterruptedException e) {
+                    throw new AssertionError("Unexpected Exception",e);
+                }
+            })
+            .collect(Collectors.summingLong(mb->mb*1024*1024));
+        assertThat(quotaToKeep, greaterThan(0L));
+        
+        assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToDelete+quotaToKeep));
+        
+        store.deleteParameters(layerName, parametersId);
+        
+        assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToKeep));
     }
 
+    @Test
     public void testRenameLayer() throws InterruptedException {
         final String oldLayerName = tilePageCalculator.getLayerNames().iterator().next();
         final String newLayerName = "renamed_layer";
+        
+        BigInteger expectedBytes = BigInteger.valueOf(1024);
+        BigInteger emptyBytes = BigInteger.ZERO;
 
         // make sure the layer is there and has stuff
-        Quota usedQuota = store.getUsedQuotaByLayerName(oldLayerName);
-        assertNotNull(usedQuota);
+        assertThat(store.getUsedQuotaByLayerName(oldLayerName), notNullValue());
 
         TileSet tileSet = tilePageCalculator.getTileSetsFor(oldLayerName).iterator().next();
         TilePage page = new TilePage(tileSet.getId(), 0, 0, (byte) 0);
         store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
-        store.addToQuotaAndTileCounts(tileSet, new Quota(BigInteger.valueOf(1024)),
-                Collections.EMPTY_LIST);
+        store.addToQuotaAndTileCounts(tileSet, new Quota(expectedBytes),
+                Collections.emptyList());
 
-        Quota expectedQuota = store.getUsedQuotaByLayerName(oldLayerName);
-        assertEquals(1024L, expectedQuota.getBytes().longValue());
+        assertThat(store.getUsedQuotaByLayerName(oldLayerName), bytes(expectedBytes));
 
-        assertNotNull(store.getTileSetById(tileSet.getId()));
+        assertThat(store.getTileSetById(tileSet.getId()), notNullValue());
 
         store.renameLayer(oldLayerName, newLayerName);
 
         // cascade deleted old layer?
-        assertNull(store.getLeastRecentlyUsedPage(Collections.singleton(oldLayerName)));
-        usedQuota = store.getUsedQuotaByLayerName(oldLayerName);
-        assertNotNull(usedQuota);
-        assertEquals(0L, usedQuota.getBytes().longValue());
+        assertThat(store.getLeastRecentlyUsedPage(Collections.singleton(oldLayerName)), nullValue());
+        assertThat(store.getUsedQuotaByLayerName(oldLayerName), bytes(emptyBytes));
 
         // created new layer?
-        Quota newLayerUsedQuota = store.getUsedQuotaByLayerName(newLayerName);
-        assertEquals(expectedQuota.getBytes(), newLayerUsedQuota.getBytes());
+        assertThat(store.getUsedQuotaByLayerName(newLayerName), bytes(expectedBytes));
     }
 
+    @Test
     public void testGetLeastFrequentlyUsedPage() throws Exception {
         final String layerName = testTileSet.getLayerName();
         Set<String> layerNames = Collections.singleton(layerName);
 
         TilePage lfuPage;
         lfuPage = store.getLeastFrequentlyUsedPage(layerNames);
-        assertNull(lfuPage);
+        assertThat(lfuPage, nullValue());
 
         TilePage page1 = new TilePage(testTileSet.getId(), 0, 1, 2);
         TilePage page2 = new TilePage(testTileSet.getId(), 1, 1, 2);
@@ -312,16 +404,15 @@ public class BDBQuotaStoreTest extends TestCase {
         Collection<PageStatsPayload> statsUpdates = Arrays.asList(payload1, payload2);
         store.addHitsAndSetAccesTime(statsUpdates).get();
 
-        TilePage leastFrequentlyUsedPage = store.getLeastFrequentlyUsedPage(layerNames);
-        assertEquals(page2, leastFrequentlyUsedPage);
+        assertThat(store.getLeastFrequentlyUsedPage(layerNames), equalTo(page2));
 
         payload2.setNumHits(1000);
         store.addHitsAndSetAccesTime(statsUpdates).get();
 
-        leastFrequentlyUsedPage = store.getLeastFrequentlyUsedPage(layerNames);
-        assertEquals(page1, leastFrequentlyUsedPage);
+        assertThat(store.getLeastFrequentlyUsedPage(layerNames), equalTo(page1));
     }
 
+    @Test
     public void testGetLeastRecentlyUsedPage() throws Exception {
         MockSystemUtils mockSystemUtils = new MockSystemUtils();
         mockSystemUtils.setCurrentTimeMinutes(1000);
@@ -331,9 +422,7 @@ public class BDBQuotaStoreTest extends TestCase {
         final String layerName = testTileSet.getLayerName();
         Set<String> layerNames = Collections.singleton(layerName);
 
-        TilePage leastRecentlyUsedPage;
-        leastRecentlyUsedPage = store.getLeastRecentlyUsedPage(layerNames);
-        assertNull(leastRecentlyUsedPage);
+        assertThat(store.getLeastRecentlyUsedPage(layerNames), nullValue());
 
         TilePage page1 = new TilePage(testTileSet.getId(), 0, 1, 2);
         TilePage page2 = new TilePage(testTileSet.getId(), 1, 1, 2);
@@ -347,48 +436,43 @@ public class BDBQuotaStoreTest extends TestCase {
         Collection<PageStatsPayload> statsUpdates = Arrays.asList(payload1, payload2);
         store.addHitsAndSetAccesTime(statsUpdates).get();
 
-        leastRecentlyUsedPage = store.getLeastRecentlyUsedPage(layerNames);
-        assertEquals(page1, leastRecentlyUsedPage);
+        assertThat(store.getLeastRecentlyUsedPage(layerNames), equalTo(page1));
 
         payload1.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 10 * 60 * 1000);
         store.addHitsAndSetAccesTime(statsUpdates).get();
 
-        leastRecentlyUsedPage = store.getLeastRecentlyUsedPage(layerNames);
-        assertEquals(page2, leastRecentlyUsedPage);
+        assertThat(store.getLeastRecentlyUsedPage(layerNames), equalTo(page2));
     }
 
+    @Test
     public void testGetTileSetById() throws Exception {
-
-        TileSet tileSet = store.getTileSetById(testTileSet.getId());
-        assertNotNull(tileSet);
-        assertEquals(testTileSet, tileSet);
-
-        try {
-            store.getTileSetById("NonExistentTileSetId");
-            fail("Expected IAE");
-        } catch (IllegalArgumentException e) {
-            assertTrue(true);
-        }
+        assertThat(store.getTileSetById(testTileSet.getId()), equalTo(testTileSet));
+        
+        exception.expect(IllegalArgumentException.class);
+        
+        store.getTileSetById("NonExistentTileSetId");
     }
 
+    @Test
     public void testGetTilesForPage() throws Exception {
         TilePage page = new TilePage(testTileSet.getId(), 0, 0, 0);
 
         long[][] expected = tilePageCalculator.toGridCoverage(testTileSet, page);
         long[][] tilesForPage = store.getTilesForPage(page);
 
-        assertTrue(Arrays.equals(expected[0], tilesForPage[0]));
+        assertThat(tilesForPage[0], equalTo(expected[0]));
 
         page = new TilePage(testTileSet.getId(), 0, 0, 1);
 
         expected = tilePageCalculator.toGridCoverage(testTileSet, page);
         tilesForPage = store.getTilesForPage(page);
 
-        assertTrue(Arrays.equals(expected[1], tilesForPage[1]));
+        assertThat(tilesForPage[1], equalTo(expected[1]));
 
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testGetUsedQuotaByLayerName() throws Exception {
         String layerName = "topp:states2";
         List<TileSet> tileSets;
@@ -401,11 +485,11 @@ public class BDBQuotaStoreTest extends TestCase {
             store.addToQuotaAndTileCounts(tset, quotaDiff, Collections.EMPTY_SET);
         }
 
-        Quota usedQuotaByLayerName = store.getUsedQuotaByLayerName(layerName);
-        assertEquals(expected.getBytes(), usedQuotaByLayerName.getBytes());
+        assertThat(store.getUsedQuotaByLayerName(layerName), bytes(expected.getBytes()));
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testGetUsedQuotaByTileSetId() throws Exception {
         String layerName = "topp:states2";
         List<TileSet> tileSets;
@@ -423,12 +507,13 @@ public class BDBQuotaStoreTest extends TestCase {
         }
 
         for (Map.Entry<String, Quota> expected : expectedById.entrySet()) {
-            BigInteger expectedValaue = expected.getValue().getBytes();
+            BigInteger expectedValue = expected.getValue().getBytes();
             String tsetId = expected.getKey();
-            assertEquals(expectedValaue, store.getUsedQuotaByTileSetId(tsetId).getBytes());
+            assertThat(store.getUsedQuotaByTileSetId(tsetId), bytes(expectedValue));
         }
     }
 
+    @Test
     public void testSetTruncated() throws Exception {
         String tileSetId = testTileSet.getId();
         TilePage page = new TilePage(tileSetId, 0, 0, 2);
@@ -441,14 +526,44 @@ public class BDBQuotaStoreTest extends TestCase {
         store.addToQuotaAndTileCounts(testTileSet, new Quota(1, StorageUnit.MiB),
                 Collections.singleton(payload));
         List<PageStats> stats = store.addHitsAndSetAccesTime(Collections.singleton(payload)).get();
-        assertTrue(stats.get(0).getFillFactor() > 0f);
+        assertThat(stats, contains(hasProperty("fillFactor", greaterThan(0f))));
         PageStats pageStats = store.setTruncated(page);
-        assertEquals(0f, pageStats.getFillFactor());
+        assertThat(pageStats, hasProperty("fillFactor", closeTo(0f, 0f)));
     }
     
+    @Test
     public void testCreatesVersion() throws Exception {
-        File versionFile = new File(targetDir, "diskquota_page_store/version.txt");
-        assertTrue(versionFile.exists());
+        File versionFile = new File(targetDir.getRoot(), "diskquota_page_store/version.txt");
+        assertThat(versionFile, FileMatchers.exists());
     }
 
+    static Matcher<Float> closeTo(float f, float epsilon) {
+        return new BaseMatcher<Float>() {
+            Matcher<Double> doubleMatcher = Matchers.closeTo((double)f, (double)epsilon);
+            @Override
+            public boolean matches(Object item) {
+                if(item instanceof Float) {
+                    item = (double)(float)item;
+                }
+                return doubleMatcher.matches(item);
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                doubleMatcher.describeTo(description);
+            }
+            
+        };
+    }
+    static Matcher<Quota> bytes(BigInteger bytes) {
+        return hasProperty("bytes", equalTo(bytes));
+    }
+    
+    static Matcher<Quota> bytes(long bytes) {
+        return hasProperty("bytes", equalTo(BigInteger.valueOf(bytes)));
+    }
+    
+    static Matcher<Quota> quotaEmpty() {
+        return bytes(BigInteger.ZERO);
+    }
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
@@ -18,12 +18,10 @@
 package org.geowebcache.diskquota;
 
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.storage.BlobStoreListener;
 import org.geowebcache.storage.DefaultStorageBroker;

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
@@ -137,6 +137,10 @@ class QueuedQuotaUpdatesProducer implements BlobStoreListener {
     public void gridSubsetDeleted(String layerName, String gridSetId) {
         quotaStore.deleteGridSubset(layerName, gridSetId);
     }
+    
+    public void parametersDeleted(String layerName, String parametersId) {
+        quotaStore.deleteParameters(layerName, parametersId);
+    }
 
     public void layerRenamed(String oldLayerName, String newLayerName) {
         try {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStore.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStore.java
@@ -102,6 +102,8 @@ public interface QuotaStore {
     public abstract PageStats setTruncated(final TilePage tilePage) throws InterruptedException;
 
     public abstract void deleteGridSubset(String layerName, String gridSetId);
+    
+    public abstract void deleteParameters(String layerName, String parametersId);
 
     /**
      * Closes the quota store, releasing any resources the store might be depending onto

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
@@ -49,7 +49,7 @@ public class LayerCacheInfoBuilderTest extends TestCase {
         protected String getParametersId(String base, java.util.Map<String,String> parameters) throws IOException {
             // we assume no collisions for these tests
             String parametersKvp = ParametersUtils.getKvp(parameters);
-            return buildKey(parametersKvp);
+            return ParametersUtils.buildKey(parametersKvp);
         };
     };
 

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 
 import junit.framework.TestCase;
 
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.mime.MimeException;
@@ -47,7 +48,7 @@ public class LayerCacheInfoBuilderTest extends TestCase {
     FilePathGenerator pathGenerator = new FilePathGenerator("") {
         protected String getParametersId(String base, java.util.Map<String,String> parameters) throws IOException {
             // we assume no collisions for these tests
-            String parametersKvp = getParametersKvp(parameters);
+            String parametersKvp = ParametersUtils.getKvp(parameters);
             return buildKey(parametersKvp);
         };
     };

--- a/geowebcache/diskquota/jdbc/pom.xml
+++ b/geowebcache/diskquota/jdbc/pom.xml
@@ -58,6 +58,11 @@
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
@@ -274,6 +274,12 @@ public class JDBCQuotaStore implements QuotaStore {
         // execute the sql query
         return nonNullQuota(jt.queryForOptionalObject(sql, new DiskQuotaMapper(), parameters));
     }
+    
+    public Quota getUsedQuotaByParametersId(String parametersId) {
+        String sql = dialect.getUsedQuotaByParametersId(schema, "parametersId");
+        return nonNullQuota(jt.queryForOptionalObject(sql, new DiskQuotaMapper(), Collections.singletonMap("parametersId", parametersId)));
+
+    }
 
     protected Quota getUsedQuotaByTileSetIdInternal(final String tileSetId) {
         String sql = dialect.getUsedQuotaByTileSetId(schema, "key");
@@ -882,5 +888,31 @@ public class JDBCQuotaStore implements QuotaStore {
 
             return new TilePage(tileSetId, pageX, pageY, pageZ, creationTimeMinutes);
         }
+    }
+
+    @Override
+    public void deleteParameters(final String layerName, final String parametersId) {
+        tt.execute(new TransactionCallbackWithoutResult() {
+
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                // first gather the disk quota used by the gridset, and update the global quota
+                Quota quota = getUsedQuotaByParametersId(parametersId);
+                quota.setBytes(quota.getBytes().negate());
+                String updateQuota = dialect.getUpdateQuotaStatement(schema, "tileSetId", "bytes");
+                Map<String, Object> params = new HashMap<String, Object>();
+                params.put("tileSetId", GLOBAL_QUOTA_NAME);
+                params.put("bytes", new BigDecimal(quota.getBytes()));
+                jt.update(updateQuota, params);
+                
+                // then delete all the gridsets with the specified id
+                String statement = dialect.getLayerParametersDeletionStatement(schema, "layerName",
+                        "parametersId");
+                params = new HashMap<String, Object>();
+                params.put("layerName", layerName);
+                params.put("parametersId", parametersId);
+                jt.update(statement, params);
+            }
+        });
     }
 }

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
@@ -657,7 +657,7 @@ public class JDBCQuotaStore implements QuotaStore {
         return executor.submit(new Callable<List<PageStats>>() {
 
             public List<PageStats> call() throws Exception {
-                return (List<PageStats>) tt.execute(new TransactionCallback() {
+                return (List<PageStats>) tt.execute(new TransactionCallback<Object>() {
 
                     public Object doInTransaction(TransactionStatus status) {
                         List<PageStats> result = new ArrayList<PageStats>();
@@ -794,7 +794,7 @@ public class JDBCQuotaStore implements QuotaStore {
     }
 
     public PageStats setTruncated(final TilePage page) throws InterruptedException {
-        return (PageStats) tt.execute(new TransactionCallback() {
+        return (PageStats) tt.execute(new TransactionCallback<Object>() {
 
             public Object doInTransaction(TransactionStatus status) {
                 if (log.isDebugEnabled()) {

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
@@ -185,6 +185,17 @@ public class SQLDialect {
 
         return sb.toString();
     }
+    public String getLayerParametersDeletionStatement(String schema, String layerNameParam,
+            String parametersIdParam) {
+        StringBuilder sb = new StringBuilder("DELETE FROM ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILESET WHERE LAYER_NAME = :").append(layerNameParam);
+        sb.append(" AND PARAMETERS_ID = :").append(parametersIdParam);
+
+        return sb.toString();
+    }
 
     public String getTileSetsQuery(String schema) {
         StringBuilder sb = new StringBuilder(
@@ -257,6 +268,15 @@ public class SQLDialect {
             sb.append(schema).append(".");
         }
         sb.append("TILESET WHERE GRIDSET_ID = :").append(gridsetIdParam);
+        return sb.toString();
+    }
+    
+    public String getUsedQuotaByParametersId(String schema, String parametersIdParam) {
+        StringBuilder sb = new StringBuilder("SELECT SUM(BYTES) FROM ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILESET WHERE PARAMETERS_ID = :").append(parametersIdParam);
         return sb.toString();
     }
 

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
@@ -56,6 +56,7 @@ public class SQLDialect {
     protected static final int TILESET_KEY_SIZE = 320;
     protected static final int TILEPAGE_KEY_SIZE = TILESET_KEY_SIZE;
     
+    @SuppressWarnings("serial")
     protected final Map<String, List<String>> TABLE_CREATION_MAP = new LinkedHashMap<String, List<String>>() {
         {
 
@@ -185,6 +186,7 @@ public class SQLDialect {
 
         return sb.toString();
     }
+    
     public String getLayerParametersDeletionStatement(String schema, String layerNameParam,
             String parametersIdParam) {
         StringBuilder sb = new StringBuilder("DELETE FROM ");

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -1,5 +1,9 @@
 package org.geowebcache.diskquota.jdbc;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.sql.DataSource;
 
@@ -25,6 +31,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+
+import org.easymock.Capture;
 import org.easymock.classextension.EasyMock;
 import org.geowebcache.config.Configuration;
 import org.geowebcache.config.XMLConfiguration;
@@ -40,10 +48,17 @@ import org.geowebcache.diskquota.storage.TilePage;
 import org.geowebcache.diskquota.storage.TilePageCalculator;
 import org.geowebcache.diskquota.storage.TileSet;
 import org.geowebcache.diskquota.storage.TileSetVisitor;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.storage.DefaultStorageFinder;
+import org.geowebcache.storage.StorageBroker;
+import org.junit.Assert;
+
+import com.google.common.base.Objects;
+
+import org.hamcrest.Matchers;
 
 public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
 
@@ -60,6 +75,8 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
     private BasicDataSource dataSource;
 
     private TileSet testTileSet;
+
+    private StorageBroker storageBroker;
 
 
     protected abstract SQLDialect getDialect();
@@ -122,6 +139,12 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         return true;
     }
     
+    Map<String, Set<String>> parameterIdsMap;
+    Map<String, Set<Map<String, String>>> parametersMap;
+
+    private Collection<TileSet> expectedTileSets;
+
+    private String[] paramIds;
     
     @Override
     protected void setUpInternal() throws Exception {
@@ -143,13 +166,33 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         configList.add(xmlConfig);
 
         layerDispatcher = new TileLayerDispatcher(new GridSetBroker(true, true), configList);
-
+        Capture<String> layerNameCap = new Capture<>();
+        storageBroker = EasyMock.createMock(StorageBroker.class);
+        EasyMock.expect(storageBroker.getCachedParameterIds(EasyMock.capture(layerNameCap)))
+            .andStubAnswer(()->parameterIdsMap.getOrDefault(
+                    layerNameCap.getValue(),
+                    Collections.singleton(null)));
+        EasyMock.replay(storageBroker);
+        parametersMap = new HashMap<>();
+        parametersMap.put("topp:states", Stream.of(
+                "STYLE=&SOMEPARAMETER=",
+                "STYLE=population&SOMEPARAMETER=2.0")
+                    .map(ParametersUtils::getMap)
+                    .collect(Collectors.toSet()));
+        parameterIdsMap= parametersMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, 
+                        e->e.getValue().stream()
+                            .map(ParametersUtils::getKvp)
+                            .collect(Collectors.toSet())
+                        ));
+        
         // add extra tests gwc configuration
         InputStream input = this.getClass().getClassLoader().getResourceAsStream("gwc-test-config.xml");
         XMLConfiguration extraConfig = new XMLConfiguration(input);
         layerDispatcher.addConfiguration(extraConfig);
 
-        tilePageCalculator = new TilePageCalculator(layerDispatcher);
+        tilePageCalculator = new TilePageCalculator(layerDispatcher, storageBroker);
 
         // prepare a connection pool for tests against a H2 database
         dataSource = getDataSource();
@@ -164,6 +207,33 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         store.initialize();
 
         testTileSet = tilePageCalculator.getTileSetsFor("topp:states2").iterator().next();
+        
+        paramIds = parameterIdsMap.get("topp:states").toArray(new String[2]);
+        
+        expectedTileSets = Arrays.asList(
+                new TileSet("topp:states", "EPSG:900913", "image/png", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "image/jpeg", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "image/gif", paramIds[0]),
+                new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/png", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/jpeg", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "image/gif", paramIds[0]),
+                new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml", paramIds[0]),
+                
+                new TileSet("topp:states", "EPSG:900913", "image/png", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "image/jpeg", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "image/gif", paramIds[1]),
+                new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/png", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/jpeg", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "image/gif", paramIds[1]),
+                new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml",  paramIds[1]),
+                
+                new TileSet("topp:states2", "EPSG:2163", "image/png", null),
+                new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null),
+                new TileSet("topp:states3", "EPSG:4326", "image/png", null),
+                new TileSet("topp:states3", "EPSG:2163", "image/png", null)
+                );
     }
 
     
@@ -198,62 +268,16 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         assertEquals(0, global.getBytes().longValue());
 
         Set<TileSet> tileSets = store.getTileSets();
-        // two formats for topp:states2, four formats and two tilesets for topp:states, one format and two tilesets for topp:states3
+
         assertNotNull(tileSets);
-        assertEquals(12, tileSets.size());
-
-        // check every possibility
-        TileSet tileSet = new TileSet("topp:states", "EPSG:900913", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "image/gif", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:900913", "application/vnd.google-earth.kml+xml",
-                null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "image/gif", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states", "EPSG:4326", "application/vnd.google-earth.kml+xml",
-                null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/jpeg", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        // validate layer topp:states3
-
-        tileSet = new TileSet("topp:states3", "EPSG:4326", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
-
-        tileSet = new TileSet("topp:states3", "EPSG:2163", "image/png", null);
-        assertTrue(tileSets.contains(tileSet));
-        assertQuotaZero(tileSet);
+        assertEquals(expectedTileSets.size(), tileSets.size());
+        
+        String[] paramIds = parameterIdsMap.get("topp:states").toArray(new String[2]);
+        
+        for(TileSet tileSet : expectedTileSets) {
+            assertTrue(tileSets.contains(tileSet));
+            assertQuotaZero(tileSet);
+        }
 
         // check the layer wide quotas
         assertQuotaZero("topp:states");
@@ -274,7 +298,7 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         tileSets = store.getTileSets();
         assertNotNull(tileSets);
         assertEquals(4, tileSets.size());
-        tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
+        TileSet tileSet = new TileSet("topp:states2", "EPSG:2163", "image/png", null);
         assertTrue(tileSets.contains(tileSet));
         assertQuotaZero(tileSet);
 
@@ -284,10 +308,10 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
     }
 
     public void testRenameLayer() throws InterruptedException {
-        assertEquals(8, countTileSetsByLayerName("topp:states"));
+        assertEquals(16, countTileSetsByLayerName("topp:states"));
         store.renameLayer("topp:states", "states_renamed");
         assertEquals(0, countTileSetsByLayerName("topp:states"));
-        assertEquals(8, countTileSetsByLayerName("states_renamed"));
+        assertEquals(16, countTileSetsByLayerName("states_renamed"));
     }
 
     public void testRenameLayer2() throws InterruptedException {
@@ -326,10 +350,10 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         // put some data into four gridsets using two layers
         String layerName1 = "topp:states";
         String layerName2 = "topp:states3";
-        TileSet tset1 = new TileSet(layerName1, "EPSG:4326", "image/jpeg", null);
-        TileSet tset2 = new TileSet(layerName1, "EPSG:900913", "image/jpeg", null);
+        TileSet tset1 = new TileSet(layerName1, "EPSG:4326", "image/jpeg", paramIds[0]);
+        TileSet tset2 = new TileSet(layerName1, "EPSG:900913", "image/jpeg", paramIds[0]);
         TileSet tset3 = new TileSet(layerName2, "EPSG:4326", "image/png", null);
-        TileSet tset4 = new TileSet(layerName1, "EPSG:4326", "image/png", null);
+        TileSet tset4 = new TileSet(layerName1, "EPSG:4326", "image/png", paramIds[0]);
         addToQuotaStore(tset1);
         addToQuotaStore(tset2);
         addToQuotaStore(tset3);
@@ -347,11 +371,23 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         sum.add(tset3Quota);
         sum.add(tset4Quota);
         assertEquals(globalQuota.getBytes(), sum.getBytes());
-        // delete sub gridset 4326 of layer topp:states
-        assertEquals(8, countTileSetsByLayerName("topp:states"));
-        store.deleteGridSubset("topp:states", "EPSG:4326");
-        assertEquals(4, countTileSetsByLayerName("topp:states"));
-        assertEquals(2, countTileSetsByLayerName("topp:states3"));
+        
+        assertThat(store.getTileSets(), 
+                containsInAnyOrder(
+                        expectedTileSets.stream()
+                            .map(Matchers::equalTo)
+                            .collect(Collectors.toSet())));
+        
+        store.deleteGridSubset(layerName1, "EPSG:4326");
+        
+        assertThat(store.getTileSets(), 
+                containsInAnyOrder(
+                        expectedTileSets.stream()
+                            .filter(ts->!(ts.getGridsetId().equals("EPSG:4326") 
+                                    && ts.getLayerName().equals(layerName1)))
+                            .map(Matchers::equalTo)
+                            .collect(Collectors.toSet())));
+        
         // verify the quota for tset2 got erased and that now the total is equal to tset1
         Quota newTset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
         Quota newTset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
@@ -372,7 +408,51 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         // test the global quota
         globalQuota = store.getGloballyUsedQuota();
         assertEquals(tset2Quota.getBytes().add(tset3Quota.getBytes()), globalQuota.getBytes());
+
     }
+    
+    public void testDeleteParameters() throws InterruptedException {
+        // put some data into the two parameterizations
+        String layerName = "topp:states";
+        TileSet tset1 = new TileSet(layerName, "EPSG:4326", "image/jpeg", paramIds[0]);
+        addToQuotaStore(tset1);
+        TileSet tset2 = new TileSet(layerName, "EPSG:4326", "image/jpeg", paramIds[1]);
+        addToQuotaStore(tset2);
+        Quota tset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
+        Quota tset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
+        Quota globalQuota = store.getGloballyUsedQuota();
+        Quota sum = new Quota();
+        sum.add(tset1Quota);
+        sum.add(tset2Quota);
+        assertEquals(globalQuota.getBytes(), sum.getBytes());
+        
+        assertThat(store.getTileSets(), 
+                containsInAnyOrder(
+                        expectedTileSets.stream()
+                            .map(Matchers::equalTo)
+                            .collect(Collectors.toSet())));
+        
+        store.deleteParameters("topp:states", paramIds[1]);
+        
+        assertThat(store.getTileSets(), 
+                containsInAnyOrder(
+                        expectedTileSets.stream()
+                            .filter(ts->!(Objects.equal(ts.getParametersId(), paramIds[1]) 
+                                    && ts.getLayerName().equals(layerName)))
+                            .map(Matchers::equalTo)
+                            .collect(Collectors.toSet())));
+        
+        // verify the quota for tset2 got erased and that now the total is equal to tset1
+        tset1Quota = store.getUsedQuotaByTileSetId(tset1.getId());
+        tset2Quota = store.getUsedQuotaByTileSetId(tset2.getId());
+        
+        assertNotNull(tset2Quota);
+        assertEquals(new BigInteger("0"), tset2Quota.getBytes());
+        globalQuota = store.getGloballyUsedQuota();
+        assertEquals(tset1Quota.getBytes(), globalQuota.getBytes());
+
+    }
+
 
     private void addToQuotaStore(TileSet tset) throws InterruptedException {
         Quota quotaDiff = new Quota(5, StorageUnit.MiB);

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -1,7 +1,6 @@
 package org.geowebcache.diskquota.jdbc;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -51,10 +50,8 @@ import org.geowebcache.diskquota.storage.TileSetVisitor;
 import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
-import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.storage.StorageBroker;
-import org.junit.Assert;
 
 import com.google.common.base.Objects;
 
@@ -272,8 +269,6 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         assertNotNull(tileSets);
         assertEquals(expectedTileSets.size(), tileSets.size());
         
-        String[] paramIds = parameterIdsMap.get("topp:states").toArray(new String[2]);
-        
         for(TileSet tileSet : expectedTileSets) {
             assertTrue(tileSets.contains(tileSet));
             assertQuotaZero(tileSet);
@@ -326,7 +321,7 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         TilePage page = new TilePage(tileSet.getId(), 0, 0, (byte) 0);
         store.addHitsAndSetAccesTime(Collections.singleton(new PageStatsPayload(page)));
         store.addToQuotaAndTileCounts(tileSet, new Quota(BigInteger.valueOf(1024)),
-                Collections.EMPTY_LIST);
+                Collections.emptyList());
 
         Quota expectedQuota = store.getUsedQuotaByLayerName(oldLayerName);
         assertEquals(1024L, expectedQuota.getBytes().longValue());
@@ -560,10 +555,9 @@ public abstract class JDBCQuotaStoreTest extends OnlineTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public void testUpdateUsedQuotaWithParameters() throws Exception {
         // prepare a tileset with params
-        String paramId = DigestUtils.shaHex("&styles=polygon");
+        String paramId = DigestUtils.sha1Hex("&styles=polygon");
         TileSet tset = new TileSet("topp:states2", "EPSG:2163", "image/jpeg", paramId);
 
         Quota quotaDiff = new Quota(10D * Math.random(), StorageUnit.MiB);

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/MassTruncateRestlet.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/MassTruncateRestlet.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
-import org.geowebcache.config.Configuration;
 import org.geowebcache.io.GeoWebCacheXStream;
 import org.geowebcache.rest.RestletException;
 import org.geowebcache.seed.MassTruncateRequest;
@@ -47,7 +46,6 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
     private static Log log = LogFactory.getLog(MassTruncateRestlet.class);
 
     private StorageBroker broker;
-    private Configuration config;
     private TileBreeder breeder;
     
     static final Class<?>[] DEFAULT_REQUEST_TYPES = {
@@ -95,7 +93,7 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
     protected void handleRequest(Request req, Response resp, Object obj) {
         MassTruncateRequest mtr = (MassTruncateRequest) obj;
         try {
-            if(!mtr.doTruncate(broker, getConfiguration(), breeder)) {
+            if(!mtr.doTruncate(broker, breeder)) {
                 throw new RestletException("Truncation failed", Status.SERVER_ERROR_INTERNAL);
             }
         } catch (IllegalArgumentException e) {
@@ -111,18 +109,11 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
         this.broker = broker;
     }
     
-    public void setConfiguration(Configuration config) {
-        this.config = config;
-    }
     
     public void setTileBreeder(TileBreeder breeder) {
         this.breeder = breeder;
     }
     
-    public Configuration getConfiguration() {
-        if(this.config==null) return this.xmlConfig;
-        return this.config;
-    }
 
     protected Class<?>[] getRequestTypes() {
         if(requestTypes==null) requestTypes=DEFAULT_REQUEST_TYPES;

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/MassTruncateRestlet.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/seed/MassTruncateRestlet.java
@@ -22,11 +22,16 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.Configuration;
 import org.geowebcache.io.GeoWebCacheXStream;
 import org.geowebcache.rest.RestletException;
 import org.geowebcache.seed.MassTruncateRequest;
+import org.geowebcache.seed.TileBreeder;
+import org.geowebcache.seed.TruncateBboxRequest;
 import org.geowebcache.seed.TruncateLayerRequest;
+import org.geowebcache.seed.TruncateOrphansRequest;
+import org.geowebcache.seed.TruncateParametersRequest;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 import org.restlet.data.MediaType;
@@ -43,8 +48,14 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
 
     private StorageBroker broker;
     private Configuration config;
+    private TileBreeder breeder;
     
-    static final Class<?>[] DEFAULT_REQUEST_TYPES = {TruncateLayerRequest.class};
+    static final Class<?>[] DEFAULT_REQUEST_TYPES = {
+            TruncateLayerRequest.class, 
+            TruncateParametersRequest.class,
+            TruncateOrphansRequest.class,
+            TruncateBboxRequest.class
+            };
 
     Class<?>[] requestTypes;
     
@@ -84,12 +95,14 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
     protected void handleRequest(Request req, Response resp, Object obj) {
         MassTruncateRequest mtr = (MassTruncateRequest) obj;
         try {
-            if(!mtr.doTruncate(broker, config)) {
+            if(!mtr.doTruncate(broker, getConfiguration(), breeder)) {
                 throw new RestletException("Truncation failed", Status.SERVER_ERROR_INTERNAL);
             }
         } catch (IllegalArgumentException e) {
             throw new RestletException(e.getMessage(), Status.CLIENT_ERROR_BAD_REQUEST);
         } catch (StorageException e) {
+            throw new RestletException(e.getMessage(), Status.SERVER_ERROR_INTERNAL);
+        } catch (GeoWebCacheException e) {
             throw new RestletException(e.getMessage(), Status.SERVER_ERROR_INTERNAL);
         }
     }
@@ -100,6 +113,10 @@ public class MassTruncateRestlet extends GWCSeedingRestlet {
     
     public void setConfiguration(Configuration config) {
         this.config = config;
+    }
+    
+    public void setTileBreeder(TileBreeder breeder) {
+        this.breeder = breeder;
     }
     
     public Configuration getConfiguration() {

--- a/geowebcache/s3storage/pom.xml
+++ b/geowebcache/s3storage/pom.xml
@@ -41,6 +41,27 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymockclassextension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-core</artifactId>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
@@ -17,22 +17,28 @@
 package org.geowebcache.s3;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.isNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileLayerDispatcher;
@@ -63,7 +69,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Function;
+import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
@@ -170,7 +178,9 @@ public class S3BlobStore implements BlobStore {
 
         log.trace(log.isTraceEnabled() ? ("Storing " + key) : "");
         s3Ops.putObject(putObjectRequest);
-
+        
+        putParametersMetadata(obj.getLayerName(), obj.getParametersId(), obj.getParameters());
+        
         /*
          * This is important because listeners may be tracking tile existence
          */
@@ -399,11 +409,71 @@ public class S3BlobStore implements BlobStore {
         String key = keyBuilder.layerMetadata(layerName);
         return s3Ops.getProperties(key);
     }
+    
+    private void putParametersMetadata(String layerName, String parametersId, Map<String, String> parameters) {
+        assert(isNull(parametersId)==isNull(parameters));
+        if(isNull(parametersId)) {
+            return;
+        }
+        Properties properties = new Properties();
+        parameters.forEach(properties::setProperty);
+        String resourceKey = keyBuilder.parametersMetadata(layerName, parametersId);
+        try {
+            s3Ops.putProperties(resourceKey, properties);
+        } catch (StorageException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    private Properties getParametersMetadata(String layerName, String parametersId) {
+        String key = keyBuilder.parametersMetadata(layerName, parametersId);
+        return s3Ops.getProperties(key);
+    }
 
     @Override
     public boolean layerExists(String layerName) {
         final String coordsPrefix = keyBuilder.forLayer(layerName);
         boolean layerExists = s3Ops.prefixExists(coordsPrefix);
         return layerExists;
+    }
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        checkNotNull(layerName, "layerName");
+        checkNotNull(parametersId, "parametersId");
+        
+        boolean prefixExists = keyBuilder.forParameters(layerName, parametersId).stream()
+            .map(prefix->{
+                try {
+                    return s3Ops.scheduleAsyncDelete(prefix);
+                } catch (RuntimeException|GeoWebCacheException e) {
+                    throw Throwables.propagate(e);
+                }
+            })
+            .reduce(Boolean::logicalOr) // Don't use Stream.anyMatch as it would short circuit
+            .orElse(false);
+        if (prefixExists) {
+            listeners.sendParametersDeleted(layerName, parametersId);
+        }
+        return prefixExists;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Set<Map<String, String>> getParameters(String layerName) {
+        return s3Ops.objectStream(keyBuilder.parametersMetadataPrefix(layerName))
+            .map(S3ObjectSummary::getKey)
+            .map(s3Ops::getProperties)
+            .map(props->(Map<String,String>)(Map<?,?>)props)
+            .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String,Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        return s3Ops.objectStream(keyBuilder.parametersMetadataPrefix(layerName))
+            .map(S3ObjectSummary::getKey)
+            .map(s3Ops::getProperties)
+            .map(props->(Map<String,String>)(Map<?,?>)props)
+            .collect(Collectors.toMap(ParametersUtils::getId, Optional::of));
     }
 }

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -55,10 +54,6 @@ import org.geowebcache.storage.TileRangeIterator;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.Protocol;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -71,7 +66,6 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
@@ -425,17 +419,13 @@ public class S3BlobStore implements BlobStore {
         }
     }
 
-    private Properties getParametersMetadata(String layerName, String parametersId) {
-        String key = keyBuilder.parametersMetadata(layerName, parametersId);
-        return s3Ops.getProperties(key);
-    }
-
     @Override
     public boolean layerExists(String layerName) {
         final String coordsPrefix = keyBuilder.forLayer(layerName);
         boolean layerExists = s3Ops.prefixExists(coordsPrefix);
         return layerExists;
     }
+    
     @Override
     public boolean deleteByParametersId(String layerName, String parametersId)
             throws StorageException {

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.s3;
 
 import static org.easymock.EasyMock.eq;

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
@@ -1,0 +1,57 @@
+package org.geowebcache.s3;
+
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.classextension.EasyMock.createMock;
+import static org.easymock.classextension.EasyMock.createNiceMock;
+import static org.easymock.classextension.EasyMock.replay;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.NoOpLockProvider;
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Rule;
+
+import org.easymock.classextension.EasyMock;
+
+public class S3BlobStoreConformanceTest extends AbstractBlobStoreTest<S3BlobStore> {
+    public PropertiesLoader testConfigLoader = new PropertiesLoader();
+    
+    @Rule
+    public TemporaryS3Folder tempFolder = new TemporaryS3Folder(testConfigLoader.getProperties());
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        Assume.assumeTrue(tempFolder.isConfigured());
+        S3BlobStoreConfig config = tempFolder.getConfig();
+        
+        TileLayerDispatcher layers = createMock(TileLayerDispatcher.class);
+        LockProvider lockProvider = new NoOpLockProvider();
+        Stream.of("testLayer", "testLayer1", "testLayer2")
+            .map(name-> {
+                TileLayer mock = createMock(name, TileLayer.class);
+                expect(mock.getName()).andStubReturn(name);
+                expect(mock.getId()).andStubReturn(name);
+                expect(mock.getGridSubsets()).andStubReturn(Collections.singleton("testGridSet"));
+                expect(mock.getMimeTypes()).andStubReturn(Arrays.asList(org.geowebcache.mime.ImageMime.png));
+                try {
+                    expect(layers.getTileLayer(eq(name))).andStubReturn(mock);
+                } catch (GeoWebCacheException e) {
+                    fail();
+                }
+                return mock;
+            }).forEach(EasyMock::replay);
+        replay(layers);
+        store = new S3BlobStore(config, layers, lockProvider);
+    }
+
+}

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
@@ -20,7 +20,6 @@ package org.geowebcache.s3;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.classextension.EasyMock.createMock;
-import static org.easymock.classextension.EasyMock.createNiceMock;
 import static org.easymock.classextension.EasyMock.replay;
 import static org.junit.Assert.fail;
 
@@ -34,7 +33,6 @@ import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.locks.NoOpLockProvider;
 import org.geowebcache.storage.AbstractBlobStoreTest;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
 

--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -34,6 +34,12 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
+            <groupId>org.geowebcache</groupId>
+            <artifactId>gwc-core</artifactId>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -61,6 +67,16 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.easymock</groupId>
+          <artifactId>easymock</artifactId>
+          <scope>test</scope>
+          </dependency>
+        <dependency>
+          <groupId>org.easymock</groupId>
+          <artifactId>easymockclassextension</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
@@ -21,9 +21,6 @@ import org.geowebcache.storage.AbstractBlobStoreTest;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-
 public class MbtilesBlobStoreConformanceTest extends AbstractBlobStoreTest<MbtilesBlobStore> {
     
     @Rule

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
@@ -1,0 +1,29 @@
+package org.geowebcache.sqlite;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+
+public class MbtilesBlobStoreConformanceTest extends AbstractBlobStoreTest<MbtilesBlobStore> {
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        this.store = new MbtilesBlobStore(getDefaultConfiguration());
+    }
+    
+    protected MbtilesConfiguration getDefaultConfiguration() {
+        MbtilesConfiguration configuration = new MbtilesConfiguration();
+        configuration.setPoolSize(1000);
+        configuration.setRootDirectory(temp.getRoot().getPath());
+        configuration.setTemplatePath(Utils.buildPath("{grid}", "{layer}", "{params}", "{format}", "{z}", "tiles-{x}-{y}.sqlite"));
+        configuration.setRowRangeCount(500);
+        configuration.setColumnRangeCount(500);
+        return configuration;
+    }
+}

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/MbtilesBlobStoreConformanceTest.java
@@ -1,3 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, 2017
+ */
+
 package org.geowebcache.sqlite;
 
 import org.geowebcache.storage.AbstractBlobStoreTest;

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqlitlePerf.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqlitlePerf.java
@@ -19,6 +19,7 @@ package org.geowebcache.sqlite;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.blobstore.file.FileBlobStore;
 
@@ -226,7 +227,7 @@ final class SqlitlePerf {
         ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
         long startTime = System.currentTimeMillis();
         // instantiate the file blobstore
-        FileBlobStore fileBlobStore = new FileBlobStore(seedDirectory.getPath());
+        BlobStore fileBlobStore = new FileBlobStore(seedDirectory.getPath());
         for (int i = 0; i < tiles.length; i++) {
             long[] tile = tiles[i];
             executor.submit((Runnable) () -> {
@@ -268,7 +269,7 @@ final class SqlitlePerf {
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info(String.format("Start seeding file system '%s'.", seedDirectory));
         }
-        FileBlobStore fileBlobStore = new FileBlobStore(seedDirectory.getPath());
+        BlobStore fileBlobStore = new FileBlobStore(seedDirectory.getPath());
         // start seeding the tiles
         long startTime = System.currentTimeMillis();
         for (int i = 0; i < TILES; i++) {

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-diskquota-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-diskquota-context.xml
@@ -24,6 +24,7 @@
 
   <bean id="gwcTilePageCalculator" class="org.geowebcache.diskquota.storage.TilePageCalculator">
     <constructor-arg ref="gwcTLDispatcher" />
+    <constructor-arg ref="gwcStorageBroker" />
   </bean>
 
   <bean id="gwcCacheCleaner" class="org.geowebcache.diskquota.CacheCleaner">

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml
@@ -13,6 +13,7 @@
   <bean id="gwcMassTruncateRestlet" class="org.geowebcache.rest.seed.MassTruncateRestlet">
     <property name="xmlConfig" ref="gwcXmlConfig"/>
     <property name="storageBroker" ref="gwcStorageBroker"/>
+    <property name="tileBreeder" ref="gwcTileBreeder"/>
   </bean>
 
   <bean id="gwcSeedFormRestlet" class="org.geowebcache.rest.seed.SeedFormRestlet">


### PR DESCRIPTION
Adds the ability to track the parameter values that produced a particular parameter ID in each of the blob stores as well as the ability to delete parameters based on both ID and values.

Adds a new parameter delete event and updates each of the disk quota stores to handle it.

Adds new Mass Truncate commands to make use of this new underlying capability to delete specific parameters, automatically purge all parameters from a layer that do not match its parameter filters (#170), and to truncate tiles within a bounding box across all combinations of parameters and image formats (#359).

Expanded unit tests for blob stores to ensure consistent behaviour which uncovered unrelated bug #479 which I have also fixed.