### PR TITLE
Make s3BlobStoreConfig constructor public to support gs-gwc-s3 community module

### DIFF
--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreConfig.java
@@ -77,7 +77,7 @@ public class S3BlobStoreConfig extends BlobStoreConfig {
     private Boolean useGzip;
 
     
-    protected S3BlobStoreConfig() {
+    public S3BlobStoreConfig() {
         super();
     }
     


### PR DESCRIPTION
Constructor was made protected by https://github.com/GeoWebCache/geowebcache/pull/514

This is causing a compile failure in the GeoServer gwc-s3 community module.