### PR TITLE
Fixup setter in ServerConfigurationPOJO

### DIFF
--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/ServerConfigurationPOJO.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/ServerConfigurationPOJO.java
@@ -157,7 +157,7 @@ public class ServerConfigurationPOJO implements ServerConfiguration {
     }
 
     @Override
-    public void setFullWMS(Boolean isFullWMS) throws IOException {
+    public void setFullWMS(Boolean fullWMS) throws IOException {
         this.fullWMS = fullWMS;
     }
 


### PR DESCRIPTION
Minor fix, and not especially important since the POJO is generally only ever constructed via reflection or copyConstructor; the setters are only included for completeness. Should still be fixed though.