### PR TITLE
Eliminate JDK11 XStream related warnings

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/io/CollectionConverter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/CollectionConverter.java
@@ -1,0 +1,66 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geowebcache.io;
+
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.mapper.Mapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class CollectionConverter
+        extends com.thoughtworks.xstream.converters.collections.CollectionConverter {
+
+    public static final String UNMODIFIABLE_LIST = "java.util.Collections$UnmodifiableList";
+    public static final String UNMODIFIABLE_SET = "java.util.Collections$UnmodifiableSet";
+    public static final String ARRAY_LIST = "java.util.Arrays$ArrayList";
+
+    public CollectionConverter(Mapper mapper) {
+        super(mapper);
+    }
+
+    public CollectionConverter(Mapper mapper, Class type) {
+        super(mapper, type);
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        if (type != null) {
+            String typeName = type.getName();
+            if (typeName.equals(ARRAY_LIST)
+                    || typeName.equals(UNMODIFIABLE_LIST)
+                    || typeName.equals(UNMODIFIABLE_SET)) {
+                return true;
+            }
+        }
+        return super.canConvert(type);
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        Class requiredType = context.getRequiredType();
+        if (requiredType != null) {
+            String typeName = requiredType.getName();
+            if (UNMODIFIABLE_LIST.equals(typeName)) {
+                List list = new ArrayList<>();
+                populateCollection(reader, context, list);
+                return Collections.unmodifiableList(list);
+            } else if (UNMODIFIABLE_SET.equals(typeName)) {
+                Set set = new HashSet<>();
+                populateCollection(reader, context, set);
+                return Collections.unmodifiableSet(set);
+            } else if (ARRAY_LIST.equals(typeName)) {
+                List list = new ArrayList<>();
+                populateCollection(reader, context, list);
+                return Arrays.asList(list.toArray());
+            }
+        }
+        return super.unmarshal(reader, context);
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/io/GeoWebCacheXStream.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/GeoWebCacheXStream.java
@@ -15,14 +15,54 @@
 package org.geowebcache.io;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.ConverterLookup;
 import com.thoughtworks.xstream.converters.ConverterRegistry;
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+import com.thoughtworks.xstream.converters.basic.BigDecimalConverter;
+import com.thoughtworks.xstream.converters.basic.BigIntegerConverter;
+import com.thoughtworks.xstream.converters.basic.BooleanConverter;
+import com.thoughtworks.xstream.converters.basic.ByteConverter;
+import com.thoughtworks.xstream.converters.basic.CharConverter;
+import com.thoughtworks.xstream.converters.basic.DateConverter;
+import com.thoughtworks.xstream.converters.basic.DoubleConverter;
+import com.thoughtworks.xstream.converters.basic.FloatConverter;
+import com.thoughtworks.xstream.converters.basic.IntConverter;
+import com.thoughtworks.xstream.converters.basic.LongConverter;
+import com.thoughtworks.xstream.converters.basic.NullConverter;
+import com.thoughtworks.xstream.converters.basic.ShortConverter;
+import com.thoughtworks.xstream.converters.basic.StringBufferConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import com.thoughtworks.xstream.converters.basic.URIConverter;
+import com.thoughtworks.xstream.converters.basic.URLConverter;
+import com.thoughtworks.xstream.converters.collections.ArrayConverter;
+import com.thoughtworks.xstream.converters.collections.BitSetConverter;
+import com.thoughtworks.xstream.converters.collections.CharArrayConverter;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
+import com.thoughtworks.xstream.converters.collections.SingletonCollectionConverter;
+import com.thoughtworks.xstream.converters.collections.SingletonMapConverter;
+import com.thoughtworks.xstream.converters.extended.ColorConverter;
+import com.thoughtworks.xstream.converters.extended.EncodedByteArrayConverter;
+import com.thoughtworks.xstream.converters.extended.FileConverter;
+import com.thoughtworks.xstream.converters.extended.GregorianCalendarConverter;
+import com.thoughtworks.xstream.converters.extended.JavaClassConverter;
+import com.thoughtworks.xstream.converters.extended.JavaFieldConverter;
+import com.thoughtworks.xstream.converters.extended.JavaMethodConverter;
+import com.thoughtworks.xstream.converters.extended.LocaleConverter;
+import com.thoughtworks.xstream.converters.extended.LookAndFeelConverter;
+import com.thoughtworks.xstream.converters.extended.SqlDateConverter;
+import com.thoughtworks.xstream.converters.extended.SqlTimeConverter;
+import com.thoughtworks.xstream.converters.extended.SqlTimestampConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionConverter;
 import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
 import com.thoughtworks.xstream.core.ClassLoaderReference;
+import com.thoughtworks.xstream.core.JVM;
+import com.thoughtworks.xstream.core.util.SelfStreamingInstanceChecker;
 import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import com.thoughtworks.xstream.mapper.Mapper;
 import com.thoughtworks.xstream.security.NoTypePermission;
 import com.thoughtworks.xstream.security.PrimitiveTypePermission;
+import java.lang.reflect.Constructor;
 import org.geowebcache.GeoWebCacheExtensions;
 
 /**
@@ -174,6 +214,284 @@ public class GeoWebCacheXStream extends XStream {
         if (whitelistProp != null) {
             String[] wildcards = whitelistProp.split("\\s+|(\\s*;\\s*)");
             this.allowTypesByWildcard(wildcards);
+        }
+    }
+
+    /**
+     * This method is a clone of the base class one, leaving the converters in the same order where
+     * possible, but altering a few ones performing illegal reflective accesses against Java core
+     * classes, replacing them with alternatives that do not, or simply removing them, if we are not
+     * using them
+     */
+    @Override
+    protected void setupConverters() {
+        Mapper mapper = getMapper();
+        ReflectionProvider reflectionProvider = getReflectionProvider();
+        ClassLoaderReference classLoaderReference = getClassLoaderReference();
+        ConverterLookup converterLookup = getConverterLookup();
+
+        registerConverter(new ReflectionConverter(mapper, reflectionProvider), PRIORITY_VERY_LOW);
+
+        registerConverter(new NullConverter(), PRIORITY_VERY_HIGH);
+        registerConverter(new IntConverter(), PRIORITY_NORMAL);
+        registerConverter(new FloatConverter(), PRIORITY_NORMAL);
+        registerConverter(new DoubleConverter(), PRIORITY_NORMAL);
+        registerConverter(new LongConverter(), PRIORITY_NORMAL);
+        registerConverter(new ShortConverter(), PRIORITY_NORMAL);
+        registerConverter((Converter) new CharConverter(), PRIORITY_NORMAL);
+        registerConverter(new BooleanConverter(), PRIORITY_NORMAL);
+        registerConverter(new ByteConverter(), PRIORITY_NORMAL);
+
+        registerConverter(new StringConverter(), PRIORITY_NORMAL);
+        registerConverter(new StringBufferConverter(), PRIORITY_NORMAL);
+        registerConverter(new DateConverter(), PRIORITY_NORMAL);
+        registerConverter(new BitSetConverter(), PRIORITY_NORMAL);
+        registerConverter(new URIConverter(), PRIORITY_NORMAL);
+        registerConverter(new URLConverter(), PRIORITY_NORMAL);
+        registerConverter(new BigIntegerConverter(), PRIORITY_NORMAL);
+        registerConverter(new BigDecimalConverter(), PRIORITY_NORMAL);
+
+        registerConverter(new ArrayConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new CharArrayConverter(), PRIORITY_NORMAL);
+        registerConverter(new CollectionConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new MapConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new TreeMapConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new TreeSetConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new SingletonCollectionConverter(mapper), PRIORITY_NORMAL);
+        registerConverter(new SingletonMapConverter(mapper), PRIORITY_NORMAL);
+        registerConverter((Converter) new EncodedByteArrayConverter(), PRIORITY_NORMAL);
+
+        registerConverter(new FileConverter(), PRIORITY_NORMAL);
+        if (JVM.isSQLAvailable()) {
+            registerConverter(new SqlTimestampConverter(), PRIORITY_NORMAL);
+            registerConverter(new SqlTimeConverter(), PRIORITY_NORMAL);
+            registerConverter(new SqlDateConverter(), PRIORITY_NORMAL);
+        }
+        registerConverter(new JavaClassConverter(classLoaderReference), PRIORITY_NORMAL);
+        registerConverter(new JavaMethodConverter(classLoaderReference), PRIORITY_NORMAL);
+        registerConverter(new JavaFieldConverter(classLoaderReference), PRIORITY_NORMAL);
+
+        if (JVM.isAWTAvailable()) {
+            registerConverter(new ColorConverter(), PRIORITY_NORMAL);
+        }
+        if (JVM.isSwingAvailable()) {
+            registerConverter(
+                    new LookAndFeelConverter(mapper, reflectionProvider), PRIORITY_NORMAL);
+        }
+        registerConverter(new LocaleConverter(), PRIORITY_NORMAL);
+        registerConverter(new GregorianCalendarConverter(), PRIORITY_NORMAL);
+
+        // late bound converters - allows XStream to be compiled on earlier JDKs
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.SubjectConverter",
+                PRIORITY_NORMAL,
+                new Class[] {Mapper.class},
+                new Object[] {mapper});
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.ThrowableConverter",
+                PRIORITY_NORMAL,
+                new Class[] {ConverterLookup.class},
+                new Object[] {converterLookup});
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.StackTraceElementConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.CurrencyConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.RegexPatternConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.CharsetConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+
+        // late bound converters - allows XStream to be compiled on earlier JDKs
+        if (JVM.loadClassForName("javax.xml.datatype.Duration") != null) {
+            registerConverterDynamically(
+                    "com.thoughtworks.xstream.converters.extended.DurationConverter",
+                    PRIORITY_NORMAL,
+                    null,
+                    null);
+        }
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.enums.EnumConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.basic.StringBuilderConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.basic.UUIDConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        if (JVM.loadClassForName("javax.activation.ActivationDataFlavor") != null) {
+            registerConverterDynamically(
+                    "com.thoughtworks.xstream.converters.extended.ActivationDataFlavorConverter",
+                    PRIORITY_NORMAL,
+                    null,
+                    null);
+        }
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.extended.PathConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.ChronologyConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.DurationConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.HijrahDateConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.JapaneseDateConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.JapaneseEraConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.InstantConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.LocalDateConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.LocalDateTimeConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.LocalTimeConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.MinguoDateConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.MonthDayConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.OffsetDateTimeConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.OffsetTimeConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.PeriodConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.SystemClockConverter",
+                PRIORITY_NORMAL,
+                new Class[] {Mapper.class},
+                new Object[] {mapper});
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.ThaiBuddhistDateConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.ValueRangeConverter",
+                PRIORITY_NORMAL,
+                new Class[] {Mapper.class},
+                new Object[] {mapper});
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.WeekFieldsConverter",
+                PRIORITY_NORMAL,
+                new Class[] {Mapper.class},
+                new Object[] {mapper});
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.YearConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.YearMonthConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.ZonedDateTimeConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.time.ZoneIdConverter",
+                PRIORITY_NORMAL,
+                null,
+                null);
+        registerConverterDynamically(
+                "com.thoughtworks.xstream.converters.reflection.LambdaConverter",
+                PRIORITY_NORMAL,
+                new Class[] {Mapper.class, ReflectionProvider.class, ClassLoaderReference.class},
+                new Object[] {mapper, reflectionProvider, classLoaderReference});
+
+        registerConverter(new SelfStreamingInstanceChecker(converterLookup, this), PRIORITY_NORMAL);
+    }
+
+    /**
+     * Straight copy of the registerConverterDynamically private method of XStream, hopefully it
+     * will be removed if XStream relaxes access control
+     */
+    private void registerConverterDynamically(
+            String className,
+            int priority,
+            Class[] constructorParamTypes,
+            Object[] constructorParamValues) {
+        try {
+            Class type = Class.forName(className, false, getClassLoaderReference().getReference());
+            Constructor constructor = type.getConstructor(constructorParamTypes);
+            Object instance = constructor.newInstance(constructorParamValues);
+            if (instance instanceof Converter) {
+                registerConverter((Converter) instance, priority);
+            } else if (instance instanceof SingleValueConverter) {
+                registerConverter((SingleValueConverter) instance, priority);
+            }
+        } catch (Exception e) {
+            throw new com.thoughtworks.xstream.InitializationException(
+                    "Could not instantiate converter : " + className, e);
+        } catch (LinkageError e) {
+            throw new com.thoughtworks.xstream.InitializationException(
+                    "Could not instantiate converter : " + className, e);
         }
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/io/TreeMapConverter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/TreeMapConverter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2004, 2005 Joe Walnes.
+ * Copyright (C) 2006, 2007, 2010, 2011, 2013, 2016 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 08. May 2004 by Joe Walnes
+ */
+package org.geowebcache.io;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
+import com.thoughtworks.xstream.core.JVM;
+import com.thoughtworks.xstream.core.util.HierarchicalStreams;
+import com.thoughtworks.xstream.core.util.PresortedMap;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.Mapper;
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Converts a java.util.TreeMap to XML, and serializes the associated java.util.Comparator. The
+ * converter assumes that the entries in the XML are already sorted according the comparator.
+ *
+ * <p>Cloned from XStream in order to avoid illegal reflective lookup warnings, might introduce
+ * loading issues if there are circular references stored in the TreeSet. We don't have those right
+ * now, the alternative would be open the java.util package for deep reflection from the command
+ * line
+ *
+ * @author Joe Walnes
+ * @author J&ouml;rg Schaible
+ */
+public class TreeMapConverter extends MapConverter {
+
+    private static final class NullComparator extends Mapper.Null implements Comparator {
+        public int compare(Object o1, Object o2) {
+            Comparable c1 = (Comparable) o1;
+            Comparable c2 = (Comparable) o2;
+            return c1.compareTo(o2);
+        }
+    }
+
+    private static final Comparator NULL_MARKER = new NullComparator();
+
+    public TreeMapConverter(Mapper mapper) {
+        super(mapper, TreeMap.class);
+    }
+
+    public void marshal(
+            Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        SortedMap sortedMap = (SortedMap) source;
+        marshalComparator(mapper(), sortedMap.comparator(), writer, context);
+        super.marshal(source, writer, context);
+    }
+
+    protected static void marshalComparator(
+            Mapper mapper,
+            Comparator comparator,
+            HierarchicalStreamWriter writer,
+            MarshallingContext context) {
+        if (comparator != null) {
+            writer.startNode("comparator");
+            writer.addAttribute(
+                    mapper.aliasForSystemAttribute("class"),
+                    mapper.serializedClass(comparator.getClass()));
+            context.convertAnother(comparator);
+            writer.endNode();
+        }
+    }
+
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        TreeMap result = null;
+        final Comparator comparator = unmarshalComparator(mapper(), reader, context, result);
+        if (result == null) {
+            result = comparator == null ? new TreeMap() : new TreeMap(comparator);
+        }
+        populateTreeMap(reader, context, result, comparator);
+        return result;
+    }
+
+    protected static Comparator unmarshalComparator(
+            Mapper mapper,
+            HierarchicalStreamReader reader,
+            UnmarshallingContext context,
+            TreeMap result) {
+        final Comparator comparator;
+        if (reader.hasMoreChildren()) {
+            reader.moveDown();
+            if (reader.getNodeName().equals("comparator")) {
+                Class comparatorClass = HierarchicalStreams.readClassType(reader, mapper);
+                comparator = (Comparator) context.convertAnother(result, comparatorClass);
+            } else if (reader.getNodeName().equals("no-comparator")) { // pre 1.4 format
+                comparator = null;
+            } else {
+                // we are already within the first entry
+                return NULL_MARKER;
+            }
+            reader.moveUp();
+        } else {
+            comparator = null;
+        }
+        return comparator;
+    }
+
+    protected void populateTreeMap(
+            HierarchicalStreamReader reader,
+            UnmarshallingContext context,
+            TreeMap result,
+            Comparator comparator) {
+        boolean inFirstElement = comparator == NULL_MARKER;
+        if (inFirstElement) {
+            comparator = null;
+        }
+        SortedMap sortedMap =
+                new PresortedMap(
+                        comparator != null && JVM.hasOptimizedTreeMapPutAll() ? comparator : null);
+        if (inFirstElement) {
+            // we are already within the first entry
+            putCurrentEntryIntoMap(reader, context, result, sortedMap);
+            reader.moveUp();
+        }
+        populateMap(reader, context, result, sortedMap);
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/io/TreeSetConverter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/TreeSetConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2004, 2005 Joe Walnes.
+ * Copyright (C) 2006, 2007, 2010, 2011, 2013, 2014, 2016 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 08. May 2004 by Joe Walnes
+ */
+package org.geowebcache.io;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.core.util.PresortedSet;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.Mapper;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Converts a java.util.TreeSet to XML, and serializes the associated java.util.Comparator. The
+ * converter assumes that the elements in the XML are already sorted according the comparator.
+ *
+ * <p>Cloned from XStream in order to avoid illegal reflective lookup warnings, might introduce
+ * loading issues if there are circular references stored in the TreeSet. We don't have those right
+ * now, the alternative would be open the java.util package for deep reflection from the command
+ * line
+ *
+ * @author Joe Walnes
+ * @author J&ouml;rg Schaible
+ */
+public class TreeSetConverter extends CollectionConverter {
+    public TreeSetConverter(Mapper mapper) {
+        super(mapper, TreeSet.class);
+    }
+
+    public void marshal(
+            Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        SortedSet sortedSet = (SortedSet) source;
+        TreeMapConverter.marshalComparator(mapper(), sortedSet.comparator(), writer, context);
+        super.marshal(source, writer, context);
+    }
+
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        TreeSet result = null;
+        Comparator unmarshalledComparator =
+                TreeMapConverter.unmarshalComparator(mapper(), reader, context, null);
+        boolean inFirstElement = unmarshalledComparator instanceof Mapper.Null;
+        Comparator comparator = inFirstElement ? null : unmarshalledComparator;
+        final PresortedSet set = new PresortedSet(comparator);
+        result = comparator == null ? new TreeSet() : new TreeSet(comparator);
+        if (inFirstElement) {
+            // we are already within the first element
+            addCurrentElementToCollection(reader, context, result, set);
+            reader.moveUp();
+        }
+        populateCollection(reader, context, result, set);
+        if (set.size() > 0) {
+            result.addAll(set); // comparator will not be called if internally optimized
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Same as in GeoServer, with unfortunate code duplication (there is no shared dependency where to put this), see https://github.com/geoserver/geoserver/pull/3198