### PR TITLE
Accommodate new NestedBlobStore functionality around parameter based deletes

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -431,7 +431,7 @@ public class XMLConfiguration implements Configuration, InitializingBean {
             xs.allowTypesByWildcard(new String[]{"org.geowebcache.**"});
         }
         
-        xs.setMode(XStream.NO_REFERENCES);
+        xs.setMode(XStream.ID_REFERENCES);
 
         xs.addDefaultImplementation(ArrayList.class, List.class);
 

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -137,6 +137,7 @@
             <xs:sequence>
               <xs:element ref="gwc:blobstore" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
+            <xs:attribute name="id" type="xs:string"></xs:attribute>
           </xs:complexType>
         </xs:element>
         
@@ -151,6 +152,7 @@
             <xs:sequence>
               <xs:element name="gridSet" type="gwc:GridSet" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
+            <xs:attribute name="id" type="xs:string"></xs:attribute>
           </xs:complexType>
         </xs:element>
         <xs:element name="layers">
@@ -165,6 +167,7 @@
               <xs:element name="wmsLayer" type="gwc:WmsLayer" />
               <xs:element ref="gwc:arcgisLayer" />
             </xs:choice>
+            <xs:attribute name="id" type="xs:string"></xs:attribute>
           </xs:complexType>
         </xs:element>	        
       	<xs:element name="fullWMS" type="xs:boolean" minOccurs="0">
@@ -175,6 +178,7 @@
            </xs:annotation>
         </xs:element>
       </xs:sequence>
+      <xs:attribute name="id" type="xs:string"></xs:attribute>
     </xs:complexType>
   </xs:element>
 
@@ -228,6 +232,7 @@
             <xs:element name="fileSystemBlockSize" type="xs:positiveInteger" minOccurs="0" maxOccurs="1" nillable="true">
             </xs:element>
           </xs:sequence>
+          <xs:attribute name="id" type="xs:string"></xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -614,8 +619,6 @@
           <xs:element name="wmsVersion" minOccurs="0">
             <xs:annotation>
               <xs:documentation xml:lang="en">
-                The VERSION parameter sent to the WMS backend.
-                The default is 1.1.1
               </xs:documentation>
             </xs:annotation>
             <xs:simpleType>
@@ -725,6 +728,7 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
+      <xs:attribute name="id" type="xs:string"></xs:attribute>
      </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -839,12 +843,14 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="MimeFormats">
     <xs:sequence>
       <xs:element name="string" type="xs:string" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="Srs">
@@ -857,6 +863,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="GridSet">
@@ -1022,12 +1029,14 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="GridSubsets">
     <xs:sequence>
       <xs:element name="gridSubset" type="gwc:GridSubset" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="GridSubset">
@@ -1092,30 +1101,36 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="Bounds">
     <xs:sequence>
       <xs:element name="coords" type="gwc:coords" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="coords">
     <xs:sequence>
       <xs:element name="double" type="xs:double" minOccurs="4" maxOccurs="4" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="WmsUrl">
     <xs:sequence>
       <xs:element name="string" type="xs:string" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="MetaWidthHeight">
     <xs:sequence>
       <xs:element name="int" type="xs:integer" minOccurs="2" maxOccurs="2" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ParameterFilters">
@@ -1144,6 +1159,7 @@
         </xs:element>
       </xs:choice>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="RegexParameterFilter">
@@ -1188,6 +1204,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="FloatParameterFilter">
@@ -1236,6 +1253,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="IntegerParameterFilter">
@@ -1325,6 +1343,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="CaseNormalize">
@@ -1350,24 +1369,28 @@
     <xs:sequence>
       <xs:element name="double" type="xs:double" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="FloatList">
     <xs:sequence>
       <xs:element name="float" type="xs:float" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="IntegerList">
     <xs:sequence>
       <xs:element name="int" type="xs:integer" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="StringList">
     <xs:sequence>
       <xs:element name="string" type="xs:string" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="formatModifiers">
