### PR TITLE
Fix sporadic ParametricDataAccessException in H2QuotaStoreTest

### DIFF
--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -572,6 +572,8 @@ public abstract class JDBCQuotaStoreTest {
 
         assertNotNull(store.getTileSetById(tileSet.getId()));
 
+        // make sure previous steps have released the lock
+        Thread.sleep(100);
         store.deleteLayer(layerName);
 
         // cascade deleted?


### PR DESCRIPTION
Occasionally (~50% of my local builds), H2QuotaStoreTest#testDeleteLayer fails with:
```
[ERROR] testDeleteLayer(org.geowebcache.diskquota.jdbc.H2QuotaStoreTest)  Time elapsed: 0.42 s  <<< ERROR!
org.geowebcache.diskquota.jdbc.ParametricDataAccessException: 
Failed to execute statement DELETE FROM TILESET WHERE LAYER_NAME = :layerName with params: {layerName=topp:states2}; nested exception is org.springframework.dao.ConcurrencyFailureException: PreparedStatementCallback; SQL [DELETE FROM TILESET WHERE LAYER_NAME = ?]; Deadlock detected. The current transaction was rolled back. Details: 
Session #12 (user: SA) is waiting to lock PUBLIC.TILESET while locking PUBLIC.TILEPAGE (exclusive).
Session #11 (user: SA) is waiting to lock PUBLIC.TILEPAGE while locking PUBLIC.TILESET (exclusive).; SQL statement:
DELETE FROM TILESET WHERE LAYER_NAME = ? [40001-119]; nested exception is org.h2.jdbc.JdbcSQLException: Deadlock detected. The current transaction was rolled back. Details: 
Session #12 (user: SA) is waiting to lock PUBLIC.TILESET while locking PUBLIC.TILEPAGE (exclusive).
Session #11 (user: SA) is waiting to lock PUBLIC.TILEPAGE while locking PUBLIC.TILESET (exclusive).; SQL statement:
DELETE FROM TILESET WHERE LAYER_NAME = ? [40001-119]
Caused by: org.springframework.dao.ConcurrencyFailureException: 
PreparedStatementCallback; SQL [DELETE FROM TILESET WHERE LAYER_NAME = ?]; Deadlock detected. The current transaction was rolled back. Details: 
Session #12 (user: SA) is waiting to lock PUBLIC.TILESET while locking PUBLIC.TILEPAGE (exclusive).
Session #11 (user: SA) is waiting to lock PUBLIC.TILEPAGE while locking PUBLIC.TILESET (exclusive).; SQL statement:
DELETE FROM TILESET WHERE LAYER_NAME = ? [40001-119]; nested exception is org.h2.jdbc.JdbcSQLException: Deadlock detected. The current transaction was rolled back. Details: 
Session #12 (user: SA) is waiting to lock PUBLIC.TILESET while locking PUBLIC.TILEPAGE (exclusive).
Session #11 (user: SA) is waiting to lock PUBLIC.TILEPAGE while locking PUBLIC.TILESET (exclusive).; SQL statement:
DELETE FROM TILESET WHERE LAYER_NAME = ? [40001-119]
Caused by: org.h2.jdbc.JdbcSQLException: 
Deadlock detected. The current transaction was rolled back. Details: 
Session #12 (user: SA) is waiting to lock PUBLIC.TILESET while locking PUBLIC.TILEPAGE (exclusive).
Session #11 (user: SA) is waiting to lock PUBLIC.TILEPAGE while locking PUBLIC.TILESET (exclusive).; SQL statement:
DELETE FROM TILESET WHERE LAYER_NAME = ? [40001-119]
```

It looks like some of the transactions from the setup haven't completed by the time the layer gets deleted. Adding a Thread.sleep seems to make the error go away.
If anyone knows of a better fix, that would be good.