### PR TITLE
Fix #506, use correct value for timeout between requests to back end while seeding.

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
@@ -33,6 +33,9 @@ import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.TileRange;
 import org.geowebcache.storage.TileRangeIterator;
+import org.geowebcache.util.Sleeper;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * A GWCTask for seeding/reseeding the cache.
@@ -58,7 +61,10 @@ class SeedTask extends GWCTask {
     private long totalFailuresBeforeAborting;
 
     private AtomicLong sharedFailureCounter;
-
+    
+    @VisibleForTesting
+    Sleeper sleeper = Thread::sleep;
+    
     /**
      * Constructs a SeedTask
      * @param sb
@@ -96,8 +102,7 @@ class SeedTask extends GWCTask {
         super.state = GWCTask.STATE.RUNNING;
 
         // Lower the priority of the thread
-        Thread.currentThread().setPriority(
-                (java.lang.Thread.NORM_PRIORITY + java.lang.Thread.MIN_PRIORITY) / 2);
+        reprioritize();
 
         checkInterrupted();
 
@@ -105,7 +110,7 @@ class SeedTask extends GWCTask {
         final long START_TIME = System.currentTimeMillis();
 
         final String layerName = tl.getName();
-        log.info(Thread.currentThread().getName() + " begins seeding layer : " + layerName);
+        log.info(getThreadName() + " begins seeding layer : " + layerName);
 
         TileRange tr = trIter.getTileRange();
 
@@ -147,7 +152,7 @@ class SeedTask extends GWCTask {
 
                     long sharedFailureCount = sharedFailureCounter.incrementAndGet();
                     if (sharedFailureCount >= totalFailuresBeforeAborting) {
-                        log.info("Aborting seed thread " + Thread.currentThread().getName()
+                        log.info("Aborting seed thread " + getThreadName()
                                 + ". Error count reached configured maximum of "
                                 + totalFailuresBeforeAborting);
                         super.state = GWCTask.STATE.DEAD;
@@ -161,7 +166,7 @@ class SeedTask extends GWCTask {
                         if (tileFailureRetryWaitTime > 0) {
                             log.trace("Waiting " + tileFailureRetryWaitTime
                                     + " before trying again");
-                            Thread.sleep(tileFailureRetryCount);
+                            waitToRetry();
                         }
                     } else {
                         log.info(logMsg
@@ -172,7 +177,7 @@ class SeedTask extends GWCTask {
             }
 
             if (log.isTraceEnabled()) {
-                log.trace(Thread.currentThread().getName() + " seeded " + Arrays.toString(gridLoc));
+                log.trace(getThreadName() + " seeded " + Arrays.toString(gridLoc));
             }
 
             // final long totalTilesCompleted = trIter.getTilesProcessed();
@@ -190,10 +195,10 @@ class SeedTask extends GWCTask {
         }
 
         if (this.terminate) {
-            log.info("Job on " + Thread.currentThread().getName() + " was terminated after "
+            log.info("Job on " + getThreadName() + " was terminated after "
                     + this.tilesDone + " tiles");
         } else {
-            log.info(Thread.currentThread().getName() + " completed (re)seeding layer " + layerName
+            log.info(getThreadName() + " completed (re)seeding layer " + layerName
                     + " after " + this.tilesDone + " tiles and " + this.timeSpent + " seconds.");
         }
 
@@ -203,6 +208,19 @@ class SeedTask extends GWCTask {
         }
 
         super.state = GWCTask.STATE.DONE;
+    }
+
+    private void reprioritize() {
+        Thread.currentThread().setPriority(
+                (java.lang.Thread.NORM_PRIORITY + java.lang.Thread.MIN_PRIORITY) / 2);
+    }
+
+    private void waitToRetry() throws InterruptedException {
+        sleeper.sleep(tileFailureRetryWaitTime);
+    }
+
+    private String getThreadName() {
+        return Thread.currentThread().getName();
     }
 
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/util/Sleeper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/Sleeper.java
@@ -1,0 +1,33 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Kevin Smith, Boundless, Copyright 2017
+ */
+
+package org.geowebcache.util;
+
+/**
+ * Functional interface for a sleep method. Used to allow mocking during unit
+ * tests.
+ * @see Thread.sleep
+ */
+@FunctionalInterface
+public interface Sleeper {
+    /**
+     * @see Thread.sleep
+     * @param millis
+     * @throws InterruptedException
+     */
+    public void sleep(long millis) throws InterruptedException;
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
@@ -19,8 +19,10 @@ package org.geowebcache.seed;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.classextension.EasyMock.createMock;
 import static org.easymock.classextension.EasyMock.replay;
-
+import static org.easymock.classextension.EasyMock.verify;
 import static org.geowebcache.TestHelpers.createFakeSourceImage;
 import static org.geowebcache.TestHelpers.createWMSLayer;
 import static org.geowebcache.TestHelpers.createRequest;
@@ -41,8 +43,6 @@ import junit.framework.TestCase;
 import org.easymock.Capture;
 import org.easymock.classextension.EasyMock;
 import org.geowebcache.GeoWebCacheException;
-import org.geowebcache.TestHelpers;
-import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileResponseReceiver;
@@ -56,6 +56,7 @@ import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.TileRange;
 import org.geowebcache.storage.TileRangeIterator;
 import org.geowebcache.util.MockWMSSourceHelper;
+import org.geowebcache.util.Sleeper;
 
 /**
  * Unit test suite for {@link SeedTask}
@@ -137,6 +138,11 @@ public class SeedTaskTest extends TestCase {
         SeedTask seedTask = new SeedTask(mockStorageBroker, trIter, tl, reseed, false);
         seedTask.setTaskId(1L);
         seedTask.setThreadInfo(new AtomicInteger(), 0);
+        Sleeper sleeper = createMock(Sleeper.class);
+        // Should not be called
+        replay(sleeper);
+        seedTask.sleeper = sleeper;
+        
         /*
          * HACK: avoid SeedTask.getCurrentThreadArrayIndex failure.
          */
@@ -150,6 +156,7 @@ public class SeedTaskTest extends TestCase {
         final long expectedWmsRequestsCount = 3; // due to metatiling
         final long wmsRequestCount = wmsRequestsCounter.get();
         assertEquals(expectedWmsRequestsCount, wmsRequestCount);
+        verify(sleeper);
     }
 
     /**
@@ -211,14 +218,21 @@ public class SeedTaskTest extends TestCase {
         expect(mockStorageBroker.get((TileObject) anyObject())).andReturn(false).anyTimes();
         replay(mockStorageBroker);
 
+        long tileFailureRetryWaitTime = 10;
+        int tileFailureRetryCount = 1;
+        long totalFailuresBeforeAborting = 4;
+        
         boolean reseed = false;
         SeedTask seedTask = new SeedTask(mockStorageBroker, trIter, tl, reseed, false);
         seedTask.setTaskId(1L);
         seedTask.setThreadInfo(new AtomicInteger(), 0);
-
-        int tileFailureRetryCount = 1;
-        long tileFailureRetryWaitTime = 10;
-        long totalFailuresBeforeAborting = 4;
+        Sleeper sleeper = createMock(Sleeper.class);
+        // It's only sleeping on checked exceptions, not sure if this is right or wrong.
+        // I added this to test a fix for the duration being incorrect.
+        sleeper.sleep(tileFailureRetryWaitTime);expectLastCall().times(2); 
+        replay(sleeper);
+        seedTask.sleeper = sleeper;
+        
         AtomicLong sharedFailureCounter = new AtomicLong();
         seedTask.setFailurePolicy(tileFailureRetryCount, tileFailureRetryWaitTime,
                 totalFailuresBeforeAborting, sharedFailureCounter);
@@ -232,6 +246,7 @@ public class SeedTaskTest extends TestCase {
          */
         seedTask.doAction();
         assertEquals(totalFailuresBeforeAborting, sharedFailureCounter.get());
+        verify(sleeper);
     }
 
     /**
@@ -284,6 +299,10 @@ public class SeedTaskTest extends TestCase {
         SeedTask task = new SeedTask(mockStorageBroker, trIter, tl, reseed, false);
         task.setTaskId(1L);
         task.setThreadInfo(new AtomicInteger(), 0);
+        Sleeper sleeper = createMock(Sleeper.class);
+        // Should not be called
+        replay(sleeper);
+        task.sleeper = sleeper;
         /*
          * HACK: avoid SeedTask.getCurrentThreadArrayIndex failure.
          */
@@ -328,6 +347,7 @@ public class SeedTaskTest extends TestCase {
         }
 
         assertEquals(expectedTiles, tileKeys);
+        verify(sleeper);
     }
 
     private static class Tuple<T extends Comparable<T>> implements Comparable<Tuple<T>> {


### PR DESCRIPTION
Using `GWC_SEED_RETRY_WAIT` instead of `GWC_SEED_RETRY_COUNT` for duration of timeout.

Also added an interface to allow mocking of `Thread.sleep` calls for tests.

See #506 