### PR TITLE
[GEOS-8471] Fix 406 error on embedded GWC seed form POST

### DIFF
--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
@@ -206,7 +206,7 @@ public class FormService {
         int threadCount = Integer.parseInt(form.get("threadCount"));
         int zoomStart = Integer.parseInt(form.get("zoomStart"));
         int zoomStop = Integer.parseInt(form.get("zoomStop"));
-        String format = form.get("format");
+        String format = form.get("tileFormat");
         Map<String, String> fullParameters;
         {
             Map<String, String> parameters = new HashMap<String, String>();;
@@ -515,7 +515,7 @@ public class FormService {
             keysValues.put(mime.getFormat(), mime.getFormat());
         }
 
-        makePullDown(doc, "format", keysValues, ImageMime.png.getFormat());
+        makePullDown(doc, "tileFormat", keysValues, ImageMime.png.getFormat());
         doc.append("</td></tr>\n");
     }
 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8471

When the content-type of a POST request is `application/x-www-form-urlencoded`, the BufferedRequestWrapper will add the POST content to the query parameters of the request.

Spring MVC has an option where the `format` parameter can be used to determine the content-type. This is disabled by default, but is enabled in GeoServer (consequently, the issue only affects embedded GWC).

These two features were causing the format parameter of the seed POST to be interpreted as the requested response type (e.g. `image/png`), which was not a valid type for the GWC Rest API (only supports html, json and xml), resulting in the 406 response.

Since this only affects embedded GWC, test cases are in GeoServer: https://github.com/geoserver/geoserver/pull/2683