### PR TITLE
[Backport 1.12] - Fix resoluiton level lookup when layer extent includes gridset bbox

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -443,7 +443,7 @@ public class Demo {
 
             if (gridSubset.fullGridSetCoverage()) {
                 buf.append("      origins: [");
-                for (int i = 0; i < gridSet.getNumLevels(); i++) {
+                for (int i = 0; i < gridSubset.getResolutions().length; i++) {
                     if (i != 0) {
                         buf.append(",");
                     }


### PR DESCRIPTION
If a TileLayer has an extent that includes the entire Bounding Box of a GridSet, the grid Subset will have `fullCoverage` set to `true`. However, if the Layer's Tile Cache configuration is set to restrict while resolution levels are Published/Cached, this code will fail as it assumes all resolution levels in the gridset have available coverages in the grid Subset.

This PR changes the logic to only iterate over the available coverages in the grid Subset in these cases.