### PR TITLE
Configurable S3 access control.

### DIFF
--- a/documentation/en/user/source/configuration/storage.rst
+++ b/documentation/en/user/source/configuration/storage.rst
@@ -193,6 +193,7 @@ Configuration example:
       <prefix>test-cache</prefix>
       <awsAccessKey>putYourActualAccessKeyHere</awsAccessKey>
       <awsSecretKey>putYourActualSecretKeyHere</awsSecretKey>
+      <access>private</access>
       <maxConnections>50</maxConnections>
       <useHTTPS>true</useHTTPS>
       <proxyDomain></proxyDomain>
@@ -212,6 +213,7 @@ Properties:
   prefix is "mycache", all tiles will be stored under ``bucket.gwc.example/mycache/{layer name}`` instead of ``bucket.gwc.example/{layer name}``.
 * **awsAccessKey**: Mandatory. The public access key the client uses to connect to S3.
 * **awsSecretKey**: Mandatory. The secret key the client uses to connect to S3.
+* **access**: Optional.  Whether direct access in S3 will be readable by the public or only to the owner of the bucket.  Defaults to public, set to private to disable public access.  
 * **maxConnections**: Optional, default: ``50``. Maximum number of concurrent HTTP connections the S3 client may use.
 * **useHTTPS**: Optional, default: ``true``. Whether to use HTTPS when connecting to S3 or not.
 * **proxyDomain**: Optional. The Windows domain name for configuring an NTLM proxy. If you are not using a Windows NTLM proxy, you don't need to set this property.

--- a/documentation/en/user/source/configuration/storage_blobstore_schema.txt
+++ b/documentation/en/user/source/configuration/storage_blobstore_schema.txt
@@ -109,6 +109,11 @@
                 <xs:documentation xml:lang="en">The secret key the client uses to connect to S3</xs:documentation>
               </xs:annotation>
             </xs:element>
+            <xs:element name="access" type="xs:string"  maxOccurs="1" minOccurs="0" default="public">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Whether S3 object access is public or private</xs:documentation>
+              </xs:annotation>
+            </xs:element>
             <xs:element name="maxConnections" type="xs:positiveInteger" minOccurs="0" default="50" nillable="true">
               <xs:annotation>
                 <xs:documentation xml:lang="en">Maximum number of concurrent HTTP connections the S3 client may use.</xs:documentation>

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -262,7 +262,12 @@
                 <xs:documentation xml:lang="en">The secret key the client uses to connect to S3</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="maxConnections" type="xs:positiveInteger" minOccurs="0" default="50" nillable="true">
