### PR TITLE
HazelcastCacheProvider should not return null with getSupportedPolicies

### DIFF
--- a/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastCacheProvider.java
+++ b/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastCacheProvider.java
@@ -14,6 +14,7 @@
  */
 package org.geowebcache.storage.blobstore.memory.distributed;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -235,7 +236,7 @@ public class HazelcastCacheProvider implements CacheProvider, DisposableBean {
 
     @Override
     public List<EvictionPolicy> getSupportedPolicies() {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Currently HazelcastCacheProvider#getSupportedPolicies returns null and this causes an exception with Admin page "Caching Defaults " (see https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8608). 