### PR TITLE
prevent focus steal on macOS

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -568,6 +568,7 @@
         <configuration>
           <forkMode>pertest</forkMode>
           <argLine>${maven.test.jvmargs} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=warn</argLine>
+          <argLine>-Djava.awt.headless=true</argLine> <!-- prevent ForkedBooter focus steal on macOS -->
         </configuration>
       </plugin>
 
@@ -575,6 +576,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.19.1</version>
+        <configuration>
+          <argLine>-Djava.awt.headless=true</argLine> <!-- prevent ForkedBooter focus steal on macOS -->
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Just setting the property at the top of the file does not mean it is passed down to the surefire and failsafe plugins.