### PR TITLE
 Declare transitive spring dependencies in dependency-management

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -38,6 +38,7 @@
     <joda-time.version>2.8.1</joda-time.version>
     <fmt.action>format</fmt.action>
     <fmt.skip>false</fmt.skip>
+    <jackson.version>2.8.7</jackson.version>
   </properties>
   
   <repositories>
@@ -286,6 +287,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <version>${spring.version}</version>
       <scope>test</scope>
@@ -385,6 +391,23 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda-time.version}</version>
+    </dependency>
+
+    <!-- Pin some additional transitive dependencies in S3 module for consistency-->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
   </dependencies>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -256,6 +256,11 @@
     <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
       <version>${spring.version}</version>
     </dependency>
@@ -267,6 +272,11 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
General improvements to the GWC root pom to better handle module dependencies (primarily transitive spring dependencies)

This hasn't yet caused an issue in core GWC, but should be cleaned up.