### PR TITLE
[GEOS-8474] Fix 'Chunk [] is not a valid entry' error in embedded GWC seed form

### DIFF
--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
@@ -137,7 +137,7 @@ public class FormService {
         return new ResponseEntity<Object>(doc.toString(), getHeaders(), HttpStatus.OK);
     }
 
-    public ResponseEntity<?> handleFormPost(HttpServletRequest request, String layer, String body) throws RestException,
+    public ResponseEntity<?> handleFormPost(String layer, Map<String, String> params) throws RestException,
             GeoWebCacheException {
         final TileLayer tl;
         {
@@ -152,21 +152,6 @@ public class FormService {
                 tl = null;
             }
         }
-
-        try {
-            body = URLDecoder.decode(body, "UTF-8");
-        } catch (IOException e) {
-            body = null;
-        }
-
-
-
-        if (body == null || body == "") {
-            throw new RestException("Unable to parse form result.",
-                    HttpStatus.BAD_REQUEST);
-        }
-
-        Map<String, String> params = splitToMap(body);
 
         if (params.containsKey("list")) {
             if (tl == null) {
@@ -769,14 +754,6 @@ public class FormService {
 
     private void makeFooter(StringBuilder doc) {
         doc.append("</body></html>\n");
-    }
-
-    private Map<String, String> splitToMap(String data) {
-        if (data.contains("&")) {
-            return Splitter.on("&").withKeyValueSeparator("=").split(data);
-        }else {
-            return Splitter.on(" ").withKeyValueSeparator("=").split(data);
-        }
     }
 
     private HttpHeaders getHeaders() {

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/SpringRestIT.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/SpringRestIT.java
@@ -181,6 +181,70 @@ public class SpringRestIT {
                 admin.getClient());
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
+
+    /* Content in body, not in query
+     * Simulates request with no content type set
+     */
+    @Test
+    public void testSeedFormPost() throws Exception {
+        String seedQuery = "threadCount=04&type=truncate&gridSetId=EPSG:4326&tileFormat=image/png&zoomStart=01&zoomStop=12&minX=&minY=&maxX=&maxY=";
+
+        CloseableHttpResponse response = handlePost(URI.create("/geowebcache/rest/seed/topp:states"),
+                admin.getClient(), seedQuery);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+    }
+
+    /* Content in body, with URL encoding
+     * Simulates request with Content-Type application/x-www-urlencoded, sent from the actual UI page.
+     */
+    @Test
+    public void testSeedFormPostUrlEncoded() throws Exception {
+        String seedQueryUrlEncoded = "threadCount=04&type=truncate&gridSetId=EPSG%3A4326&tileFormat=image%2Fpng&zoomStart=01&zoomStop=12&minX=&minY=&maxX=&maxY=";
+
+        CloseableHttpResponse response = handlePost(URI.create("/geowebcache/rest/seed/topp:states"),
+                admin.getClient(), seedQueryUrlEncoded);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    /* Content in body, space delimited
+     * Simulates an edge case that GWC supports (presumably for backwards compatibility reasons)
+     */
+    @Test
+    public void testSeedFormPostSpaceDelimited() throws Exception {
+        String seedQuerySpaceDelimited = "threadCount=04 type=truncate gridSetId=EPSG:4326 tileFormat=image/png zoomStart=01 zoomStop=12 minX= minY= maxX= maxY=";
+
+        CloseableHttpResponse response = handlePost(URI.create("/geowebcache/rest/seed/topp:states"),
+                admin.getClient(), seedQuerySpaceDelimited);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    /* Content in query, not in body
+     * Simulates request with Content-Type application/x-www-urlencoded when certain content negotiation parameter
+     * filters are enabled
+     */
+    @Test
+    public void testSeedFormPostQuery() throws Exception {
+        String seedQueryUrlEncoded = "threadCount=04&type=truncate&gridSetId=EPSG%3A4326&tileFormat=image%2Fpng&zoomStart=01&zoomStop=12&minX=&minY=&maxX=&maxY=";
+
+        CloseableHttpResponse response = handlePost(URI.create("/geowebcache/rest/seed/topp:states?" + seedQueryUrlEncoded),
+                admin.getClient(), "");
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    /* Content in query, and in body
+     * Simulates request with Content-Type application/x-www-urlencoded when certain content negotiation parameter
+     * filters are enabled, and the request is wrapped with a BufferedRequestWrapper (Embedded GWC only)
+     */
+    @Test
+    public void testSeedFormPostQueryBody() throws Exception {
+        String seedQuery = "threadCount=04&type=truncate&gridSetId=EPSG:4326&tileFormat=image/png&zoomStart=01&zoomStop=12&minX=&minY=&maxX=&maxY=";
+        String seedQueryUrlEncoded = "threadCount=04&type=truncate&gridSetId=EPSG%3A4326&tileFormat=image%2Fpng&zoomStart=01&zoomStop=12&minX=&minY=&maxX=&maxY=";
+
+        CloseableHttpResponse response = handlePost(URI.create("/geowebcache/rest/seed/topp:states?"+seedQueryUrlEncoded),
+                admin.getClient(), seedQuery);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
     
     @Test
     public void testGetLogo() throws Exception {


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8474

Closely related to https://github.com/GeoWebCache/geowebcache/pull/577 , but only occurs when the GeoServer LoggingFilter is disabled (it is disabled by default in 2.12, but enabled by default in 2.13)

Occurs when the request InputStream is empty / already read / EOF. This occurs only when Content-Type is `application/x-www-urlencoded` (i.e., POST from the seed form page). Enabling the LoggingFilter wraps the request in a BufferedRequestWriter that preserves the contents of the InputStream.

Fixed by getting the urlencoded parameters from the parameter map. Still need to read the body as well, in order to support cases when the Content-Type is not `application/x-www-urlencoded` (which GeoWebCache seems to support)