### PR TITLE
Restore and update the maven jetty plugin configuration

### DIFF
--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -171,6 +171,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.4.14.v20181114</version>
+        <configuration>
+          <webApp>
+            <contextPath>/geowebcache</contextPath>
+          </webApp>
+          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <stopPort>9966</stopPort>
+          <stopKey>foo</stopKey>
+          <supportedPackagings>
+            <supportedPackaging>jar</supportedPackaging>
+          </supportedPackagings>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This was incorrectly removed during the Spring MVC REST update.
I've restored it, and updated it to a modern version of the plugin.

As before, it can be run using `mvn jetty:run`