### PR TITLE
[fixes #718] Upgrade or remove commons-fileupload dependency

### DIFF
--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -17,11 +17,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-mbtiles</artifactId>
             <version>${gt.version}</version>


### PR DESCRIPTION
Removes the unused dependency on commons-fileupload. which has a security vulnerability. from the sqlite module.