### PR TITLE
Fixed missing BlobStore import

### DIFF
--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
+import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.StorageBrokerTest;
 import org.geowebcache.storage.StorageException;
 import org.geowebcache.storage.TileObject;


### PR DESCRIPTION
Apparently one import didn't make it through the backport, causing compilation failure.