@@ -1381,6 +1404,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="FormatModifier">
@@ -1443,6 +1467,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="RequestFilters">
@@ -1481,6 +1506,7 @@
         </xs:annotation>
       </xs:element>
     </xs:choice>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="circularExtentFilter">
@@ -1495,6 +1521,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="WmsRasterFilter">
@@ -1596,6 +1623,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="FileRasterFilter">
@@ -1689,6 +1717,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ExpireList">
@@ -1703,11 +1732,13 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ExpirationRule">
     <xs:attribute name="minZoom" type="xs:int" />
     <xs:attribute name="expiration" type="xs:int" />
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="DEPRECATEDgrids">
@@ -1942,6 +1973,7 @@
       </xs:element>
     </xs:sequence>
 
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="KeywordsType">
@@ -1954,6 +1986,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ServiceProviderType">
@@ -1980,6 +2013,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="ServiceContactType">
@@ -2062,6 +2096,7 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
   <xs:complexType name="legendType" mixed="true">
     <xs:sequence>
@@ -2154,5 +2189,6 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="id" type="xs:string"></xs:attribute>
   </xs:complexType>
 </xs:schema>

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
@@ -110,10 +110,10 @@ public class FloatParameterFilterTest {
     
     @Test
     public void testToXML() throws Exception {
-        XMLAssert.assertXMLEqual("<floatParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<floatParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
-                "  <values>\n"+
+                "  <values id=\"2\">\n"+
                 "    <float>42.0</float>\n"+
                 "    <float>6.283</float>\n"+
                 "    <float>-17.5</float>\n"+

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
@@ -119,10 +119,10 @@ public class IntegerParameterFilterTest {
     
     @Test
     public void testToXML() throws Exception {
-        XMLAssert.assertXMLEqual("<integerParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<integerParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
-                "  <values>\n"+
+                "  <values id=\"2\">\n"+
                 "    <int>42</int>\n"+
                 "    <int>2</int>\n"+
                 "    <int>0</int>\n"+

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
@@ -173,7 +173,7 @@ public class RegexParameterFilterTest {
     }
     @Test
     public void testToXMLNullNormalizer() throws Exception {
-        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<regexParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
                 "  <regex>foo|Bar|BAZ</regex>\n"+
@@ -183,10 +183,10 @@ public class RegexParameterFilterTest {
     @Test
     public void testToXMLDefaultNormalizer() throws Exception {
         filter.setNormalize(new CaseNormalizer());
-        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<regexParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
-                "  <normalize/>\n"+
+                "  <normalize id=\"2\"/>\n"+
                 "  <regex>foo|Bar|BAZ</regex>\n"+
                 "</regexParameterFilter>", xs.toXML(filter));
     }
@@ -194,10 +194,10 @@ public class RegexParameterFilterTest {
     @Test
     public void testToXMLNoneNormalizer() throws Exception {
         filter.setNormalize(new CaseNormalizer(Case.NONE));
-        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<regexParameterFilter id=\"1\">\n"+
                                  "  <key>TEST</key>\n"+
                                  "  <defaultValue>Default</defaultValue>\n"+
-                                 "  <normalize>\n"+
+                                 "  <normalize id=\"2\">\n"+
                                  "    <case>NONE</case>\n"+
                                  "  </normalize>\n"+
                                  "  <regex>foo|Bar|BAZ</regex>\n"+
@@ -207,12 +207,12 @@ public class RegexParameterFilterTest {
     @Test
     public void testToXMLUpperCanadianEnglish() throws Exception {
         filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.CANADA));
-        XMLAssert.assertXMLEqual("<regexParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<regexParameterFilter id=\"1\">\n"+
                                  "  <key>TEST</key>\n"+
                                  "  <defaultValue>Default</defaultValue>\n"+
-                                 "  <normalize>\n"+
+                                 "  <normalize id=\"2\">\n"+
                                  "    <case>UPPER</case>\n"+
-                                 "    <locale>en_CA</locale>\n"+
+                                 "    <locale id=\"3\">en_CA</locale>\n"+
                                  "  </normalize>\n"+
                                  "  <regex>foo|Bar|BAZ</regex>\n"+
                                  "</regexParameterFilter>", xs.toXML(filter));

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
@@ -173,10 +173,10 @@ public class StringParameterFilterTest {
     
     @Test
     public void testToXMLNullNormalizer() throws Exception {
-        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<stringParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
-                "  <values>\n"+
+                "  <values id=\"2\">\n"+
                 "    <string>foo</string>\n"+
                 "    <string>Bar</string>\n"+
                 "    <string>BAZ</string>\n"+
@@ -187,11 +187,11 @@ public class StringParameterFilterTest {
     @Test
     public void testToXMLDefaultNormalizer() throws Exception {
         filter.setNormalize(new CaseNormalizer());
-        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<stringParameterFilter id=\"1\">\n"+
                 "  <key>TEST</key>\n"+
                 "  <defaultValue>Default</defaultValue>\n"+
-                "  <normalize/>\n"+
-                "  <values>\n"+
+                "  <normalize id=\"2\"/>\n"+
+                "  <values id=\"3\">\n"+
                 "    <string>foo</string>\n"+
                 "    <string>Bar</string>\n"+
                 "    <string>BAZ</string>\n"+
@@ -202,13 +202,13 @@ public class StringParameterFilterTest {
     @Test
     public void testToXMLNoneNormalizer() throws Exception {
         filter.setNormalize(new CaseNormalizer(Case.NONE));
-        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<stringParameterFilter id=\"1\">\n"+
                                  "  <key>TEST</key>\n"+
                                  "  <defaultValue>Default</defaultValue>\n"+
-                                 "  <normalize>\n"+
+                                 "  <normalize id=\"2\">\n"+
                                  "    <case>NONE</case>\n"+
                                  "  </normalize>\n"+
-                                 "  <values>\n"+
+                                 "  <values id=\"3\">\n"+
                                  "    <string>foo</string>\n"+
                                  "    <string>Bar</string>\n"+
                                  "    <string>BAZ</string>\n"+
@@ -219,14 +219,14 @@ public class StringParameterFilterTest {
     @Test
     public void testToXMLUpperCanadianEnglish() throws Exception {
         filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.CANADA));
-        XMLAssert.assertXMLEqual("<stringParameterFilter>\n"+
+        XMLAssert.assertXMLEqual("<stringParameterFilter id=\"1\">\n"+
                                  "  <key>TEST</key>\n"+
                                  "  <defaultValue>Default</defaultValue>\n"+
-                                 "  <normalize>\n"+
+                                 "  <normalize id=\"2\">\n"+
                                  "    <case>UPPER</case>\n"+
-                                 "    <locale>en_CA</locale>\n"+
+                                 "    <locale id=\"3\">en_CA</locale>\n"+
                                  "  </normalize>\n"+
-                                 "  <values>\n"+
+                                 "  <values id=\"4\">\n"+
                                  "    <string>foo</string>\n"+
                                  "    <string>Bar</string>\n"+
                                  "    <string>BAZ</string>\n"+

--- a/geowebcache/nestedstorage/pom.xml
+++ b/geowebcache/nestedstorage/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geowebcache</groupId>
+    <artifactId>geowebcache</artifactId>
+    <version>1.12-SNAPSHOT</version>
+  </parent>
+  <groupId>org.geowebcache</groupId>
+  <artifactId>gwc-nestedstorage</artifactId>
+  <name>gwc-nestedstorage</name>
+  <url>http://geowebcache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-core</artifactId>
+      <scope>compile</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-core</artifactId>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymockclassextension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+  </dependencies>
+  <description>A Module to allow you to configure geowebcache with a layered blobstorage configuration.  This allows you to make use of cheap/relatively fast local storage such as AWS ephemeral drives alongside scalable cheap persistent storage such as AWS S3.  </description>
+</project>

--- a/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStore.java
+++ b/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStore.java
@@ -1,0 +1,177 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Stuart Adam, Ordnance Survey, Copyright 2017
+ */
+package org.geowebcache.nested;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.BlobStoreListener;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+
+public class NestedBlobStore implements BlobStore {
+
+    private BlobStore frontStore;
+
+    private BlobStore backingStore;
+
+    public NestedBlobStore(NestedBlobStoreConfig config) {
+        setFrontStore(config.getFrontStore());
+        setBackingStore(config.getBackingStore());
+    }
+
+    public void setFrontStore(BlobStore frontStore) {
+        this.frontStore = frontStore;
+    }
+
+    public void setBackingStore(BlobStore backingStore) {
+        this.backingStore = backingStore;
+    }
+
+    @Override
+    public boolean deleteByGridsetId(String layerName, String gridSetId) throws StorageException {
+        boolean ret = false;
+        try {
+            ret = backingStore.deleteByGridsetId(layerName, gridSetId);
+        } finally {
+            frontStore.deleteByGridsetId(layerName, gridSetId);
+        }
+        return ret;
+    }
+    
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        boolean ret = false;
+        try {
+            ret = backingStore.deleteByParametersId(layerName, parametersId);
+        } finally {
+            frontStore.deleteByParametersId(layerName, parametersId);
+        }
+        return ret;
+    }
+
+    @Override
+    public boolean delete(String layerName) throws StorageException {
+        boolean ret = false;
+        try {
+            ret = backingStore.delete(layerName);
+        } finally {
+            frontStore.delete(layerName);
+        }
+        return ret;
+    }
+
+    @Override
+    public boolean delete(TileObject obj) throws StorageException {
+        boolean ret = false;
+        try {
+            ret = backingStore.delete(obj);
+        } finally {
+            frontStore.delete(obj);
+        }
+        return ret;
+    }
+
+    @Override
+    public boolean delete(TileRange obj) throws StorageException {
+        boolean ret = false;
+        try {
+            ret = backingStore.delete(obj);
+        } finally {
+            frontStore.delete(obj);
+        }
+        return ret;
+    }
+
+    @Override
+    public boolean get(TileObject obj) throws StorageException {
+        boolean answer = frontStore.get(obj);
+        if (!answer) {
+            answer = backingStore.get(obj);
+            if (answer) {
+                frontStore.put(obj);
+            }
+        }
+        return answer;
+    }
+
+    @Override
+    public void put(TileObject obj) throws StorageException {
+        backingStore.put(obj);
+        frontStore.put(obj);
+    }
+
+    @Override
+    public void clear() throws StorageException {
+        throw new UnsupportedOperationException("clear() should not be called");
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void addListener(BlobStoreListener listener) {
+        backingStore.addListener(listener);
+    }
+
+    @Override
+    public boolean removeListener(BlobStoreListener listener) {
+        return backingStore.removeListener(listener);
+    }
+
+    @Override
+    public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
+        boolean answer = false;
+        try {
+            answer = backingStore.rename(oldLayerName, newLayerName);
+        } finally {
+            frontStore.rename(oldLayerName, newLayerName);
+        }
+        return answer;
+    }
+
+    @Override
+    public String getLayerMetadata(String layerName, String key) {
+        String layerMetaData = frontStore.getLayerMetadata(layerName, key);
+        if (null == layerMetaData) {
+            layerMetaData = backingStore.getLayerMetadata(layerName, key);
+            frontStore.putLayerMetadata(layerName, key, layerMetaData);
+        }
+        return layerMetaData;
+    }
+
+    @Override
+    public void putLayerMetadata(String layerName, String key, String value) {
+        backingStore.putLayerMetadata(layerName, key, value);
+        frontStore.putLayerMetadata(layerName, key, value);
+    }
+
+    @Override
+    public boolean layerExists(String layerName) {
+        return frontStore.layerExists(layerName) || backingStore.layerExists(layerName);
+    }
+
+    @Override
+    public Map<String, Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        return backingStore.getParametersMapping(layerName);
+    }
+}

--- a/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStoreConfig.java
+++ b/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStoreConfig.java
@@ -1,0 +1,99 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Stuart Adam, Ordnance Survey, Copyright 2017
+ */
+package org.geowebcache.nested;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.BlobStoreConfig;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.StorageException;
+
+/**
+ * Plain old java object representing the configuration for a nested blob store.
+ */
+public class NestedBlobStoreConfig extends BlobStoreConfig {
+
+    static Log log = LogFactory.getLog(NestedBlobStoreConfig.class);
+
+    private static final long serialVersionUID = 9072751143836460389L;
+
+    public void setFrontStoreConfig(BlobStoreConfig frontStore) {
+        this.frontStoreConfig = frontStore;
+    }
+
+    public void setBackingStoreConfig(BlobStoreConfig backingStore) {
+        this.backingStoreConfig = backingStore;
+    }
+
+    private BlobStoreConfig frontStoreConfig;
+
+    private BlobStoreConfig backingStoreConfig;
+
+    private BlobStore frontStore;
+
+    private BlobStore backingStore;
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
+            throws StorageException {
+
+        checkNotNull(layers);
+        checkState(getId() != null);
+        checkState(isEnabled(),
+                "Can't call NestedBlobStoreConfig.createInstance() as blob store is not enabled");
+        backingStore = backingStoreConfig.createInstance(layers, lockProvider);
+        frontStore = frontStoreConfig.createInstance(layers, lockProvider);
+        BlobStore store = new NestedBlobStore(this);
+        return store;
+    }
+
+    @Override
+    public String getLocation() {
+        return "Composite";
+    }
+
+    public BlobStore getFrontStore() {
+        return frontStore;
+    }
+
+    public BlobStore getBackingStore() {
+        return backingStore;
+    }
+}

--- a/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStoreConfigProvider.java
+++ b/geowebcache/nestedstorage/src/main/java/org/geowebcache/nested/NestedBlobStoreConfigProvider.java
@@ -1,0 +1,30 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Stuart Adam, Ordnance Survey, Copyright 2017
+ */
+package org.geowebcache.nested;
+
+import org.geowebcache.config.XMLConfigurationProvider;
+
+import com.thoughtworks.xstream.XStream;
+
+public class NestedBlobStoreConfigProvider implements XMLConfigurationProvider {
+    @Override
+    public XStream getConfiguredXStream(XStream xs) {
+        xs.alias("NestedBlobStore", NestedBlobStoreConfig.class);
+        return xs;
+    }
+
+}

--- a/geowebcache/nestedstorage/src/test/java/org/geowebcache/nested/NestedBlobStoreComformanceTest.java
+++ b/geowebcache/nestedstorage/src/test/java/org/geowebcache/nested/NestedBlobStoreComformanceTest.java
@@ -1,0 +1,36 @@
+package org.geowebcache.nested;
+
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.blobstore.file.FileBlobStore;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+public class NestedBlobStoreComformanceTest extends AbstractBlobStoreTest<NestedBlobStore> {
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+    
+    @Rule 
+    public TemporaryFolder temp2 = new TemporaryFolder(); 
+    
+    private BlobStore backingStore;
+    private BlobStore frontStore;
+    
+    @Override
+    public void createTestUnit() throws Exception {
+        frontStore = new FileBlobStore(temp.getRoot().getAbsolutePath());
+        backingStore = new FileBlobStore(temp2.getRoot().getAbsolutePath());
+        this.store = configureStore();
+    }
+    
+    private NestedBlobStore configureStore() {
+        NestedBlobStoreConfig config = Mockito.mock(NestedBlobStoreConfig.class);
+        Mockito.when(config.getBackingStore()).thenReturn(backingStore);
+        Mockito.when(config.getFrontStore()).thenReturn(frontStore);
+        NestedBlobStore store;
+        store = new NestedBlobStore(config);
+        return store;
+    }
+}

--- a/geowebcache/nestedstorage/src/test/java/org/geowebcache/nested/NestedBlobStoreTest.java
+++ b/geowebcache/nestedstorage/src/test/java/org/geowebcache/nested/NestedBlobStoreTest.java
@@ -1,0 +1,398 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * @author Stuart Adam, Ordnance Survey, Copyright 2017
+ */
+package org.geowebcache.nested;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.BlobStoreListener;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.base.Throwables;
+
+public class NestedBlobStoreTest {
+    private static final String DEFAULT_FORMAT = "png";
+
+    private static final String DEFAULT_GRIDSET = "EPSG:4326";
+
+    private static final String DEFAULT_LAYER = "topp:world";
+
+    @Mock
+    BlobStore frontStore;
+
+    @Mock
+    BlobStore backingStore;
+
+    @Mock
+    NestedBlobStoreConfig config;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetFromFrontStore() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        Mockito.when(frontStore.get(to)).thenReturn(true);
+
+        store.get(to);
+        Mockito.verify(frontStore).get(to);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testGetFromBackingStoreAndPopulateFrontStore() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        Mockito.when(frontStore.get(to)).thenReturn(false);
+        Mockito.when(backingStore.get(to)).thenReturn(true);
+
+        store.get(to);
+        Mockito.verify(frontStore).get(to);
+        Mockito.verify(backingStore).get(to);
+        Mockito.verify(frontStore).put(to);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testFailedGetFromFrontBackingStore() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        Mockito.when(frontStore.get(to)).thenReturn(false);
+        Mockito.when(backingStore.get(to)).thenReturn(false);
+
+        store.get(to);
+        Mockito.verify(frontStore).get(to);
+        Mockito.verify(backingStore).get(to);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testPut() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        store.put(to);
+        Mockito.verify(frontStore).put(to);
+        Mockito.verify(backingStore).put(to);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testGetLayerMetaDataFrontStore() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        String key = "key";
+        String layerName = "layer";
+        Mockito.when(frontStore.getLayerMetadata(layerName, key)).thenReturn("value");
+
+        store.getLayerMetadata(layerName, key);
+        Mockito.verify(frontStore).getLayerMetadata(layerName, key);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testGetLayerMetaDataBackingStoreIfFrontStoreEmpty() throws StorageException {
+        NestedBlobStore store = configureStore();
+
+        String key = "key";
+        String layerName = "layer";
+        Mockito.when(frontStore.getLayerMetadata(layerName, key)).thenReturn(null);
+        Mockito.when(backingStore.getLayerMetadata(layerName, key)).thenReturn("value");
+
+        store.getLayerMetadata(layerName, key);
+        Mockito.verify(frontStore).getLayerMetadata(layerName, key);
+        Mockito.verify(backingStore).getLayerMetadata(layerName, key);
+        Mockito.verify(frontStore).putLayerMetadata(layerName, key, "value");
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testPutLayerMetaData() throws StorageException {
+        NestedBlobStore store = configureStore();
+
+        String key = "key";
+        String layerName = "layer";
+        String value = "value";
+
+        store.putLayerMetadata(layerName, key, value);
+        Mockito.verify(frontStore).putLayerMetadata(layerName, key, value);
+        Mockito.verify(backingStore).putLayerMetadata(layerName, key, value);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testDeleteTileObject() throws StorageException {
+        TileObject to = configureQuery();
+        NestedBlobStore store = configureStore();
+
+        store.delete(to);
+        Mockito.verify(frontStore).delete(to);
+        Mockito.verify(backingStore).delete(to);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testDeleteTileRange() throws StorageException, MimeException {
+        long[][] rangeBounds = { //
+                { 0, 0, 0, 0, 0 }, //
+                { 0, 0, 1, 1, 1 }, //
+                { 0, 0, 3, 3, 2 } //
+        };
+
+        MimeType mimeType = MimeType.createFromExtension(DEFAULT_FORMAT);
+
+        Map<String, String> parameters = null;
+
+        final int truncateStart = 0, truncateStop = 1;
+
+        TileRange tileRange = tileRange(DEFAULT_LAYER, DEFAULT_GRIDSET, truncateStart, truncateStop,
+                rangeBounds, mimeType, parameters);
+        NestedBlobStore store = configureStore();
+
+        store.delete(tileRange);
+        Mockito.verify(frontStore).delete(tileRange);
+        Mockito.verify(backingStore).delete(tileRange);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testDeleteLayerName() throws StorageException {
+        String layer = "layer";
+        NestedBlobStore store = configureStore();
+
+        store.delete(layer);
+        Mockito.verify(frontStore).delete(layer);
+        Mockito.verify(backingStore).delete(layer);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testDeleteByGridsetId() throws StorageException {
+        String layer = "layer";
+        String gridSet = "gridSet";
+        NestedBlobStore store = configureStore();
+
+        store.deleteByGridsetId(layer, gridSet);
+        Mockito.verify(frontStore).deleteByGridsetId(layer, gridSet);
+        Mockito.verify(backingStore).deleteByGridsetId(layer, gridSet);
+        Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testDeleteByParametersId() throws StorageException {
+       NestedBlobStore store = configureStore();
+       String parametersId="parametersId";
+       String layer = "layer";
+       store.deleteByParametersId(layer , parametersId);
+       Mockito.verify(frontStore).deleteByParametersId(layer, parametersId);
+       Mockito.verify(backingStore).deleteByParametersId(layer, parametersId);
+       Mockito.verifyNoMoreInteractions(frontStore, backingStore);
+    }
+    
+    @Test
+    public void testRename() throws StorageException {
+        NestedBlobStore store = configureStore();
+        String oldLayerName = "oldLayerName";
+        String newLayerName = "newLayerName";
+        store.rename(oldLayerName, newLayerName);
+        Mockito.verify(frontStore).rename(oldLayerName, newLayerName);
+        Mockito.verify(backingStore).rename(oldLayerName, newLayerName);
+        Mockito.verifyZeroInteractions(frontStore, backingStore);
+    }
+    
+    @Test
+    public void testLayerExists() {
+        NestedBlobStore store = configureStore();
+        Mockito.when(frontStore.layerExists("frontLayerName")).thenReturn(true);
+        Mockito.when(frontStore.layerExists("backLayerName")).thenReturn(false);
+        Mockito.when(backingStore.layerExists("backLayerName")).thenReturn(true);
+        assertTrue(store.layerExists("frontLayerName"));
+        assertTrue(store.layerExists("backLayerName"));
+        assertFalse(store.layerExists("nonExistantLayerName"));
+    }
+    
+    @Test 
+    public void testGetParametersMapping() {
+        NestedBlobStore store = configureStore();
+        String layer="layer";
+        store.getParametersMapping(layer);
+        Mockito.verify(backingStore).getParametersMapping(layer);
+        Mockito.verifyZeroInteractions(frontStore, backingStore);
+    }
+
+    @Test
+    public void testAddBlobStoreListener() {
+        NestedBlobStore store = configureStore();
+        BlobStoreListener listener = new BlobStoreListener() {
+            @Override
+            public void tileStored(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize) {
+
+            }
+
+            @Override
+            public void tileDeleted(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize) {
+
+            }
+
+            @Override
+            public void tileUpdated(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize, long oldSize) {
+
+            }
+
+            @Override
+            public void layerDeleted(String layerName) {
+
+            }
+
+            @Override
+            public void layerRenamed(String oldLayerName, String newLayerName) {
+
+            }
+
+            @Override
+            public void gridSubsetDeleted(String layerName, String gridSetId) {
+
+            }
+
+            @Override
+            public void parametersDeleted(String layerName, String parametersId) {
+                
+            }
+        };
+        store.addListener(listener);
+        Mockito.verify(backingStore).addListener(listener);
+        Mockito.verifyZeroInteractions(frontStore);
+        Mockito.verifyNoMoreInteractions(backingStore);
+    }
+
+    @Test
+    public void testRemoveBlobStoreListener() {
+        NestedBlobStore store = configureStore();
+        BlobStoreListener listener = new BlobStoreListener() {
+            @Override
+            public void tileStored(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize) {
+
+            }
+
+            @Override
+            public void tileDeleted(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize) {
+
+            }
+
+            @Override
+            public void tileUpdated(String layerName, String gridSetId, String blobFormat,
+                    String parametersId, long x, long y, int z, long blobSize, long oldSize) {
+
+            }
+
+            @Override
+            public void layerDeleted(String layerName) {
+
+            }
+
+            @Override
+            public void layerRenamed(String oldLayerName, String newLayerName) {
+
+            }
+
+            @Override
+            public void gridSubsetDeleted(String layerName, String gridSetId) {
+
+            }
+
+            @Override
+            public void parametersDeleted(String layerName, String parametersId) {
+                
+            }
+        };
+        store.removeListener(listener);
+        Mockito.verify(backingStore).removeListener(listener);
+        Mockito.verifyZeroInteractions(frontStore);
+        Mockito.verifyNoMoreInteractions(backingStore);
+    }
+
+    private NestedBlobStore configureStore() {
+        config = Mockito.mock(NestedBlobStoreConfig.class);
+        Mockito.when(config.getBackingStore()).thenReturn(backingStore);
+        Mockito.when(config.getFrontStore()).thenReturn(frontStore);
+        NestedBlobStore store;
+        store = new NestedBlobStore(config);
+        return store;
+    }
+
+    private TileObject configureQuery() {
+        TileObject to;
+        to = queryTile(1, 2, 3);
+        return to;
+    }
+
+    private TileObject queryTile(long x, long y, int z) {
+        return queryTile(DEFAULT_LAYER, DEFAULT_GRIDSET, DEFAULT_FORMAT, x, y, z);
+    }
+
+    private TileObject queryTile(String layer, String gridset, String extension, long x, long y,
+            int z) {
+        return queryTile(layer, gridset, extension, x, y, z, (Map<String, String>) null);
+    }
+
+    private TileObject queryTile(String layer, String gridset, String extension, long x, long y,
+            int z, Map<String, String> parameters) {
+
+        String format;
+        try {
+            format = MimeType.createFromExtension(extension).getFormat();
+        } catch (MimeException e) {
+            throw Throwables.propagate(e);
+        }
+
+        TileObject tile = TileObject.createQueryTileObject(layer, new long[] { x, y, z }, gridset,
+                format, parameters);
+        return tile;
+    }
+
+    private TileRange tileRange(String layerName, String gridSetId, int zoomStart, int zoomStop,
+            long[][] rangeBounds, MimeType mimeType, Map<String, String> parameters) {
+
+        TileRange tileRange = new TileRange(layerName, gridSetId, zoomStart, zoomStop, rangeBounds,
+                mimeType, parameters);
+        return tileRange;
+    }
+}

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -677,5 +677,6 @@
 	<module>distributed</module>
     <module>s3storage</module>
     <module>sqlite</module>
+    <module>nestedstorage</module>
   </modules>
 </project>


### PR DESCRIPTION
    Accommodate new BlobStore functionality around parameter based deletes.
    Merge branch 'master' into nested-storage to consume upstream updates.
    A blob store to allow a layered n-tier blob storage hierarchy.
    Allow id references in geowebcache.xml

    This allows the use of nestedblobstore configuration as follows

    <NestedBlobStore>
    <id>files3</id>
    <frontStoreConfig reference="file" />
    <backingStoreConfig reference="s3" />
    <enabled>true</enabled>
    </NestedBlobStore>
    </blobStores>