### PR TITLE
Resolves #614, WMS capabilities contains invalid <ows:Identifier/> element

### DIFF
--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
@@ -420,10 +420,15 @@ public class WMSGetCapabilities {
         xml.simpleElement("Format", formatStr, true);
         xml.simpleElement("Layers", layer.getName(), true);
         xml.indentElement("Styles");
-        xml.indentElement("Style");
-        xml.simpleElement("ows:Identifier", ServletUtils.URLEncode(styleName), true);
-        encodeStyleLegendGraphic(xml, legendInfo);
-        xml.endElement();
+        // let's check if a style is available
+        if (styleName != null && !styleName.trim().isEmpty()) {
+            xml.indentElement("Style");
+            // encode the style name
+            xml.simpleElement("Name", ServletUtils.URLEncode(styleName), true);
+            // encode style associated legend
+            encodeStyleLegendGraphic(xml, legendInfo);
+            xml.endElement();
+        }
 
         xml.endElement();
         xml.endElement();

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
@@ -127,15 +127,19 @@ public class WMSGetCapabilitiesTest {
         assertThat(xml, containsString("testAdv"));
         assertThat(xml, not(containsString("testNotAdv")));
 
+        // check no empty style was created
+        assertThat(document.getDocumentElement(), HasXPath.hasXPath("/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/" +
+                "TileSet[Layers='testAdv']/Styles[not(Style/Name)]"));
+
         // check for legends URL for style 1
         assertThat(document.getDocumentElement(), HasXPath.hasXPath("/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/" +
-                "TileSet/Styles/Style[Identifier='style1']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
+                "TileSet/Styles/Style[Name='style1']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
                 "/OnlineResource[@type='simple'][@href='htp://localhost:8080/geoserver?service=WMS&request=GetLegendGraphic&" +
                 "format=image/png&width=50&height=100&layer=testAdv&style=style1']"));
 
         // check for legends URL for style 2
         assertThat(document.getDocumentElement(), HasXPath.hasXPath("/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/" +
-                "TileSet/Styles/Style[Identifier='style2']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
+                "TileSet/Styles/Style[Name='style2']/LegendURL[@width='50'][@height='100'][Format='image/png']" +
                 "/OnlineResource[@type='simple'][@href='htp://localhost:8080/geoserver?service=WMS&request=GetLegendGraphic&" +
                 "format=image/png&width=50&height=100&layer=testAdv&style=style2']"));
         


### PR DESCRIPTION
Associated issue:
https://github.com/GeoWebCache/geowebcache/issues/614

This PR makes a style be encoded only if a non empty and non NULL style name is provided. The correct ``Name`` element is used instead of the invalid ``ows:Identifier``.

Tests were updated accordingly.