### PR TITLE
fix for AuthKey URLs 

### DIFF
--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -387,7 +387,11 @@ public class WMTSGetCapabilities {
         xml.indentElement("ows:Operation").attribute("name", operationName);
         xml.indentElement("ows:DCP");
         xml.indentElement("ows:HTTP");
-        xml.indentElement("ows:Get").attribute("xlink:href", baseUrl+"?");
+        if (baseUrl.contains("?")) {
+            xml.indentElement("ows:Get").attribute("xlink:href", baseUrl + "&");
+        } else {
+            xml.indentElement("ows:Get").attribute("xlink:href", baseUrl + "?");
+        }
         xml.indentElement("ows:Constraint").attribute("name", "GetEncoding");
         xml.indentElement("ows:AllowedValues");
         xml.simpleElement("ows:Value", "KVP", true);


### PR DESCRIPTION
This is a fix for https://github.com/GeoWebCache/geowebcache/issues/640 

It has no test but I'm not sure how to add a test without setting up an authkey server.