### PR TITLE
[issue-718] Upgrade Apache commons fileupload to 1.3.3 version

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -23,6 +23,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-text.version>1.4</commons-text.version>
+    <commons-fileupload.version>1.3.3</commons-fileupload.version>
     <guava.version>27.0-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>
     <log4j.version>1.2.14</log4j.version>
@@ -159,6 +160,11 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons-codec.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>
     </dependency>
 
     <dependency>

--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>


### PR DESCRIPTION
This PR upgrades Apache Commons Fileupload dependency to 1.3.3 version from parent pom.xml.

Issue:
https://github.com/GeoWebCache/geowebcache/issues/718