### PR TITLE
upgrade to jts-core 1.14.0

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -114,6 +114,12 @@
     <dependency>
       <groupId>it.geosolutions.jaiext.utilities</groupId>
       <artifactId>jt-utilities</artifactId>
+      <exclusions>
+         <exclusion>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -22,7 +22,7 @@
 
     <dependency>
       <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
+      <artifactId>jts-core</artifactId>
       <version>${jts.version}</version>
     </dependency>
 

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <gt.version>18-SNAPSHOT</gt.version>
-    <jts.version>1.13</jts.version>
+    <jts.version>1.14.0</jts.version>
     <jaiext.version>1.0.15</jaiext.version>
     <spring.version>4.2.5.RELEASE</spring.version>
     <restlet.version>1.0.8</restlet.version>


### PR DESCRIPTION
Compatibility with GeoTools upgrade to JTS 1.14.0 (GEOT-5813) via https://github.com/geotools/geotools/pull/1665