### PR TITLE
Fix NPE when checking security of tile fuser requests, Fixes #558

### DIFF
--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -308,7 +308,8 @@ public class WMSTileFuser{
             hints = HintsLevel.getHintsForMode(values.get("hints")).getRenderingHints();
         }        
     }
-
+    
+    @Deprecated
     protected WMSTileFuser(TileLayer layer, GridSubset gridSubset, BoundingBox bounds, int width,
             int height) {
         this.sb = null;
@@ -526,6 +527,8 @@ public class WMSTileFuser{
 
                 ConveyorTile tile = new ConveyorTile(sb, layer.getName(), gridSubset.getName(),
                         gridLoc, srcFormat, fullParameters, null, null);
+                
+                tile.setTileLayer(layer);
                 
                 securityDispatcher.checkSecurity(tile);
                 

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -308,7 +308,12 @@ public class WMSTileFuser{
             hints = HintsLevel.getHintsForMode(values.get("hints")).getRenderingHints();
         }        
     }
-    
+	
+    /**
+     * This was used for unit tests and should not have been used elsewhere.  It will likely cause 
+     * NullPointerExceptions if used in production.  Use WMSTileFuser(TileLayerDispatcher tld, 
+     * StorageBroker sb, HttpServletRequest servReq) instead.  It will be removed in future.
+     */
     @Deprecated
     protected WMSTileFuser(TileLayer layer, GridSubset gridSubset, BoundingBox bounds, int width,
             int height) {


### PR DESCRIPTION
Sets the `tileLayer` field on the tile requests made by the `TileFuser` so that the security check doesn't give an NPE.  See #558 