### PR TITLE
Modify S3BLogStore to use default credentials provider chain

### DIFF
--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -260,12 +260,12 @@
                 </xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="awsAccessKey" type="xs:string" minOccurs="1">
+            <xs:element name="awsAccessKey" type="xs:string" minOccurs="0">
               <xs:annotation>
                 <xs:documentation xml:lang="en">The public access key the client uses to connect to S3.</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="awsSecretKey" type="xs:string" minOccurs="1">
+            <xs:element name="awsSecretKey" type="xs:string" minOccurs="0">
               <xs:annotation>
                 <xs:documentation xml:lang="en">The secret key the client uses to connect to S3</xs:documentation>
               </xs:annotation>

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStore.java
@@ -94,8 +94,6 @@ public class S3BlobStore implements BlobStore {
             LockProvider lockProvider) throws StorageException {
         checkNotNull(config);
         checkNotNull(layers);
-        checkNotNull(config.getAwsAccessKey(), "Access key not provided");
-        checkNotNull(config.getAwsSecretKey(), "Secret key not provided");
 
         this.bucketName = config.getBucket();
         String prefix = config.getPrefix() == null ? "" : config.getPrefix();


### PR DESCRIPTION
Changes:
- Do not require awsAccessKey and awsAccessSecret in XML config file
- Use the default credential provider chain: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
- Leverage instance profiles for credentials

Addresses concerns in https://github.com/GeoWebCache/geowebcache/issues/632

