### PR TITLE
ClientStreamAbortedException logged at SEVERE level, should be at lower level

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -33,7 +33,7 @@
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs/>
-    <imageio-ext.version>1.1.27</imageio-ext.version>
+    <imageio-ext.version>1.1.28</imageio-ext.version>
     <hazelcast.version>2.3.1</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
     <fmt.action>format</fmt.action>


### PR DESCRIPTION
Upgrade to imageio-ext 1.1.28:

https://github.com/geosolutions-it/imageio-ext/issues/181