### PR TITLE
GridSet method access to public for Geoserver Wfs3 vector tiles

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSet.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSet.java
@@ -109,7 +109,7 @@ public class GridSet implements Info {
         this.resolutionsPreserved = resolutionsPreserved;
     }
 
-    protected BoundingBox boundsFromIndex(long[] tileIndex) {
+    public BoundingBox boundsFromIndex(long[] tileIndex) {
         final int tileZ = (int) tileIndex[2];
         Grid grid = getGrid(tileZ);
 


### PR DESCRIPTION
This PR modifies access level from protected to public for a method used in Geoserver WFS3 community module.

Geoserver PR:
https://github.com/geoserver/geoserver/pull/3117