### PR TITLE
Fix issues found during WMTS 1.0 CITE tests

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
@@ -97,11 +97,21 @@ public class LegendInfoBuilder {
     }
 
     public LegendInfoBuilder withMinScale(Double minScale) {
+        if (minScale == null || Math.abs(minScale) < 0.000001) {
+            // NULL or zero minimum scale means that there is no minimum scale
+            this.minScale = null;
+            return this;
+        }
         this.minScale = minScale;
         return this;
     }
 
     public LegendInfoBuilder withMaxScale(Double maxScale) {
+        if (maxScale == null || maxScale == Double.POSITIVE_INFINITY) {
+            // NULL or positive infinity means that no max scale was defined
+            this.maxScale = null;
+            return this;
+        }
         this.maxScale = maxScale;
         return this;
     }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -100,7 +100,7 @@ public class WMTSGetCapabilities {
         byte[] data = generateGetCapabilities(encoding).getBytes(encoding);
         
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/vnd.ogc.wms_xml");
+        response.setContentType("text/xml");
         response.setCharacterEncoding(encoding.name());
         response.setContentLength(data.length);
         response.setHeader("content-disposition", "inline;filename=wmts-getcapabilities.xml");

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
@@ -66,7 +66,7 @@ public class WMTSRestTest {
     public void testGetCap() throws Exception {
         MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
         mockMvc.perform(get("/rest/wmts/WMTSCapabilities.xml"))
-                .andExpect(content().contentType("application/vnd.ogc.wms_xml"))
+                .andExpect(content().contentType("text/xml"))
                 .andExpect(status().is(200))
                 .andExpect(xpath("//wmts:Contents/wmts:Layer", namespaces).nodeCount(1))
                 .andExpect(


### PR DESCRIPTION
Associates issues:
* https://github.com/GeoWebCache/geowebcache/issues/563
* https://github.com/GeoWebCache/geowebcache/issues/564

This PR allows Geoserver to compute MinScales and MaxSscales for styles legends. It also change the mime type used for WMTS capabilities documents to ``text\xml``. 