### PR TITLE
Null check gridsetId in ConveyorTile before getting grid subset. Backport to 1.13

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
@@ -175,7 +175,7 @@ public class ConveyorTile extends Conveyor implements TileResponseReceiver {
     }
 
     public synchronized GridSubset getGridSubset() {
-        if (gridSubset == null) {
+        if (gridSubset == null && gridSetId!= null) {
             gridSubset = tileLayer.getGridSubset(gridSetId);
         }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/conveyor/ConveyorTileTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/conveyor/ConveyorTileTest.java
@@ -1,0 +1,40 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin Smith, Boundless, Copyright 2018
+ */
+
+package org.geowebcache.conveyor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.storage.StorageBroker;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConveyorTileTest {
+
+    @Test
+    public void testGetGridSubsetWithNullGridsetId() {
+        // All these nulls may need to be replace with mocks eventually.
+        ConveyorTile tile = new ConveyorTile((StorageBroker)null, (String)null, (HttpServletRequest)null, (HttpServletResponse)null);
+        tile.setGridSetId(null); // Should be this already but just to make sure.
+        GridSubset result = tile.getGridSubset();
+        Assert.assertThat(result, Matchers.nullValue());
+    }
+
+}


### PR DESCRIPTION
Backport of #623