### PR TITLE
Fix RestIT failure caused by threaded shutdown of previous fixture (resolves #562)

### DIFF
--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/JettyRule.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/JettyRule.java
@@ -157,13 +157,10 @@ public class JettyRule extends org.junit.rules.ExternalResource {
     
     @Override
     protected void after() {
-        // Jetty shutdown takes 100 seconds so do this in a thread to speed it up.
-        new Thread(()->{
-            try {
-                jettyServer.stop();
-            } catch (Exception e) {
-                throw new IllegalStateException("Error while shutting down test Jetty",e);
-            }
-        }).start();
+        try {
+            jettyServer.stop();
+        } catch (Exception e) {
+            log.error("Could not stop Jetty server: " + e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/GeoWebCache/geowebcache/issues/562.

The failure of https://github.com/GeoWebCache/geowebcache/issues/562 is caused by the shutdown thread of the previous fixture shutting down the Jetty instance in use. Do Not Do That Then™.

Shutdown seems to be very quick these days and the thread is no longer needed.