### PR TITLE
update to org.json:json:20180813

### DIFF
--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -73,8 +73,8 @@
       </dependency>
     <dependency>
       <groupId>org.json</groupId>
-      <artifactId>org.json</artifactId>
-      <version>2.0</version>
+      <artifactId>json</artifactId>
+      <version>20180813</version>
     </dependency>
   </dependencies>
 

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
@@ -892,7 +892,7 @@ public class RestIntegrationTest {
         JSONObject jsonObject = getResponseEntityAsJSONObject(response);
         jsonObject = jsonObject.getJSONObject("gridSet");
         assertEquals("EPSG:2163", jsonObject.get("name"));
-        assertEquals("2163", jsonObject.getJSONObject("srs").getString("number"));
+        assertEquals(2163, jsonObject.getJSONObject("srs").get("number"));
         assertEquals(
                 "[-2495667.977678598,-2223677.196231552,3291070.6104286816,959189.3312465074]",
                 jsonObject.getJSONObject("extent").get("coords").toString());


### PR DESCRIPTION
The current GeoWebCache release uses a library [org.json:org.json:2.0 ](https://mvnrepository.com/artifact/org.json/org.json/2.0) which is unsupported since 2013. A newer and more actual version is: [org.json:json:20180813](https://mvnrepository.com/artifact/org.json/json/20180813).

I tried to update to the newer version and analyzed its usage. I found JSONObject is used almost internally. A main difference is, that the new json library turned the JSONException into a RuntimeException. Within GeoWebCache all JSONException are catched and turned into an IOException. This should continue to work.

The only issue i found was a failed unit test. But this is not induced by GeoWebCache. Instead it uncovers a flaw of the unit test itself:

`assertEquals("2163", ...getString("number")` works fine with json 2.0 because it automatically converts numbers to strings regardless while json 20180813 is more strict. It refuses to get the value as a string if it is a number. Thus:

`assertEqual(2163, ...get("number")` 

is even better since it asserts that the json value really is a number, not just a String.

The usage of json(2.0) can be traced back to org.restlet which has been removed since 14.07.2017 at 21:30 with [bb5ce18e](https://github.com/GeoWebCache/geowebcache/commit/bb5ce18eecb5a7a027bd1807a7e629de298bb2e1)

Dieter.