+            <xs:element name="access" type="xs:string" maxOccurs="1" minOccurs="0" default="public">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Whether S3 object access is public or private</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+             <xs:element name="maxConnections" type="xs:positiveInteger" minOccurs="0" default="50" nillable="true">
               <xs:annotation>
                 <xs:documentation xml:lang="en">Maximum number of concurrent HTTP connections the S3 client may use.</xs:documentation>
               </xs:annotation>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -54,6 +54,22 @@
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymockclassextension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty</artifactId>
+      <version>6.1.20</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -54,22 +54,6 @@
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
-      <version>6.1.20</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
@@ -87,6 +87,8 @@ public class S3BlobStore implements BlobStore {
     private volatile boolean shutDown;
 
     private final S3Ops s3Ops;
+    
+    private CannedAccessControlList acl;
 
     public S3BlobStore(S3BlobStoreConfig config, TileLayerDispatcher layers,
             LockProvider lockProvider) throws StorageException {
@@ -100,6 +102,7 @@ public class S3BlobStore implements BlobStore {
         this.keyBuilder = new TMSKeyBuilder(prefix, layers);
 
         conn = config.buildClient();
+        acl = config.getAccessControlList();
 
         try {
             log.debug("Checking access rights to bucket " + bucketName);
@@ -168,7 +171,7 @@ public class S3BlobStore implements BlobStore {
 
         final ByteArrayInputStream input = toByteArray(blob);
         PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, input,
-                objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead);
+                objectMetadata).withCannedAcl(acl);
 
         log.trace(log.isTraceEnabled() ? ("Storing " + key) : "");
         s3Ops.putObject(putObjectRequest);

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
@@ -56,6 +56,8 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
 
     private String awsSecretKey;
 
+    private String access = "public";
+
     private Integer maxConnections;
 
     private Boolean useHTTPS = true;
@@ -74,7 +76,14 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
 
     private Boolean useGzip;
 
-    private CannedAccessControlList accessControlList;
+    
+    protected S3BlobStoreConfig() {
+        super();
+    }
+    
+    public S3BlobStoreConfig(String id) {
+        super(id);
+    }
 
     /**
      * @return the name of the AWS S3 bucket where to store tiles
@@ -276,6 +285,12 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
      * @return public or private access
      */
     public CannedAccessControlList getAccessControlList() {
+        CannedAccessControlList accessControlList;
+        if(access.equalsIgnoreCase("private")) {
+            accessControlList = CannedAccessControlList.BucketOwnerFullControl;
+        } else {
+            accessControlList = CannedAccessControlList.PublicRead;
+        }
         return accessControlList;
     }
 
@@ -285,11 +300,7 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
      * @param access whether access is private or public
      */
     public void setAccess(String access) {
-        if(access.equalsIgnoreCase("private")) {
-            accessControlList = CannedAccessControlList.BucketOwnerFullControl;
-        } else {
-            accessControlList = CannedAccessControlList.PublicRead;
-        }
+        this.access = access;
     }
 
     /**

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
@@ -37,6 +37,7 @@ import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 
 /**
  * Plain old java object representing the configuration for an S3 blob store.
@@ -72,6 +73,8 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
     private String proxyPassword;
 
     private Boolean useGzip;
+
+    private CannedAccessControlList accessControlList;
 
     /**
      * @return the name of the AWS S3 bucket where to store tiles
@@ -265,6 +268,28 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
      */
     public void setProxyPassword(String proxyPassword) {
         this.proxyPassword = proxyPassword;
+    }
+    
+    /**
+     * Checks access type
+     *
+     * @return public or private access
+     */
+    public CannedAccessControlList getAccessControlList() {
+        return accessControlList;
+    }
+
+    /**
+     * Sets whether access should be private or public
+     *
+     * @param access whether access is private or public
+     */
+    public void setAccess(String access) {
+        if(access.equalsIgnoreCase("private")) {
+            accessControlList = CannedAccessControlList.BucketOwnerFullControl;
+        } else {
+            accessControlList = CannedAccessControlList.PublicRead;
+        }
     }
 
     /**

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/config/S3BlobStoreConfigStoreLoadTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/config/S3BlobStoreConfigStoreLoadTest.java
@@ -1,0 +1,163 @@
+package org.geowebcache.config;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.grid.GridSetBroker;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.NoOpLockProvider;
+import org.geowebcache.s3.PropertiesLoader;
+import org.geowebcache.s3.S3BlobStoreConfig;
+import org.geowebcache.s3.S3BlobStoreConfigProvider;
+import org.geowebcache.s3.TemporaryS3Folder;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.util.ApplicationContextProvider;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.context.WebApplicationContext;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+public class S3BlobStoreConfigStoreLoadTest {
+
+    private XMLConfiguration config;
+
+    private static final Log log = LogFactory.getLog(S3BlobStoreConfigStoreLoadTest.class);
+
+    public PropertiesLoader testConfigLoader = new PropertiesLoader();
+
+    @Rule
+    public TemporaryS3Folder tempFolder = new TemporaryS3Folder(testConfigLoader.getProperties());
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Mock
+    ApplicationContextProvider context;
+
+    @Mock
+    TileLayerDispatcher dispatch;
+
+    private File configDir;
+
+    private File configFile;
+
+    @Mock
+    private WebApplicationContext webCtx;
+
+    private Map<String, XMLConfigurationProvider> providers;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testSaveLoadS3BlobStoresAccess() throws Exception {
+        Assume.assumeTrue(tempFolder.isConfigured());
+        setupXMLConfig();
+        S3BlobStoreConfig store1 = createConfig("1");
+        S3BlobStoreConfig store2 = createConfig("2");
+        store2.setAccess("private");
+
+        saveConfig(store1, store2);
+        validateAndLoadSavedConfig();
+    }
+
+    private void saveConfig(S3BlobStoreConfig store1, S3BlobStoreConfig store2) throws IOException {
+        List<BlobStoreConfig> blobStores = config.getBlobStores();
+        blobStores.add(store1);
+        blobStores.add(store2);
+        config.save();
+    }
+
+    private void validateAndLoadSavedConfig()
+            throws SAXException, IOException, ConfigurationException, FileNotFoundException {
+        validateSavedConfig();
+        loadSavedConfig();
+    }
+
+    private void loadSavedConfig() {
+        try {
+            XMLConfiguration configLoad = new XMLConfiguration(context, configDir.getAbsolutePath(),
+                    null);
+            GridSetBroker gridSetBroker = new GridSetBroker(true, true);
+            configLoad.initialize(gridSetBroker);
+            createFromSavedConfig(configLoad);
+        } catch (StorageException | GeoWebCacheException e) {
+            log.error(e.getMessage());
+            fail("Error loading from " + configFile + " " + e.getMessage());
+        }
+    }
+
+    private void createFromSavedConfig(XMLConfiguration configLoad) throws StorageException {
+        List<BlobStoreConfig> blobStores2 = configLoad.getBlobStores();
+        for (BlobStoreConfig blobStoreConfig : blobStores2) {
+            LockProvider lockProvider = new NoOpLockProvider();
+            blobStoreConfig.createInstance(dispatch, lockProvider);
+        }
+    }
+
+    private void validateSavedConfig()
+            throws SAXException, IOException, ConfigurationException, FileNotFoundException {
+        try {
+            XMLConfiguration
+                    .validate(XMLConfiguration.loadDocument(new FileInputStream(configFile)));
+        } catch (SAXParseException e) {
+            log.error(e.getMessage());
+            fail("Error validating from " + configFile + " " + e.getMessage());
+        }
+    }
+
+    private S3BlobStoreConfig createConfig(String id) {
+        S3BlobStoreConfig store = new S3BlobStoreConfig(id);
+        store.setDefault(true);
+        store.setEnabled(true);
+        Properties properties = testConfigLoader.getProperties();
+        store.setBucket(properties.getProperty("bucket"));
+        store.setAwsAccessKey(properties.getProperty("accessKey"));
+        store.setAwsSecretKey(properties.getProperty("secretKey"));
+        return store;
+    }
+
+    private void setupXMLConfig() throws IOException, GeoWebCacheException {
+        configDir = temp.getRoot();
+        configFile = temp.newFile("geowebcache.xml");
+
+        URL source = XMLConfiguration.class
+                .getResource(XMLConfigurationBackwardsCompatibilityTest.LATEST_FILENAME);
+        FileUtils.copyURLToFile(source, configFile);
+
+        providers = new HashMap<String, XMLConfigurationProvider>();
+        Mockito.when(context.getApplicationContext()).thenReturn(webCtx, webCtx, webCtx, webCtx);
+        Mockito.when(webCtx.getBeansOfType(XMLConfigurationProvider.class)).thenReturn(providers,
+                providers);
+        S3BlobStoreConfigProvider provider = new S3BlobStoreConfigProvider();
+        Mockito.when(webCtx.getBean("S3BlobStore")).thenReturn(provider, provider);
+        providers.put("S3BlobStore", provider);
+        GridSetBroker gridSetBroker = new GridSetBroker(true, true);
+        config = new XMLConfiguration(context, configDir.getAbsolutePath());
+        config.initialize(gridSetBroker);
+    }
+
+}

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigTest.java
@@ -1,6 +1,6 @@
 package org.geowebcache.s3;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -21,5 +21,4 @@ public class S3BlobStoreConfigTest {
         config.setAccess("private");
         assertEquals(CannedAccessControlList.BucketOwnerFullControl, config.getAccessControlList());
     }
-
 }

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigTest.java
@@ -1,0 +1,25 @@
+package org.geowebcache.s3;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+public class S3BlobStoreConfigTest {
+
+    @Test
+    public void testACLPublic() {
+        S3BlobStoreConfig config = new S3BlobStoreConfig();
+        config.setAccess("public");
+        assertEquals(CannedAccessControlList.PublicRead, config.getAccessControlList());
+    }
+    
+    @Test
+    public void testACLPrivate() {
+        S3BlobStoreConfig config = new S3BlobStoreConfig();
+        config.setAccess("private");
+        assertEquals(CannedAccessControlList.BucketOwnerFullControl, config.getAccessControlList());
+    }
+
+}


### PR DESCRIPTION
ACL defaults to public as currently but can be configured as private which changes it to BucketOwnerFullControl