### PR TITLE
Demo tile origin bug, Fixes #552

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -387,15 +387,9 @@ public class Demo {
             buf.append("      tileSize: [")
                     .append(gridSubset.getTileWidth()).append(",")
                     .append(gridSubset.getTileHeight()).append("],\n");
-            if (gridSet.isTopLeftAligned()) {
-                buf.append("      origin: [")
-                        .append(bbox.getMaxX()).append(", ")
-                        .append(bbox.getMinY()).append("],\n");
-            } else {
-                buf.append("      origin: [")
-                        .append(bbox.getMinX()).append(", ")
-                        .append(bbox.getMaxY()).append("],\n");
-            }
+            buf.append("      origin: [")
+                    .append(bbox.getMinX()).append(", ")
+                    .append(bbox.getMaxY()).append("],\n");
             buf.append("      resolutions: resolutions,\n"
                     + "      matrixIds: gridNames\n"
                     + "    }),\n"
@@ -454,27 +448,15 @@ public class Demo {
                         buf.append(",");
                     }
                     BoundingBox subbox = gridSubset.getCoverageBounds(i);
-                    if (gridSet.isTopLeftAligned()) {
-                        buf.append("[")
-                                .append(subbox.getMaxX()).append(", ")
-                                .append(subbox.getMinY()).append("]");
-                    } else {
-                        buf.append("[")
-                                .append(subbox.getMinX()).append(", ")
-                                .append(subbox.getMaxY()).append("]");
-                    }
+                    buf.append("[")
+                            .append(subbox.getMinX()).append(", ")
+                            .append(subbox.getMaxY()).append("]");
                 }
                 buf.append("],\n");
             } else {
-                if (gridSet.isTopLeftAligned()) {
-                    buf.append("      origin: [")
-                            .append(bbox.getMaxX()).append(", ")
-                            .append(bbox.getMinY()).append("],\n");
-                } else {
-                    buf.append("      origin: [")
-                            .append(bbox.getMinX()).append(", ")
-                            .append(bbox.getMaxY()).append("],\n");
-                }
+                buf.append("      origin: [")
+                        .append(bbox.getMinX()).append(", ")
+                        .append(bbox.getMaxY()).append("],\n");
             }
             buf.append("      resolutions: resolutions,\n"
                     + "      matrixIds: params['TILEMATRIX']\n"

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetTest.java
@@ -1,10 +1,22 @@
 package org.geowebcache.grid;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 
-import junit.framework.TestCase;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-public class GridSetTest extends TestCase {
+public class GridSetTest {
+    
+    public @Rule ExpectedException exception = ExpectedException.none();
 
     GridSetBroker gridSetBroker = new GridSetBroker(false, false);
 
@@ -15,35 +27,80 @@ public class GridSetTest extends TestCase {
     // Bottom left
     GridSet gridSetBL = GridSetFactory.createGridSet("test", SRS.getEPSG4326(),
             BoundingBox.WORLD4326, false, 10, null, 0.00028, 256, 256, false);
+    // Top left
+    GridSet gridSetTLswap = GridSetFactory.createGridSet("test", SRS.getEPSG4326(),
+            BoundingBox.WORLD4326, true, 10, null, 0.00028, 256, 256, true);
 
+    // Bottom left
+    GridSet gridSetBLswap = GridSetFactory.createGridSet("test", SRS.getEPSG4326(),
+            BoundingBox.WORLD4326, false, 10, null, 0.00028, 256, 256, true);
+    
+    Matcher<BoundingBox> closeTo(BoundingBox expected, double error) {
+        return allOf(
+                hasProperty("minX", Matchers.closeTo(expected.getMinX(), error)),
+                hasProperty("minY", Matchers.closeTo(expected.getMinY(), error)),
+                hasProperty("maxX", Matchers.closeTo(expected.getMaxX(), error)),
+                hasProperty("maxY", Matchers.closeTo(expected.getMaxY(), error))
+            );
+    }
+    
+    @Test
     public void testBoundsFromIndex() throws Exception {
         long[] index = { 0, 0, 1 };
         BoundingBox bboxTL = gridSetTL.boundsFromIndex(index);
         BoundingBox bboxBL = gridSetBL.boundsFromIndex(index);
+        BoundingBox bboxTLswap = gridSetTLswap.boundsFromIndex(index);
+        BoundingBox bboxBLswap = gridSetBLswap.boundsFromIndex(index);
         BoundingBox solution = new BoundingBox(-180.0, -90.0, -90.0, 0);
 
-        assertTrue(bboxTL.equals(solution));
-        assertTrue(bboxBL.equals(solution));
+        assertThat(bboxTL, closeTo(solution, 0.00000001));
+        assertThat(bboxBL, closeTo(solution, 0.00000001));
+        assertThat(bboxTLswap, closeTo(solution, 0.00000001));
+        assertThat(bboxBLswap, closeTo(solution, 0.00000001));
+    }
+    
+    @Test
+    public void testBounds() throws Exception {
+        BoundingBox bboxTL = gridSetTL.getBounds();
+        BoundingBox bboxBL = gridSetBL.getBounds();
+        BoundingBox bboxTLswap = gridSetTLswap.getBounds();
+        BoundingBox bboxBLswap = gridSetBLswap.getBounds();
+        BoundingBox solution = new BoundingBox(-180.0, -90.0, 180, 90);
+
+        assertThat(bboxTL, closeTo(solution, 0.00000001));
+        assertThat(bboxBL, closeTo(solution, 0.00000001));
+        assertThat(bboxTLswap, closeTo(solution, 0.00000001));
+        assertThat(bboxBLswap, closeTo(solution, 0.00000001));
     }
 
+    @Test
     public void testBoundsFromRectangle() throws Exception {
         long[] rect = { 0, 0, 0, 0, 0 };
         BoundingBox bboxTL = gridSetTL.boundsFromRectangle(rect);
         BoundingBox bboxBL = gridSetBL.boundsFromRectangle(rect);
+        BoundingBox bboxTLswap = gridSetTLswap.boundsFromRectangle(rect);
+        BoundingBox bboxBLswap = gridSetBLswap.boundsFromRectangle(rect);
         BoundingBox solution = new BoundingBox(-180.0, -90.0, 0.0, 90.0);
 
-        assertEquals(solution, bboxTL);
-        assertEquals(solution, bboxBL);
+        assertThat(bboxTL, equalTo(solution));
+        assertThat(bboxBL, equalTo(solution));
+        assertThat(bboxTLswap, equalTo(solution));
+        assertThat(bboxBLswap, equalTo(solution));
 
         long[] rect2 = { 2, 1, 2, 1, 1 };
         BoundingBox bboxTL2 = gridSetTL.boundsFromRectangle(rect2);
         BoundingBox bboxBL2 = gridSetBL.boundsFromRectangle(rect2);
+        BoundingBox bboxTLswap2 = gridSetTLswap.boundsFromRectangle(rect2);
+        BoundingBox bboxBLswap2 = gridSetBLswap.boundsFromRectangle(rect2);
         BoundingBox solution2 = new BoundingBox(0.0, 0.0, 90.0, 90.0);
 
-        assertEquals(solution2, bboxBL2);
-        assertEquals(solution2, bboxTL2);
+        assertThat(bboxTL2, equalTo(solution2));
+        assertThat(bboxBL2, equalTo(solution2));
+        assertThat(bboxTLswap2, equalTo(solution2));
+        assertThat(bboxBLswap2, equalTo(solution2));
     }
 
+    @Test
     public void testClosestIndex() throws Exception {
         BoundingBox box = new BoundingBox(-180.0, -90.0, -90.0, 0);
         long[] idxTL = gridSetTL.closestIndex(box);
@@ -54,6 +111,7 @@ public class GridSetTest extends TestCase {
         assertTrue(Arrays.equals(idxBL, solution));
     }
 
+    @Test
     public void testClosestRectangle() throws Exception {
         BoundingBox box = new BoundingBox(-180.0, -90.0, 0.0, 0.0);
         long[] rectTL = gridSetTL.closestRectangle(box);
@@ -64,25 +122,25 @@ public class GridSetTest extends TestCase {
         assertTrue(Arrays.equals(rectBL, solution));
     }
 
+    @Test
     public void testGetLeftTopCorner() throws Exception {
         double[] tlTL = gridSetTL.getOrderedTopLeftCorner(1);
         double[] tlBL = gridSetBL.getOrderedTopLeftCorner(1);
 
-        assertTrue(Math.abs(tlBL[1] - 90.0) < 0.01);
-        assertTrue(Math.abs(tlTL[1] - 90.0) < 0.01);
+        assertThat(tlBL[1], Matchers.closeTo(90.0, 0.01));
+        assertThat(tlTL[1], Matchers.closeTo(90.0, 0.01));
     }
     
-    public void testClosestIndexInvalidBounds() throws Exception {
-        assertInvalidBounds(new BoundingBox(0, -180, 180.0, 0));
-        assertInvalidBounds(new BoundingBox(0, 0, 180.0, 180));
+    @Test
+    public void testClosestIndexInvalidBounds1() throws Exception {
+        BoundingBox box = new BoundingBox(0, -180, 180.0, 0);
+        exception.expect(GridAlignmentMismatchException.class);
+        gridSetTL.closestIndex(box);
     }
-
-    private void assertInvalidBounds(BoundingBox box) throws GridMismatchException {
-        try {
-            gridSetTL.closestIndex(box);
-            fail("Unexpected, the bbox cannot match any tile");
-        } catch(GridAlignmentMismatchException e) {
-            // good, expected
-        }
+    @Test
+    public void testClosestIndexInvalidBounds2() throws Exception {
+        BoundingBox box = new BoundingBox(0, 0, 180.0, 180);
+        exception.expect(GridAlignmentMismatchException.class);
+        gridSetTL.closestIndex(box);
     }
 }


### PR DESCRIPTION
Fixes incorrect tile origin being given to OL3 on the demo page when gridset is top aligned.  The changes to the unit test were while I was debugging.  They aren't directly relevant but are beneficial so I left them in.  The actual fix is to the generation of Javascript on the demo page so not amenable to unit testing.