### PR TITLE
Fix servlet context path parsing

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
@@ -19,6 +19,8 @@ package org.geowebcache.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.text.ParseException;
@@ -458,35 +460,38 @@ public class ServletUtils {
      */
     public static String getServletBaseURL(HttpServletRequest req, String servletPrefix) {
         String result;
-        if (req.getServerPort() == 80 || req.getServerPort() == 443) {
-            result = req.getScheme() + "://" + req.getServerName();
-        } else {
-            result = req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort();
-        }
-        if(servletPrefix==null){
-            return result;
-        } else {
+        result = req.getScheme() + "://" + req.getHeader("Host");
+        
+        if(servletPrefix!=null){
             // If the servlet is embeded within another, include the context path of the parent 
             // servlet in the base.
             String reqUrl = req.getContextPath();
-            return result+reqUrl;
+            result = result+reqUrl;
         }
-    }
-    
+        
+        try {
+        	URI url = new URI(result);
+        	return url.toString();
+        } catch(URISyntaxException e) {
+        	return "";	// prevents passing invalid stuff via nasty headers
+        }
+    }    
+
     /**
      * Generate the context path of the request, less the specified trailing path
      * @param req
      * @param trailingPath
      */
     public static String getServletContextPath(HttpServletRequest req, String trailingPath, String servletPrefix) {
-        String reqUrl = req.getRequestURL().toString();
-        String servletBase = ServletUtils.getServletBaseURL(req, servletPrefix);
-        int prefixIdx = servletBase.length();
-        int suffixIdx = reqUrl.indexOf(trailingPath);
-        String context = null;
-        if(suffixIdx > -1){
-            context = reqUrl.substring(prefixIdx, suffixIdx);
+        URI urlTokens = null;
+        try {
+        	urlTokens = new URI(req.getRequestURL().toString());
+        } catch(URISyntaxException e) {
+        	return "";	// Prevents passing nasty things in 
         }
+        String path = urlTokens.getPath();
+        int suffixIdx = path.indexOf(trailingPath);
+        String context = path.substring(0,suffixIdx);
         return context;
     }
 
@@ -501,7 +506,7 @@ public class ServletUtils {
         String context = "";
         for (String trailingPath : trailingPaths) {
             context = getServletContextPath(req, trailingPath, servletPrefix);
-            if (context != null) {
+            if (context.length() > 0) {
                 break;
             }
         }


### PR DESCRIPTION
This patch fixes servlet context path parsing which fails in cases where
HTTP request Host attribute does not match exactly with request URL

Example:
geowebcache running in localhost:8080
`$ curl -i -H 'Host: localhost:80' "http://localhost:8080/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true"`
results getCapabilities result with lines:

`<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/service/wms?SERVICE=WMS&amp;"/>`

This is fine but...

`$ curl -i -H 'Host: localhost:443' "http://localhost:8080/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true"`

Produces invalid result

`<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/:443/service/wms?SERVICE=WMS&amp;"/>`

Patch fixes case where ServletUtils.getServletContextPath(HttpServletRequest, String, String) method refers ServletUtils.getServletBaseURL(HttpServletRequest, String) when finding out the context. Latter method is constructing URL based on HTTP's requests "Host" attribute which might differ from URL requested (like in example). Some load balancers does that. Patch modifies the way how those methods produces they result.

Addition to that, this patch also adds some validation for Host attribute and request URL which are
later used in generating getCapabilities response. Validation should prevent injecting arbitary text in that response.

Example:
`$ curl -i -H 'Host: nasty_code%we_dont_want_to_end_up_anywhere!><magic strings>' "http://localhost:8080/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true"`

`<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://nasty_code%we_dont_want_to_end_up_anywhere!&gt;&lt;magic strings&gt;/service/wms?SERVICE=WMS&amp;"/>`

I'm not sure this is actually a security problem but old behaviour is not valid for sure.

NOTE: This is a second version of pull request since  old(#583) one was for branch 1.12.x. This is ported to master. Behaviour of patch remains same.