### PR TITLE
Change DefaultGridSet priority

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
@@ -68,7 +68,7 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
 
         }
         
-        WORLD_EPSG4326 = GridSetFactory.createGridSet("EPSG:4326", SRS.getEPSG4326(),
+        WORLD_EPSG4326 = GridSetFactory.createGridSet(unprojectedName, SRS.getEPSG4326(),
                 BoundingBox.WORLD4326, false, GridSetFactory.DEFAULT_LEVELS, null,
                 GridSetFactory.DEFAULT_PIXEL_SIZE_METER, 256, 256, true);
         WORLD_EPSG4326.setDescription("A default WGS84 tile matrix set where the first zoom level "

--- a/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
@@ -243,7 +243,7 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
 
     @Override
     public int getPriority(Class<? extends BaseConfiguration> clazz) {
-        return GeoWebCacheExtensionPriority.HIGHEST;
+        return GeoWebCacheExtensionPriority.LOWEST;
     }
 
     @Override
@@ -252,7 +252,7 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
 
     @Override
     public int getPriority() {
-        return GeoWebCacheExtensionPriority.HIGHEST;
+        return GeoWebCacheExtensionPriority.LOWEST;
     }
     
     

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetBroker.java
@@ -183,11 +183,33 @@ public class GridSetBroker implements ConfigurationAggregator<GridSetConfigurati
     }
     
     public GridSet getWorldEpsg4326() {
-        return getDefaults().worldEpsg4326();
+        // get the internal default. We need it's name, if nothing else.
+        final GridSet internalDefault4326GridSet = getDefaults().worldEpsg4326();
+        // get the name of the internal default as it may not always be "EPSG:4326"
+        final String internalDefault4326Name = internalDefault4326GridSet.getName();
+        // Use the highest priority EPSG:4326 gridset we have (either an overriden one, or the defaults)
+        Optional<GridSet> gridSet = getGridSet(internalDefault4326Name);
+        if (gridSet.isPresent()) {
+            return gridSet.get();
+        }
+        // probably won't ever hit this, but if 4326 isn't in the configuration at this point, just return the internal
+        // defaults.
+        return internalDefault4326GridSet;
     }
 
     public GridSet getWorldEpsg3857() {
-        return getDefaults().worldEpsg3857();
+        // get the internal default. We need it's name, if nothing else.
+        final GridSet internalDefault3857GridSet = getDefaults().worldEpsg3857();
+        // get the name of the internal default as it may not always be "EPSG:3857"
+        final String internalDefault3857Name = internalDefault3857GridSet.getName();
+        // Use the highest priority EPSG:3857 gridset we have (either an overriden one, or the defaults)
+        Optional<GridSet> gridSet = getGridSet(internalDefault3857Name);
+        if (gridSet.isPresent()) {
+            return gridSet.get();
+        }
+        // probably won't ever hit this, but if 3857 isn't in the configuration at this point, just return the internal
+        // defaults.
+        return internalDefault3857GridSet;
     }
 
     

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -400,25 +400,30 @@ public class XMLConfigurationTest {
         // get the GridSet for 4326, should be the override in the test XML file
         GridSet override4326 = gridSetBroker.get("EPSG:4326");
         assertNotNull(override4326);
-        // get the default GridSet for 4326.
-        GridSet worldEpsg4326 = defaultGridSets.worldEpsg4326();
+        // make sure GridSetBroker returns the overriden 4326 when getWorld4326() is used, so that the same 4326 is used
+        // when asking by name, or convenience method
+        GridSet worldEpsg4326 = gridSetBroker.getWorldEpsg4326();
+        assertNotNull(worldEpsg4326);
+        assertEquals(override4326, worldEpsg4326);
+        // get the internal default GridSet for 4326.
+        GridSet internal4326 = defaultGridSets.worldEpsg4326();
         // override should have a different resolution list
-        assertEquals("Unexpected number of Default EPSG:4326 reslution levels", 22, worldEpsg4326.getNumLevels());
-        assertEquals("Unexpected number of Overriden EPSG:4326 reslution levels", 14, override4326.getNumLevels());
+        assertEquals("Unexpected number of Default EPSG:4326 resolution levels", 22, internal4326.getNumLevels());
+        assertEquals("Unexpected number of Overriden EPSG:4326 resolution levels", 14, override4326.getNumLevels());
         // first level on override should be 1.40625
         final Grid overrideLevel = override4326.getGrid(0);
-        final Grid defaultLevel = worldEpsg4326.getGrid(0);
+        final Grid defaultLevel = internal4326.getGrid(0);
         assertEquals("Unexpected default resolution level 0", 0.703125, defaultLevel.getResolution(), 0d);
         assertEquals("Unexpected override resolution level 0", 1.40625, overrideLevel.getResolution(), 0d);
         // ensure descriptions are expected
         final String overrideDescription = override4326.getDescription();
-        final String defaultDescription = worldEpsg4326.getDescription();
+        final String defaultDescription = internal4326.getDescription();
         assertFalse("Default EPSG:4326 GridSet description should not contain 'OVERRIDE'", defaultDescription.contains(
             "OVERRIDE"));
         assertTrue("Overriden EPSG:4326 GridSet description should contain 'OVERRIDE'", overrideDescription.contains(
             "OVERRIDE"));
     }
-    
+
     @Test
     public void testNoBlobStores() throws Exception{
         assertNotNull(config.getBlobStores());

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/DefaultGridSetsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/DefaultGridSetsTest.java
@@ -1,0 +1,81 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2018
+ *
+ */
+package org.geowebcache.grid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.geowebcache.config.DefaultGridsets;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class DefaultGridSetsTest {
+
+    @Test
+    public void testDefaultMercatorGridSet() throws Exception {
+        // setup GridSet defaults that use legacy names (i.e. use EPSG:######)
+        final DefaultGridsets defaultGridSets = new DefaultGridsets(false, true);
+        // create a GirdSetBroker with the defaults
+        final GridSetBroker broker = new GridSetBroker(Arrays.asList(defaultGridSets));
+        // make sure EPSG:3857 is available and is the mercator default
+        GridSet epsg3857GridSet = broker.get("EPSG:3857");
+        assertNotNull("GridSetBroker missing EPSG:3857 GridSet", epsg3857GridSet);
+        // make sure GoogleMapsCompatible is NOT in the defaults
+        GridSet googleMapsCompatible = broker.get("GoogleMapsCompatible");
+        assertNull("Unexpected GoogleMapsCompatible GridSet found", googleMapsCompatible);
+        // make sure EPSG:900913 is NOT in the defaults
+        GridSet epsg900913GridSet = broker.get("EPSG:900913");
+        assertNull("Unexpected EPSG:900913 GridSet found", epsg900913GridSet);
+        // get the default mercator gridset and make sure it matches the EPSG:3857 gridset
+        GridSet defaultMercatorGridSet = broker.getWorldEpsg3857();
+        assertNotNull("GridSetBroker missing default mercator GridSet", defaultMercatorGridSet);
+        assertEquals("Unexpected default mercator GridSet", epsg3857GridSet, defaultMercatorGridSet);
+    }
+    @Test
+    public void testNonGwc11xDefaultGridSets() throws Exception {
+        // setup GridSet defaults that use non-legacy names (i.e. use GlobalCRS84Geometric instead of EPSG:4326)
+        final DefaultGridsets defaultGridSets = new DefaultGridsets(false, false);
+        // create a GirdSetBroker with the defaults
+        final GridSetBroker broker = new GridSetBroker(Arrays.asList(defaultGridSets));
+        // make sure GlobalCRS84Geometric is available and is the unprojected default
+        GridSet globalCrs84GridSet = broker.get("GlobalCRS84Geometric");
+        assertNotNull("GridSetBroker missing GlobalCRS84Geometric GridSet", globalCrs84GridSet);
+        // make sure that EPSG:4326 is NOT in the defaults
+        GridSet epsg4326GridSet = broker.get("EPSG:4326");
+        assertNull("Unexpected EPSG:4326 GridSet found", epsg4326GridSet);
+        // get the default unprojected gridset and make sure it matches the GlobalCRS84Geometric gridset
+        GridSet defaultUnprojectedGridSet = broker.getWorldEpsg4326();
+        assertNotNull("GridSetBroker missing default unprojected GridSet", defaultUnprojectedGridSet);
+        assertEquals("Unexpected default unprojected GridSet", globalCrs84GridSet, defaultUnprojectedGridSet);
+        // make sure GoogleMapsCompatible is available and is the mercator default
+        GridSet googleMapsCompatible = broker.get("GoogleMapsCompatible");
+        assertNotNull("GridSetBroker missing GoogleMapsCompatible GridSet", googleMapsCompatible);
+        // make sure EPSG:3857 is NOT in the defaults
+        GridSet epsg3857GridSet = broker.get("EPSG:3857");
+        assertNull("Unexpected EPSG:3857 GridSet found", epsg3857GridSet);
+        // make sure EPSG:900913 is NOT in the defaults
+        GridSet epsg900913GridSet = broker.get("EPSG:900913");
+        assertNull("Unexpected EPSG:900913 GridSet found", epsg900913GridSet);
+        // get the default mercator gridset and make sure it matches the GoogleMapsCompatible gridset
+        GridSet defaultMercatorGridSet = broker.getWorldEpsg3857();
+        assertNotNull("GridSetBroker missing default mercator GridSet", defaultMercatorGridSet);
+        assertEquals("Unexpected default mercator GridSet", googleMapsCompatible, defaultMercatorGridSet);
+    }
+}

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://geowebcache.org/schema/1.9.0"
+                  xsi:schemaLocation="http://geowebcache.org/schema/1.9.0 http://geowebcache.org/schema/1.9.0/geowebcache.xsd">
+  <version>1.8.0</version>
+  <backendTimeout>120</backendTimeout>
+  <serviceInformation>
+    <title>GeoWebCache</title>
+    <description>GeoWebCache is an advanced tile cache for WMS servers. It supports a large variety of protocols and
+      formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</description>
+    <keywords>
+      <string>WFS</string>
+      <string>WMS</string>
+      <string>WMTS</string>
+      <string>GEOWEBCACHE</string>
+    </keywords>
+    <serviceProvider>
+      <providerName>John Smith inc.</providerName>
+      <providerSite>http://www.example.com/</providerSite>
+      <serviceContact>
+        <individualName>John Smith</individualName>
+        <positionName>Geospatial Expert</positionName>
+        <addressType>Work</addressType>
+        <addressStreet>1 Bumpy St.</addressStreet>
+        <addressCity>Hobart</addressCity>
+        <addressAdministrativeArea>TAS</addressAdministrativeArea>
+        <addressPostalCode>7005</addressPostalCode>
+        <addressCountry>Australia</addressCountry>
+        <phoneNumber>+61 3 0000 0000</phoneNumber>
+        <faxNumber>+61 3 0000 0001</faxNumber>
+        <addressEmail>john.smith@example.com</addressEmail>
+      </serviceContact>
+    </serviceProvider>
+    <fees>NONE</fees>
+    <accessConstraints>NONE</accessConstraints>
+  </serviceInformation>
+
+  <blobStores>
+    <!-- A sample file blob store configuration. Enable and set as default to override the legacy lookup method for the cache directory  -->
+    <FileBlobStore default="false">
+      <id>defaultCache</id>
+      <enabled>false</enabled>
+      <baseDirectory>/tmp/defaultCache</baseDirectory>
+      <fileSystemBlockSize>4096</fileSystemBlockSize>
+    </FileBlobStore>
+    <!-- A sample AWS S3 blob store configuration.   -->
+    <!--
+   <S3BlobStore>
+     <id>myS3Cache</id>
+     <enabled>false</enabled>
+     <bucket>put-your-actual-bucket-name-here</bucket>
+     <prefix>test-cache</prefix>
+     <awsAccessKey>putYourActualAccessKeyHere</awsAccessKey>
+     <awsSecretKey>putYourActualSecretKeyHere</awsSecretKey>
+     <maxConnections>50</maxConnections>
+     <useHTTPS>true</useHTTPS>
+     <proxyDomain></proxyDomain>
+     <proxyWorkstation></proxyWorkstation>
+     <proxyHost></proxyHost>
+     <proxyPort></proxyPort>
+     <proxyUsername></proxyUsername>
+     <proxyPassword></proxyPassword>
+     <useGzip>true</useGzip>
+   </S3BlobStore>
+    -->
+  </blobStores>
+
+  <gridSets>
+    <!-- Grid Set Example, by default EPSG:900913 and EPSG:4326 are defined -->
+    <gridSet>
+      <!-- This does not have to be an EPSG code, you can also have multiple gridSet elements per SRS -->
+      <name>EPSG:2163</name>
+      <srs>
+        <number>2163</number>
+      </srs>
+      <extent>
+        <coords>
+          <double>-2495667.977678598</double>
+          <double>-2223677.196231552</double>
+          <double>3291070.6104286816</double>
+          <double>959189.3312465074</double>
+        </coords>
+      </extent>
+      <scaleDenominators>
+        <double>25000000</double>
+        <double>1000000</double>
+        <double>100000</double>
+        <double>25000</double>
+      </scaleDenominators>
+      <tileHeight>200</tileHeight>
+      <tileWidth>200</tileWidth>
+    </gridSet>
+    <!-- Override EPSG:4326 default with something differen -->
+    <gridSet>
+      <name>EPSG:4326</name>
+      <description>A default WGS84 tile matrix set where the first zoom level covers the world with two tiles
+        on the horizonal axis and one tile over the vertical axis and each subsequent zoom level is calculated
+        by half the resolution of its previous one. OVERRIDE.
+      </description>
+      <srs>
+        <number>4326</number>
+      </srs>
+      <extent>
+        <coords>
+          <double>-180.0</double>
+          <double>-90.0</double>
+          <double>180.0</double>
+          <double>90.0</double>
+        </coords>
+      </extent>
+      <alignTopLeft>false</alignTopLeft>
+      <resolutions>
+        <double>1.40625</double>   
+        <double>0.703125</double>
+        <double>0.3515625</double>   
+        <double>0.17578125</double>
+        <double>0.087890625</double>
+        <double>0.0439453125</double>
+        <double>0.02197265625</double>
+        <double>0.010986328125</double>
+        <double>0.0054931640625</double>
+        <double>0.00274658203125</double>
+        <double>0.001373291015625</double>
+        <double>6.866455078125E-4</double>
+        <double>3.433227539062E-4</double>
+        <double>1.716613769531E-4</double>
+      </resolutions>
+      <metersPerUnit>111319.49079327358</metersPerUnit>
+      <pixelSize>2.8E-4</pixelSize>
+
+      <tileHeight>256</tileHeight>
+      <tileWidth>256</tileWidth>
+
+      <yCoordinateFirst>false</yCoordinateFirst>
+    </gridSet>
+  </gridSets>
+
+  <layers>
+
+    <wmsLayer>
+      <!--
+      <blobStoreId>myS3Cache</blobStoreId>
+      -->
+      <name>topp:states</name>
+      <mimeFormats>
+        <string>image/gif</string>
+        <string>image/jpeg</string>
+        <string>image/png</string>
+        <string>image/png8</string>
+      </mimeFormats>
+      <gridSubsets>
+        <gridSubset>
+          <gridSetName>EPSG:4326</gridSetName>
+          <extent>
+            <coords>
+              <double>-129.6</double>
+              <double>3.45</double>
+              <double>-62.1</double>
+              <double>70.9</double>
+            </coords>
+          </extent>
+        </gridSubset>
+        <gridSubset>
+          <gridSetName>EPSG:2163</gridSetName>
+        </gridSubset>
+      </gridSubsets>
+      <parameterFilters>
+        <stringParameterFilter>
+          <key>STYLES</key>
+          <defaultValue>population</defaultValue>
+          <values>
+            <string>population</string>
+            <string>polygon</string>
+            <string>pophatch</string>
+          </values>
+        </stringParameterFilter>
+      </parameterFilters>
+      <wmsUrl>
+        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+      </wmsUrl>
+    </wmsLayer>
+
+    <wmsLayer>
+      <name>raster test layer</name>
+      <mimeFormats>
+        <string>image/gif</string>
+        <string>image/jpeg</string>
+        <string>image/png</string>
+        <string>image/png8</string>
+      </mimeFormats>
+      <wmsUrl>
+        <string>http://demo.opengeo.org/geoserver/wms</string>
+      </wmsUrl>
+      <wmsLayers>nurc:Img_Sample</wmsLayers>
+    </wmsLayer>
+
+    <wmsLayer>
+      <name>img states</name>
+      <metaInformation>
+        <title>Nicer title for Image States</title>
+        <description>This is a description. Fascinating.</description>
+      </metaInformation>
+      <mimeFormats>
+        <string>image/gif</string>
+        <string>image/jpeg</string>
+        <string>image/png</string>
+        <string>image/png8</string>
+      </mimeFormats>
+      <!-- Grid Subset Example -->
+      <gridSubsets>
+        <gridSubset>
+          <gridSetName>EPSG:4326</gridSetName>
+          <extent>
+            <coords>
+              <double>-129.6</double>
+              <double>3.45</double>
+              <double>-62.1</double>
+              <double>70.9</double>
+            </coords>
+          </extent>
+        </gridSubset>
+      </gridSubsets>
+      <expireCacheList>
+        <expirationRule minZoom="0" expiration="60" />
+      </expireCacheList>
+      <expireClientsList>
+        <expirationRule minZoom="0" expiration="500" />
+      </expireClientsList>
+      <wmsUrl>
+        <string>http://demo.opengeo.org/geoserver/wms</string>
+      </wmsUrl>
+      <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
+      <transparent>false</transparent>
+      <bgColor>0x0066FF</bgColor>
+    </wmsLayer>
+  </layers>
+
+</gwcConfiguration>
+

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
@@ -90,7 +90,7 @@
       <tileHeight>200</tileHeight>
       <tileWidth>200</tileWidth>
     </gridSet>
-    <!-- Override EPSG:4326 default with something differen -->
+    <!-- Override EPSG:4326 default with something different -->
     <gridSet>
       <name>EPSG:4326</name>
       <description>A default WGS84 tile matrix set where the first zoom level covers the world with two tiles


### PR DESCRIPTION
This change allows any of the internal default GridSets to be overridden in geowebcache.xml. 

Addresses https://github.com/GeoWebCache/geowebcache/issues/620