### PR TITLE
Makes GWC compliant with CITE expected exceptions

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/Configuration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/Configuration.java
@@ -132,4 +132,15 @@ public interface Configuration {
     public void addLayer(TileLayer tl) throws IllegalArgumentException;
 
     public boolean containsLayer(String tileLayerId);
+
+    /**
+     * If this method returns TRUE WMTS service implementation will strictly comply with the
+     * correspondent CITE tests.
+     *
+     * @return TRUE or FALSE, activating or deactivation CITE strict compliance mode for WMTS
+     */
+    default boolean isWmtsCiteCompliant() {
+        // by default CITE tests strict compliance is not activated
+        return false;
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
@@ -27,8 +27,6 @@ import org.geowebcache.locks.LockProvider;
 import org.geowebcache.locks.MemoryLockProvider;
 import org.geowebcache.mime.FormatModifier;
 
-import com.thoughtworks.xstream.annotations.XStreamOmitField;
-
 /**
  * POJO for geowebcache.xml configuration
  * 
@@ -76,6 +74,8 @@ public class GeoWebCacheConfiguration {
     private List<XMLGridSet> gridSets;
     
     private Boolean fullWMS;
+
+    private Boolean wmtsCiteCompliant;
 
     /**
      * The persisted list of layers
@@ -313,5 +313,26 @@ public class GeoWebCacheConfiguration {
      */
     public void setFullWMS(Boolean fullWMS) {
         this.fullWMS = fullWMS;
+    }
+
+    /**
+     * If this method returns NULL CITE strict compliance mode should not be considered for WMTS
+     * service implementation.
+     *
+     * @return may return TRUE, FALSE or NULL
+     */
+    public Boolean isWmtsCiteCompliant() {
+        return wmtsCiteCompliant;
+    }
+
+    /**
+     * Can be used to force WMTS service implementation to be strictly compliant with the
+     * correspondent CITE tests.
+     *
+     * @param wmtsCiteStrictCompliant TRUE or FALSE, activating or deactivation CITE
+     *                                strict compliance mode for WMTS
+     */
+    public void setWmtsCiteCompliant(Boolean wmtsCiteCompliant) {
+        this.wmtsCiteCompliant = wmtsCiteCompliant;
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
@@ -321,8 +321,8 @@ public class GeoWebCacheConfiguration {
      *
      * @return may return TRUE, FALSE or NULL
      */
-    public Boolean isWmtsCiteCompliant() {
-        return wmtsCiteCompliant;
+    public boolean isWmtsCiteCompliant() {
+        return wmtsCiteCompliant != null ? wmtsCiteCompliant : false;
     }
 
     /**
@@ -332,7 +332,7 @@ public class GeoWebCacheConfiguration {
      * @param wmtsCiteStrictCompliant TRUE or FALSE, activating or deactivation CITE
      *                                strict compliance mode for WMTS
      */
-    public void setWmtsCiteCompliant(Boolean wmtsCiteCompliant) {
+    public void setWmtsCiteCompliant(boolean wmtsCiteCompliant) {
         this.wmtsCiteCompliant = wmtsCiteCompliant;
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
@@ -489,6 +488,8 @@ public class XMLConfiguration implements Configuration, InitializingBean {
 
         xs.alias("serviceInformation", ServiceInformation.class);
         xs.alias("contactInformation", ContactInformation.class);
+
+        xs.omitField(ServiceInformation.class, "citeCompliant");
         
         xs.processAnnotations(TruncateLayerRequest.class);
 
@@ -1002,4 +1003,27 @@ public class XMLConfiguration implements Configuration, InitializingBean {
         return gwcConfig.getLockProvider();
     }
 
+    @Override
+    public boolean isWmtsCiteCompliant() {
+        if (gwcConfig == null || gwcConfig.isWmtsCiteCompliant() == null) {
+            // if there is not configuration available we consider CITE strict compliance to be deactivated
+            return false;
+        }
+        // return whatever CITE compliance mode is defined
+        return gwcConfig.isWmtsCiteCompliant();
+    }
+
+    /**
+     * Can be used to force WMTS service implementation to be strictly compliant with the
+     * correspondent CITE tests.
+     *
+     * @param wmtsCiteStrictCompliant TRUE or FALSE, activating or deactivation CITE
+     *                                strict compliance mode for WMTS
+     */
+    public void setWmtsCiteStrictCompliant(boolean wmtsCiteStrictCompliant) {
+        if (gwcConfig != null) {
+            // activate or deactivate CITE strict compliance mode for WMTS implementation
+            gwcConfig.setWmtsCiteCompliant(wmtsCiteStrictCompliant);
+        }
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -1005,7 +1005,7 @@ public class XMLConfiguration implements Configuration, InitializingBean {
 
     @Override
     public boolean isWmtsCiteCompliant() {
-        if (gwcConfig == null || gwcConfig.isWmtsCiteCompliant() == null) {
+        if (gwcConfig == null) {
             // if there is not configuration available we consider CITE strict compliance to be deactivated
             return false;
         }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/meta/ServiceInformation.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/meta/ServiceInformation.java
@@ -40,6 +40,9 @@ public class ServiceInformation implements Serializable{
 
     private String providerSite;
 
+    // if TRUE the implementation of this service should strictly comply with CITE tests
+    private boolean citeCompliant;
+
     /**
      * @return the title
      */
@@ -152,4 +155,11 @@ public class ServiceInformation implements Serializable{
         this.serviceProvider = serviceProvider;
     }
 
+    public boolean isCiteCompliant() {
+        return citeCompliant;
+    }
+
+    public void setCiteCompliant(boolean citeCompliant) {
+        this.citeCompliant = citeCompliant;
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterException.java
@@ -26,8 +26,33 @@ public class ParameterException extends GeoWebCacheException {
     
     private static final long serialVersionUID = 2471474123508934754L;
 
+    private final int httpCode;
+    private final String exceptionCode;
+    private final String locator;
+
     public ParameterException(String msg) {
         super(msg);
+        httpCode = 500;
+        exceptionCode = "NoApplicableCode";
+        locator = "";
     }
 
+    public ParameterException(int httpCode, String exceptionCode, String locator, String msg) {
+        super(msg);
+        this.httpCode = httpCode;
+        this.exceptionCode = exceptionCode;
+        this.locator = locator;
+    }
+
+    public int getHttpCode() {
+        return httpCode;
+    }
+
+    public String getExceptionCode() {
+        return exceptionCode;
+    }
+
+    public String getLocator() {
+        return locator;
+    }
 }

--- a/geowebcache/core/src/main/resources/geowebcache_cite.xml
+++ b/geowebcache/core/src/main/resources/geowebcache_cite.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://geowebcache.org/schema/1.13.0"
+  xsi:schemaLocation="http://geowebcache.org/schema/1.13.0 http://geowebcache.org/schema/1.13.0/geowebcache.xsd">
+  <version>1.13.0</version>
+  <backendTimeout>120</backendTimeout>
+  <wmtsCiteCompliant>true</wmtsCiteCompliant>
+  <layers/>
+</gwcConfiguration>

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -30,6 +30,14 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="wmtsCiteCompliant" type="xs:boolean" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              If TRUE the implementation of WMTS service will strictly
+              comply with the corresponding CITE tests.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
         <xs:element name="lockProvider" type="xs:string" minOccurs="0">
         <xs:annotation>
           <xs:documentation xml:lang="en">

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -142,6 +142,8 @@ public class XMLConfigurationTest {
         config.setTemplate("/geowebcache.xml");
         config.initialize(gridSetBroker);
         assertEquals(3, config.getTileLayerCount());
+        // WMTS CITE strict compliance should be deactivated
+        assertThat(config.isWmtsCiteCompliant(), is(false));
     }
 
     @Test
@@ -353,5 +355,16 @@ public class XMLConfigurationTest {
         config.initialize(gridSetBroker);
         final String savedVersion = config.getVersion();
         assertEquals(currVersion, savedVersion);
+    }
+
+    @Test
+    public void testWmtsCiteStrictComplianceIsActivated() throws Exception {
+        // delete existing GWC configuration file
+        assertThat(configFile.delete(), is(true));
+        // instantiate a new one based with strict CITE compliance activated
+        config.setTemplate("/geowebcache_cite.xml");
+        config.initialize(gridSetBroker);
+        // CITE strict compliance should be activated for WMTS
+        assertThat(config.isWmtsCiteCompliant(), is(true));
     }
 }

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-wmtsservice-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-wmtsservice-context.xml
@@ -22,5 +22,6 @@
     <constructor-arg ref="gwcURLMangler"/>
     <constructor-arg ref="geowebcacheDispatcher"/>
     <property name="securityDispatcher" ref="gwcSecurityDispatcher"/>
+  <property name="mainConfiguration" ref="gwcXmlConfig"/>
   </bean>
 </beans>

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-wmtsservice-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-wmtsservice-context.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:mvc="http://www.springframework.org/schema/mvc"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
-                           http://www.springframework.org/schema/mvc
-                           http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+
   <description>
-   Bean configuration file for the gwc-wmts module
+    Bean configuration file for the gwc-wmts module
   </description>
 
   <bean id="gwcServiceWMTS"
-	class="org.geowebcache.service.wmts.WMTSService">
-	<constructor-arg ref="gwcStorageBroker"/>
-	<constructor-arg ref="gwcTLDispatcher"/>
-	<constructor-arg ref="gwcGridSetBroker"/>
-	<constructor-arg ref="gwcRuntimeStats"/>
+        class="org.geowebcache.service.wmts.WMTSService">
+    <constructor-arg ref="gwcStorageBroker"/>
+    <constructor-arg ref="gwcTLDispatcher"/>
+    <constructor-arg ref="gwcGridSetBroker"/>
+    <constructor-arg ref="gwcRuntimeStats"/>
     <constructor-arg ref="gwcURLMangler"/>
     <constructor-arg ref="geowebcacheDispatcher"/>
     <property name="securityDispatcher" ref="gwcSecurityDispatcher"/>
-  <property name="mainConfiguration" ref="gwcXmlConfig"/>
+    <property name="mainConfiguration" ref="gwcXmlConfig"/>
   </bean>
 </beans>

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -155,7 +155,7 @@ public class WMTSGetCapabilities {
 
             contents(xml);
             xml.indentElement("ServiceMetadataURL")
-                    .attribute("xlink:href", baseUrl + "?REQUEST=getcapabilities&VERSION=1.0.0")
+                    .attribute("xlink:href", baseUrl + "?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0")
                     .endElement();
 
             xml.indentElement("ServiceMetadataURL")

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
@@ -95,7 +95,7 @@ public class WMTSRestTest {
                         namespaces).nodeCount(1))
                 .andExpect(
                         xpath("//wmts:ServiceMetadataURL[@xlink:href='http://localhost/service/wmts"
-                                + "?REQUEST=getcapabilities&VERSION=1.0.0']", namespaces)
+                                + "?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0']", namespaces)
                                         .nodeCount(1))
                 .andExpect(
                         xpath("//wmts:ServiceMetadataURL[@xlink:href='http://localhost/rest/wmts"

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -290,7 +290,7 @@ public class WMTSServiceTest {
                 + "[@template='http://localhost:8080/geowebcache" + WMTSService.REST_PATH + "/mockLayer/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}?format=application/vnd.ogc.gml'])", doc));        
         // Checking the service metadata URL
         assertEquals("1", xpath.evaluate(
-                "count(//wmts:ServiceMetadataURL[@xlink:href='http://localhost:8080/geowebcache" + WMTSService.SERVICE_PATH + "?REQUEST=getcapabilities&VERSION=1.0.0'])", doc));
+                "count(//wmts:ServiceMetadataURL[@xlink:href='http://localhost:8080/geowebcache" + WMTSService.SERVICE_PATH + "?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0'])", doc));
         assertEquals("1", xpath.evaluate(
                 "count(//wmts:ServiceMetadataURL[@xlink:href='http://localhost:8080/geowebcache" + WMTSService.REST_PATH + "/WMTSCapabilities.xml'])", doc));
     }


### PR DESCRIPTION
Associated issues: 
- https://github.com/GeoWebCache/geowebcache/issues/570
- https://github.com/GeoWebCache/geowebcache/issues/571
- https://github.com/GeoWebCache/geowebcache/issues/573
- https://github.com/GeoWebCache/geowebcache/issues/574

Note that this PR also adds a CITE compliance mode to GeoWebCache, this mode can be activated when using standalone GWC or when using it integrated with GeoServer, related issue is #570.