### PR TITLE
Improve MVC Rest exception handling and returned content type (1.14.x backport)

### DIFF
--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/BlobStoreController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/BlobStoreController.java
@@ -21,7 +21,6 @@ import org.geowebcache.rest.converter.XStreamListAliasWrapper;
 import org.geowebcache.rest.exception.RestException;
 import org.geowebcache.storage.BlobStoreAggregator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,13 +33,6 @@ import org.springframework.web.bind.annotation.*;
 public class BlobStoreController extends GWCController {
 
     @Autowired private BlobStoreAggregator blobStores;
-
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
-        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
-    }
 
     @RequestMapping(
         method = RequestMethod.GET,

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/BoundsController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/BoundsController.java
@@ -21,7 +21,9 @@ import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.rest.exception.RestException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +36,9 @@ public class BoundsController extends GWCController {
 
     @ExceptionHandler(RestException.class)
     public ResponseEntity<?> handleRestException(RestException ex) {
-        return new ResponseEntity<Object>(ex.toString(), ex.getStatus());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
     }
 
     @RequestMapping(value = "/bounds/{layer}/{srs}/{type}", method = RequestMethod.GET)

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/FilterUpdateController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/FilterUpdateController.java
@@ -39,11 +39,6 @@ public class FilterUpdateController extends GWCController {
 
     @Autowired TileLayerDispatcher tld;
 
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        return new ResponseEntity<Object>(ex.toString(), ex.getStatus());
-    }
-
     @RequestMapping(value = "/filter/{filterName}/update/{updateType}", method = RequestMethod.POST)
     public ResponseEntity<?> doPost(
             HttpServletRequest request,

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/GridSetController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/GridSetController.java
@@ -20,7 +20,6 @@ import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.rest.converter.XStreamListAliasWrapper;
 import org.geowebcache.rest.exception.RestException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,13 +32,6 @@ import org.springframework.web.bind.annotation.*;
 public class GridSetController extends GWCController {
 
     @Autowired GridSetBroker broker;
-
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
-        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
-    }
 
     @RequestMapping(
         method = RequestMethod.GET,

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/MassTruncateController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/MassTruncateController.java
@@ -37,7 +37,9 @@ import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -64,7 +66,9 @@ public class MassTruncateController extends GWCSeedingController {
 
     @ExceptionHandler(RestException.class)
     public ResponseEntity<?> handleRestException(RestException ex) {
-        return new ResponseEntity<Object>(ex.toString(), ex.getStatus());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
     }
 
     public void setStorageBroker(StorageBroker broker) {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ReloadController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ReloadController.java
@@ -45,11 +45,6 @@ public class ReloadController {
 
     @Autowired TileLayerDispatcher layerDispatcher;
 
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        return new ResponseEntity<Object>(ex.toString(), ex.getStatus());
-    }
-
     @RequestMapping(value = "/reload", method = RequestMethod.POST)
     public @ResponseBody ResponseEntity<?> doPost(
             HttpServletRequest request,

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/RestExceptionHandler.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/RestExceptionHandler.java
@@ -1,0 +1,49 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino / Geosolutions 2019
+ */
+package org.geowebcache.rest.controller;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.http.HttpServletResponse;
+import org.geowebcache.rest.exception.RestException;
+import org.springframework.http.MediaType;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+/** Common Rest Exception Handler for Spring MVC Controllers. */
+@ControllerAdvice
+public class RestExceptionHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(RestExceptionHandler.class.getName());
+
+    /**
+     * Exception Handler method for {@link RestException}. Ensures the Media Type for the response
+     * is text/plain.
+     */
+    @ExceptionHandler(RestException.class)
+    public void handleRestException(
+            RestException e, HttpServletResponse response, WebRequest request, OutputStream os)
+            throws IOException {
+        LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        response.setStatus(e.getStatus().value());
+        response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+        StreamUtils.copy(e.getMessage(), Charset.forName("UTF-8"), os);
+    }
+}

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/SeedController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/SeedController.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.DefaultingConfiguration;
-import org.geowebcache.rest.exception.RestException;
 import org.geowebcache.rest.service.FormService;
 import org.geowebcache.rest.service.SeedService;
 import org.geowebcache.seed.TileBreeder;
@@ -51,11 +50,6 @@ public class SeedController {
     @Autowired FormService formService;
 
     @Autowired protected DefaultingConfiguration xmlConfig;
-
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        return new ResponseEntity<Object>(ex.toString(), ex.getStatus());
-    }
 
     /**
      * GET method for querying running GWC tasks

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ServerController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ServerController.java
@@ -19,10 +19,7 @@ import org.geowebcache.config.ServerConfiguration;
 import org.geowebcache.rest.converter.ServerConfigurationPOJO;
 import org.geowebcache.rest.exception.RestException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,14 +28,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping(path = "${gwc.context.suffix:}/rest/global")
 public class ServerController {
     @Autowired ServerConfiguration serverConfiguration;
-
-    // TODO: Can this be consolidated across controllers?
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
-        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
-    }
 
     @RequestMapping(method = RequestMethod.GET)
     public ServerConfiguration serverGet() throws IOException {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/TileLayerController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/TileLayerController.java
@@ -34,7 +34,6 @@ import org.geowebcache.util.URLMangler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
@@ -51,13 +50,6 @@ public class TileLayerController extends GWCController {
     private GeoWebCacheDispatcher controller = null;
 
     @Autowired private StorageBroker storageBroker;
-
-    @ExceptionHandler(RestException.class)
-    public ResponseEntity<?> handleRestException(RestException ex) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
-        return new ResponseEntity<Object>(ex.toString(), headers, ex.getStatus());
-    }
 
     // set by spring
     public void setUrlMangler(URLMangler urlMangler) {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/SeedService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/SeedService.java
@@ -51,7 +51,9 @@ import org.geowebcache.util.ApplicationContextProvider;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.WebApplicationContext;
@@ -83,9 +85,13 @@ public class SeedService {
             long[][] list;
             list = seeder.getStatusList();
             obj = new JSONObject(xs.toXML(list));
-            return new ResponseEntity<>(obj.toString(), HttpStatus.OK);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            return new ResponseEntity<>(obj.toString(), headers, HttpStatus.OK);
         } catch (JSONException jse) {
-            return new ResponseEntity<Object>("error", HttpStatus.INTERNAL_SERVER_ERROR);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            return new ResponseEntity<Object>("error", headers, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -107,15 +113,22 @@ public class SeedService {
                 try {
                     seeder.findTileLayer(layer);
                 } catch (GeoWebCacheException e) {
-                    return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.setContentType(MediaType.TEXT_PLAIN);
+                    return new ResponseEntity<String>(
+                            e.getMessage(), headers, HttpStatus.BAD_REQUEST);
                 }
                 list = seeder.getStatusList(layer);
             }
             obj = new JSONObject(xs.toXML(list));
-            return new ResponseEntity<>(obj.toString(), HttpStatus.OK);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            return new ResponseEntity<>(obj.toString(), headers, HttpStatus.OK);
         } catch (JSONException jse) {
             log.error(jse);
-            return new ResponseEntity<Object>("error", HttpStatus.INTERNAL_SERVER_ERROR);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            return new ResponseEntity<Object>("error", headers, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -224,9 +237,13 @@ public class SeedService {
                         HttpStatus.BAD_REQUEST);
             }
             handleRequest(layer, obj);
-            return new ResponseEntity<Object>(HttpStatus.OK);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            return new ResponseEntity<Object>(headers, HttpStatus.OK);
         } catch (IOException e) {
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            return new ResponseEntity<Object>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/BoundsControllerMVCTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/BoundsControllerMVCTest.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino (Geosolutions), 2019
+ */
 package org.geowebcache.rest.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
     "file:../web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml",
     "file:../web/src/main/webapp/WEB-INF/geowebcache-core-context.xml"
 })
-public class BlobStoreControllerTest {
+public class BoundsControllerMVCTest {
 
     @Autowired private WebApplicationContext wac;
 
@@ -35,9 +49,9 @@ public class BlobStoreControllerTest {
 
     /** Checks correct media type for RestException response handling. GET method. */
     @Test
-    public void testBlobstoresGetContentType() throws Exception {
+    public void testBoundsGetContentType() throws Exception {
         mockMvc.perform(
-                        get("/rest/blobstores/{blobStoreName}", "xxxp4z85")
+                        get("/rest/bounds/{layer}/{srs}/{type}", "xxxp4z85", "4326", "nothanks")
                                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(content().contentType(MediaType.TEXT_PLAIN))
                 .andExpect(status().is4xxClientError());

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/FilterUpdateControllerMVCTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/FilterUpdateControllerMVCTest.java
@@ -1,6 +1,20 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino (Geosolutions), 2019
+ */
 package org.geowebcache.rest.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
     "file:../web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml",
     "file:../web/src/main/webapp/WEB-INF/geowebcache-core-context.xml"
 })
-public class BlobStoreControllerTest {
+public class FilterUpdateControllerMVCTest {
 
     @Autowired private WebApplicationContext wac;
 
@@ -33,11 +47,11 @@ public class BlobStoreControllerTest {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
 
-    /** Checks correct media type for RestException response handling. GET method. */
+    /** Checks correct media type for RestException response handling. POST method. */
     @Test
-    public void testBlobstoresGetContentType() throws Exception {
+    public void testFilterGetContentType() throws Exception {
         mockMvc.perform(
-                        get("/rest/blobstores/{blobStoreName}", "xxxp4z85")
+                        post("/rest/filter/{filterName}/update/{updateType}", "xxxp4z85", "noidea")
                                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(content().contentType(MediaType.TEXT_PLAIN))
                 .andExpect(status().is4xxClientError());

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/GridSetControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/GridSetControllerTest.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino (Geosolutions), 2019
+ */
 package org.geowebcache.rest.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
     "file:../web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml",
     "file:../web/src/main/webapp/WEB-INF/geowebcache-core-context.xml"
 })
-public class BlobStoreControllerTest {
+public class GridSetControllerTest {
 
     @Autowired private WebApplicationContext wac;
 
@@ -35,9 +49,9 @@ public class BlobStoreControllerTest {
 
     /** Checks correct media type for RestException response handling. GET method. */
     @Test
-    public void testBlobstoresGetContentType() throws Exception {
+    public void testGridsetsGetContentType() throws Exception {
         mockMvc.perform(
-                        get("/rest/blobstores/{blobStoreName}", "xxxp4z85")
+                        get("/rest/gridsets/{gridset}", "xxxp4z85")
                                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(content().contentType(MediaType.TEXT_PLAIN))
                 .andExpect(status().is4xxClientError());

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/SeedControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/SeedControllerTest.java
@@ -1,0 +1,87 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino (Geosolutions), 2019
+ */
+package org.geowebcache.rest.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration()
+@ContextConfiguration({
+    "file:../web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml",
+    "file:../web/src/main/webapp/WEB-INF/geowebcache-core-context.xml"
+})
+public class SeedControllerTest {
+
+    @Autowired private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Configuration
+    @ComponentScan(basePackages = {"org.geowebcache.rest.controller"})
+    @EnableWebMvc
+    static class Config {
+        @Bean
+        PropertyPlaceholderConfigurer propConfig() {
+            PropertyPlaceholderConfigurer ppc = new PropertyPlaceholderConfigurer();
+            ppc.setLocation(new ClassPathResource("test.properties"));
+            return ppc;
+        }
+    }
+
+    /** Checks correct media type for RestException response handling. GET method. */
+    @Test
+    public void testSeedGetContentType() throws Exception {
+        mockMvc.perform(get("/rest/seed/{layer}", "xxxp4z85").accept(MediaType.TEXT_HTML))
+                .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+                .andExpect(status().is4xxClientError());
+    }
+
+    /** Checks correct media type for RestException response handling. POST method. */
+    @Test
+    public void testSeedPostContentType() throws Exception {
+        mockMvc.perform(
+                        post("/rest/seed/{layer}", "xxxp4z85")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .accept(MediaType.TEXT_HTML))
+                .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+                .andExpect(status().is4xxClientError());
+    }
+}

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/TileLayerControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/controller/TileLayerControllerTest.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino (Geosolutions), 2019
+ */
 package org.geowebcache.rest.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
     "file:../web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml",
     "file:../web/src/main/webapp/WEB-INF/geowebcache-core-context.xml"
 })
-public class BlobStoreControllerTest {
+public class TileLayerControllerTest {
 
     @Autowired private WebApplicationContext wac;
 
@@ -35,10 +49,8 @@ public class BlobStoreControllerTest {
 
     /** Checks correct media type for RestException response handling. GET method. */
     @Test
-    public void testBlobstoresGetContentType() throws Exception {
-        mockMvc.perform(
-                        get("/rest/blobstores/{blobStoreName}", "xxxp4z85")
-                                .accept(MediaType.APPLICATION_JSON))
+    public void testLayersGetContentType() throws Exception {
+        mockMvc.perform(get("/rest/layers/{layer}", "xxxp4z85").accept(MediaType.TEXT_HTML))
                 .andExpect(content().contentType(MediaType.TEXT_PLAIN))
                 .andExpect(status().is4xxClientError());
     }

--- a/geowebcache/rest/src/test/resources/test.properties
+++ b/geowebcache/rest/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+gwc.context.suffix:


### PR DESCRIPTION
This PR improves RestException handling moving to central Controller Advise when can (since some controller need to have it locally by a test) and setting the right content type before returning ResponseEntity to Spring MVC layer.

Also added some full MVC integration test classes for testing exception handler.

1.14.x backport.