### PR TITLE
Azure blobstore backport to 1.15.x

### DIFF
--- a/geowebcache/azureblob/pom.xml
+++ b/geowebcache/azureblob/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geowebcache</artifactId>
+        <groupId>org.geowebcache</groupId>
+        <version>1.16-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.geowebcache</groupId>
+    <artifactId>gwc-azure-blob</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geowebcache</groupId>
+            <artifactId>gwc-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+      
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <!-- at the time of writing 11.0.1 was available but pom on repoes was corrupted -->
+            <version>11.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geowebcache</groupId>
+            <artifactId>gwc-core</artifactId>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/geowebcache/azureblob/pom.xml
+++ b/geowebcache/azureblob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>geowebcache</artifactId>
         <groupId>org.geowebcache</groupId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.15-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
@@ -1,0 +1,471 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.isNull;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.microsoft.azure.storage.blob.BlockBlobURL;
+import com.microsoft.azure.storage.blob.DownloadResponse;
+import com.microsoft.azure.storage.blob.models.BlobGetPropertiesResponse;
+import com.microsoft.azure.storage.blob.models.BlobHTTPHeaders;
+import com.microsoft.azure.storage.blob.models.BlobItem;
+import com.microsoft.rest.v2.RestException;
+import com.microsoft.rest.v2.util.FlowableUtil;
+import io.reactivex.Flowable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.BlobStoreListener;
+import org.geowebcache.storage.BlobStoreListenerList;
+import org.geowebcache.storage.CompositeBlobStore;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+import org.geowebcache.storage.TileRangeIterator;
+import org.springframework.http.HttpStatus;
+
+public class AzureBlobStore implements BlobStore {
+
+    static Log log = LogFactory.getLog(AzureBlobStore.class);
+
+    private final TMSKeyBuilder keyBuilder;
+    private final BlobStoreListenerList listeners = new BlobStoreListenerList();
+    private final AzureClient client;
+    private DeleteManager deleteManager;
+
+    private volatile boolean shutDown = false;
+
+    public AzureBlobStore(
+            AzureBlobStoreInfo configuration, TileLayerDispatcher layers, LockProvider lockProvider)
+            throws StorageException {
+        this.client = new AzureClient(configuration);
+
+        String prefix = Optional.ofNullable(configuration.getPrefix()).orElse("");
+        this.keyBuilder = new TMSKeyBuilder(prefix, layers);
+
+        // check target is suitable for a cache
+        boolean emptyFolder = client.listBlobs(prefix, 1).isEmpty();
+        boolean existingMetadata = !client.listBlobs(keyBuilder.storeMetadata(), 1).isEmpty();
+        CompositeBlobStore.checkSuitability(
+                configuration.getLocation(), existingMetadata, emptyFolder);
+
+        // Just a marker to indicate this is a GWC cache.
+        client.putProperties(keyBuilder.storeMetadata(), new Properties());
+
+        // deletes are a complicated beast, we have a dedicated class to run them
+        deleteManager =
+                new DeleteManager(
+                        client, lockProvider, keyBuilder, configuration.getMaxConnections());
+        deleteManager.issuePendingBulkDeletes();
+    }
+
+    @Override
+    public boolean delete(String layerName) throws StorageException {
+        checkNotNull(layerName, "layerName");
+
+        final String metadataKey = keyBuilder.layerMetadata(layerName);
+        final String layerPrefix = keyBuilder.forLayer(layerName);
+
+        // this might not be there, tolerant delete
+        try {
+            BlockBlobURL metadata = client.getBlockBlobURL(metadataKey);
+            int statusCode = metadata.delete().blockingGet().statusCode();
+            if (!HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
+                return false;
+            }
+        } catch (RestException e) {
+            return false;
+        }
+
+        boolean layerExists = deleteManager.scheduleAsyncDelete(layerPrefix);
+        if (layerExists) {
+            listeners.sendLayerDeleted(layerName);
+        }
+        return layerExists;
+    }
+
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        checkNotNull(layerName, "layerName");
+        checkNotNull(parametersId, "parametersId");
+
+        boolean prefixExists =
+                keyBuilder
+                        .forParameters(layerName, parametersId)
+                        .stream()
+                        .map(
+                                prefix -> {
+                                    try {
+                                        return deleteManager.scheduleAsyncDelete(prefix);
+                                    } catch (StorageException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .reduce(Boolean::logicalOr) // Don't use Stream.anyMatch as it would short
+                        // circuit
+                        .orElse(false);
+        if (prefixExists) {
+            listeners.sendParametersDeleted(layerName, parametersId);
+        }
+        return prefixExists;
+    }
+
+    @Override
+    public boolean deleteByGridsetId(final String layerName, final String gridSetId)
+            throws StorageException {
+
+        checkNotNull(layerName, "layerName");
+        checkNotNull(gridSetId, "gridSetId");
+
+        final String gridsetPrefix = keyBuilder.forGridset(layerName, gridSetId);
+
+        boolean prefixExists = deleteManager.scheduleAsyncDelete(gridsetPrefix);
+        if (prefixExists) {
+            listeners.sendGridSubsetDeleted(layerName, gridSetId);
+        }
+        return prefixExists;
+    }
+
+    @Override
+    public boolean delete(TileObject obj) throws StorageException {
+        final String key = keyBuilder.forTile(obj);
+        BlockBlobURL blob = client.getBlockBlobURL(key);
+
+        // don't bother for the extra call if there are no listeners
+        if (listeners.isEmpty()) {
+            try {
+                int statusCode = blob.delete().blockingGet().statusCode();
+                return HttpStatus.valueOf(statusCode).is2xxSuccessful();
+            } catch (RestException e) {
+                return false;
+            }
+        }
+
+        try {
+            // if there are listeners, gather extra information
+            BlobGetPropertiesResponse properties = blob.getProperties().blockingGet();
+            Long oldSize = properties.headers().contentLength();
+            int statusCode = blob.delete().blockingGet().statusCode();
+            if (!HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
+                return false;
+            }
+            if (oldSize != null) {
+                obj.setBlobSize(oldSize.intValue());
+            }
+        } catch (RestException e) {
+            if (e.response().statusCode() != 404) {
+                throw new StorageException("Failed to delete tile ", e);
+            }
+            return false;
+        }
+        listeners.sendTileDeleted(obj);
+        return true;
+    }
+
+    @Override
+    public boolean delete(TileRange tileRange) throws StorageException {
+        // see if there is anything to delete in that range by computing a prefix
+        final String coordsPrefix = keyBuilder.coordinatesPrefix(tileRange);
+        if (client.listBlobs(coordsPrefix, 1).isEmpty()) {
+            return false;
+        }
+
+        // open an iterator oer tile locations, to avoid memory accumulation
+        final Iterator<long[]> tileLocations =
+                new AbstractIterator<long[]>() {
+
+                    // TileRange iterator with 1x1 meta tiling factor
+                    private TileRangeIterator trIter =
+                            new TileRangeIterator(tileRange, new int[] {1, 1});
+
+                    @Override
+                    protected long[] computeNext() {
+                        long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
+                        return gridLoc == null ? endOfData() : gridLoc;
+                    }
+                };
+
+        // if no listeners, we don't need to gather extra tile info, use a dedicated fast path
+        if (listeners.isEmpty()) {
+            // if there are no listeners, don't bother requesting every tile
+            // metadata to notify the listeners
+            Iterator<String> keysIterator =
+                    Iterators.transform(
+                            tileLocations,
+                            tl ->
+                                    keyBuilder.forLocation(
+                                            coordsPrefix, tl, tileRange.getMimeType()));
+            // split the iteration in parts to avoid memory accumulation
+            Iterator<List<String>> partition =
+                    Iterators.partition(keysIterator, DeleteManager.PAGE_SIZE);
+
+            while (partition.hasNext() && !shutDown) {
+                List<String> locations = partition.next();
+                deleteManager.deleteParallel(locations);
+            }
+
+        } else {
+            // if we need to gather info, we'll end up just calling "delete" on each tile
+            // this is run here instead of inside the delete manager as we need high level info
+            // about tiles, e.g., TileObject, to inform the listeners
+            String layerName = tileRange.getLayerName();
+            String gridSetId = tileRange.getGridSetId();
+            String format = tileRange.getMimeType().getFormat();
+            Map<String, String> parameters = tileRange.getParameters();
+
+            Iterator<Callable> tilesIterator =
+                    Iterators.transform(
+                            tileLocations,
+                            xyz -> {
+                                TileObject tile =
+                                        TileObject.createQueryTileObject(
+                                                layerName, xyz, gridSetId, format, parameters);
+                                tile.setParametersId(tileRange.getParametersId());
+                                return new Callable() {
+                                    @Override
+                                    public Object call() throws Exception {
+                                        return delete(tile);
+                                    }
+                                };
+                            });
+            Iterator<List<Callable>> partition =
+                    Iterators.partition(tilesIterator, DeleteManager.PAGE_SIZE);
+
+            // once a page of callables is ready, run them in parallel on the delete manager
+            while (partition.hasNext() && !shutDown) {
+                deleteManager.executeParallel(partition.next());
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean get(TileObject obj) throws StorageException {
+        final String key = keyBuilder.forTile(obj);
+        final BlockBlobURL blob = client.getBlockBlobURL(key);
+        try {
+            DownloadResponse response = blob.download().blockingGet();
+            ByteBuffer buffer =
+                    FlowableUtil.collectBytesInBuffer(response.body(null)).blockingGet();
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+
+            obj.setBlobSize(bytes.length);
+            obj.setBlob(new ByteArrayResource(bytes));
+            obj.setCreated(response.headers().lastModified().toEpochSecond() * 1000l);
+        } catch (RestException e) {
+            if (e.response().statusCode() == 404) {
+                return false;
+            }
+            throw new StorageException("Error getting " + key, e);
+        }
+        return true;
+    }
+
+    @Override
+    public void put(TileObject obj) throws StorageException {
+        final Resource blob = obj.getBlob();
+        checkNotNull(blob);
+        checkNotNull(obj.getBlobFormat());
+
+        final String key = keyBuilder.forTile(obj);
+
+        BlockBlobURL blobURL = client.getBlockBlobURL(key);
+
+        // if there are listeners, gather first the old size with a "head" request
+        Long oldSize = null;
+        boolean existed = false;
+        if (!listeners.isEmpty()) {
+            try {
+                BlobGetPropertiesResponse properties = blobURL.getProperties().blockingGet();
+                oldSize = properties.headers().contentLength();
+                existed = true;
+            } catch (RestException e) {
+                if (e.response().statusCode() != HttpStatus.NOT_FOUND.value()) {
+                    throw new StorageException("Failed to check if the container exists", e);
+                }
+            }
+        }
+
+        // then upload
+        try (InputStream is = blob.getInputStream()) {
+            byte[] bytes = IOUtils.toByteArray(is);
+            ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            String mimeType = MimeType.createFromFormat(obj.getBlobFormat()).getMimeType();
+            BlobHTTPHeaders headers = new BlobHTTPHeaders().withBlobContentType(mimeType);
+            int status =
+                    blobURL.upload(Flowable.just(buffer), bytes.length, headers, null, null, null)
+                            .blockingGet()
+                            .statusCode();
+            if (!HttpStatus.valueOf(status).is2xxSuccessful()) {
+                throw new StorageException(
+                        "Failed to upload tile to Azure on container "
+                                + client.getContainerName()
+                                + " and key "
+                                + key
+                                + " got HTTP  status "
+                                + status);
+            }
+        } catch (RestException | IOException | MimeException e) {
+            throw new StorageException(
+                    "Failed to upload tile to Azure on container "
+                            + client.getContainerName()
+                            + " and key "
+                            + key,
+                    e);
+        }
+        // along with the metadata
+        putParametersMetadata(obj.getLayerName(), obj.getParametersId(), obj.getParameters());
+
+        // This is important because listeners may be tracking tile existence
+        if (!listeners.isEmpty()) {
+            if (existed) {
+                listeners.sendTileUpdated(obj, oldSize);
+            } else {
+                listeners.sendTileStored(obj);
+            }
+        }
+    }
+
+    private void putParametersMetadata(
+            String layerName, String parametersId, Map<String, String> parameters) {
+        assert (isNull(parametersId) == isNull(parameters));
+        if (isNull(parametersId)) {
+            return;
+        }
+        Properties properties = new Properties();
+        parameters.forEach(properties::setProperty);
+        String resourceKey = keyBuilder.parametersMetadata(layerName, parametersId);
+        try {
+            client.putProperties(resourceKey, properties);
+        } catch (StorageException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void clear() throws StorageException {
+        // mimicking the S3 store here. The parent class javadoc says it should only be used for
+        // testing anyways
+        throw new UnsupportedOperationException("clear() should not be called");
+    }
+
+    @Override
+    public void destroy() {
+        shutDown = true;
+        if (client != null) {
+            client.close();
+        }
+        if (deleteManager != null) {
+            deleteManager.close();
+        }
+    }
+
+    @Override
+    public void addListener(BlobStoreListener listener) {
+        listeners.addListener(listener);
+    }
+
+    @Override
+    public boolean removeListener(BlobStoreListener listener) {
+        return listeners.removeListener(listener);
+    }
+
+    @Override
+    public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
+        log.debug("No need to rename layers, AzureBlobStore uses layer id as key root");
+        if (client.listBlobs(oldLayerName, 1).size() > 0) {
+            listeners.sendLayerRenamed(oldLayerName, newLayerName);
+        }
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public String getLayerMetadata(String layerName, String key) {
+        Properties properties = getLayerMetadata(layerName);
+        String value = properties.getProperty(key);
+        return value;
+    }
+
+    @Override
+    public void putLayerMetadata(String layerName, String key, String value) {
+        Properties properties = getLayerMetadata(layerName);
+        properties.setProperty(key, value);
+        String resourceKey = keyBuilder.layerMetadata(layerName);
+        try {
+            client.putProperties(resourceKey, properties);
+        } catch (StorageException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Properties getLayerMetadata(String layerName) {
+        String key = keyBuilder.layerMetadata(layerName);
+        try {
+            return client.getProperties(key);
+        } catch (StorageException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean layerExists(String layerName) {
+        final String coordsPrefix = keyBuilder.forLayer(layerName);
+        return client.listBlobs(coordsPrefix, 1).size() > 0;
+    }
+
+    @Override
+    public Map<String, Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        // going big, with MAX_VALUE, since at the end everything must be held in memory anyways
+        List<BlobItem> items =
+                client.listBlobs(keyBuilder.parametersMetadataPrefix(layerName), Integer.MAX_VALUE);
+        Map<String, Optional<Map<String, String>>> result = new HashMap<>();
+        try {
+            for (BlobItem item : items) {
+                Map<String, String> properties =
+                        (Map<String, String>) (Map<?, ?>) client.getProperties(item.name());
+                result.put(ParametersUtils.getId(properties), Optional.of(properties));
+            }
+            return result;
+        } catch (StorageException e) {
+            throw new RuntimeException("Failed to retrieve properties mappings", e);
+        }
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreConfigProvider.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreConfigProvider.java
@@ -1,0 +1,109 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import com.google.common.base.Strings;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+import com.thoughtworks.xstream.converters.basic.BooleanConverter;
+import com.thoughtworks.xstream.converters.basic.IntConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.geowebcache.GeoWebCacheExtensions;
+import org.geowebcache.config.BlobStoreInfo;
+import org.geowebcache.config.Info;
+import org.geowebcache.config.XMLConfigurationProvider;
+
+public class AzureBlobStoreConfigProvider implements XMLConfigurationProvider {
+
+    private static GeoWebCacheEnvironment gwcEnvironment = null;
+
+    private static SingleValueConverter EnvironmentNullableIntConverter =
+            new IntConverter() {
+
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return super.fromString(str);
+                }
+            };
+
+    private static SingleValueConverter EnvironmentNullableBooleanConverter =
+            new BooleanConverter() {
+
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return super.fromString(str);
+                }
+            };
+
+    private static SingleValueConverter EnvironmentStringConverter =
+            new StringConverter() {
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return str;
+                }
+            };
+
+    private static String resolveFromEnv(String str) {
+        if (gwcEnvironment == null) {
+            gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
+        }
+        if (gwcEnvironment != null
+                && str != null
+                && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            Object result = gwcEnvironment.resolveValue(str);
+            if (result == null) {
+                return null;
+            }
+            return result.toString();
+        }
+        return str;
+    }
+
+    @Override
+    public XStream getConfiguredXStream(XStream xs) {
+        Class<AzureBlobStoreInfo> clazz = AzureBlobStoreInfo.class;
+        xs.alias("AzureBlobStore", clazz);
+        xs.registerLocalConverter(clazz, "maxConnections", EnvironmentNullableIntConverter);
+        xs.registerLocalConverter(clazz, "proxyPort", EnvironmentNullableIntConverter);
+        xs.registerLocalConverter(clazz, "useHTTPS", EnvironmentNullableBooleanConverter);
+        xs.registerLocalConverter(clazz, "container", EnvironmentStringConverter);
+        xs.registerLocalConverter(clazz, "accountName", EnvironmentStringConverter);
+        xs.registerLocalConverter(clazz, "accountKey", EnvironmentStringConverter);
+        xs.registerLocalConverter(clazz, "prefix", EnvironmentStringConverter);
+        xs.registerLocalConverter(clazz, "proxyHost", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                BlobStoreInfo.class, "enabled", EnvironmentNullableBooleanConverter);
+        xs.aliasField("id", clazz, "name");
+        return xs;
+    }
+
+    @Override
+    public boolean canSave(Info i) {
+        return i instanceof AzureBlobStoreInfo;
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
@@ -1,0 +1,267 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.BlobStoreInfo;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.StorageException;
+
+/** Plain old java object representing the configuration for an S3 blob store. */
+public class AzureBlobStoreInfo extends BlobStoreInfo {
+
+    /**
+     * Max number of connections used inside the Netty HTTP client. Might seem a lot, but when
+     * deleting we have to issue a delete on each single tile, so we need a large parallelism to
+     * make that feasible
+     */
+    public static final int DEFAULT_CONNECTIONS = 100;
+
+    static Log log = LogFactory.getLog(AzureBlobStoreInfo.class);
+
+    private String container;
+
+    private String prefix;
+
+    private String accountName;
+
+    private String accountKey;
+
+    private Integer maxConnections;
+
+    private Boolean useHTTPS = true;
+
+    private String proxyHost;
+
+    private Integer proxyPort;
+
+    private String proxyUsername;
+
+    private String proxyPassword;
+
+    private String serviceURL;
+
+    public AzureBlobStoreInfo() {
+        super();
+    }
+
+    public AzureBlobStoreInfo(String id) {
+        super(id);
+    }
+
+    /** @return the name of the AWS S3 bucket where to store tiles */
+    public String getContainer() {
+        return container;
+    }
+
+    /** Sets the name of the AWS S3 bucket where to store tiles */
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public void setAccountName(String accountName) {
+        this.accountName = accountName;
+    }
+
+    public String getAccountKey() {
+        return accountKey;
+    }
+
+    public void setAccountKey(String accountKey) {
+        this.accountKey = accountKey;
+    }
+
+    public String getServiceURL() {
+        return serviceURL;
+    }
+
+    public void setServiceURL(String serviceURL) {
+        this.serviceURL = serviceURL;
+    }
+
+    /**
+     * Returns the base prefix, which is a prefix path to use as the root to store tiles under the
+     * bucket.
+     *
+     * @return optional string for a "base prefix"
+     */
+    @Nullable
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /** @return The maximum number of allowed open HTTP connections. */
+    public Integer getMaxConnections() {
+        return maxConnections == null ? DEFAULT_CONNECTIONS : maxConnections;
+    }
+
+    /** Sets the maximum number of allowed open HTTP connections. */
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    /** @return whether to use HTTPS (true) or HTTP (false) when talking to S3 (defaults to true) */
+    public Boolean isUseHTTPS() {
+        return useHTTPS;
+    }
+
+    /** @param useHTTPS whether to use HTTPS (true) or HTTP (false) when talking to S3 */
+    public void setUseHTTPS(Boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+
+    /**
+     * Returns the optional proxy host the client will connect through.
+     *
+     * @return The proxy host the client will connect through.
+     */
+    @Nullable
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    /**
+     * Sets the optional proxy host the client will connect through.
+     *
+     * @param proxyHost The proxy host the client will connect through.
+     */
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    /**
+     * Returns the optional proxy port the client will connect through.
+     *
+     * @return The proxy port the client will connect through.
+     */
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    /**
+     * Sets the optional proxy port the client will connect through.
+     *
+     * @param proxyPort The proxy port the client will connect through.
+     */
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    /**
+     * Returns the optional proxy user name to use if connecting through a proxy.
+     *
+     * @return The optional proxy user name the configured client will use if connecting through a
+     *     proxy.
+     */
+    @Nullable
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    /**
+     * Sets the optional proxy user name to use if connecting through a proxy.
+     *
+     * @param proxyUsername The proxy user name to use if connecting through a proxy.
+     */
+    public void setProxyUsername(String proxyUsername) {
+        this.proxyUsername = proxyUsername;
+    }
+
+    /**
+     * Returns the optional proxy password to use when connecting through a proxy.
+     *
+     * @return The password to use when connecting through a proxy.
+     */
+    @Nullable
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    /**
+     * Sets the optional proxy password to use when connecting through a proxy.
+     *
+     * @param proxyPassword The password to use when connecting through a proxy.
+     */
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
+            throws StorageException {
+
+        checkNotNull(layers);
+        checkState(getName() != null);
+        checkState(
+                isEnabled(),
+                "Can't call S3BlobStoreConfig.createInstance() is blob store is not enabled");
+        return new AzureBlobStore(this, layers, lockProvider);
+    }
+
+    @Override
+    public String getLocation() {
+        String bucket = this.getContainer();
+        String prefix = this.getPrefix();
+        if (prefix == null) {
+            return String.format("container: %s", bucket);
+        } else {
+            return String.format("container: %s prefix: %s", bucket, prefix);
+        }
+    }
+
+    Proxy getProxy() {
+        if (proxyHost != null) {
+            return new Proxy(
+                    Proxy.Type.HTTP,
+                    new InetSocketAddress(proxyHost, proxyPort != null ? proxyPort : 8888));
+        }
+        return null;
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
@@ -31,7 +31,7 @@ import org.geowebcache.locks.LockProvider;
 import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.StorageException;
 
-/** Plain old java object representing the configuration for an S3 blob store. */
+/** Plain old java object representing the configuration for an Azure blob store. */
 public class AzureBlobStoreInfo extends BlobStoreInfo {
 
     /**
@@ -73,12 +73,12 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
         super(id);
     }
 
-    /** @return the name of the AWS S3 bucket where to store tiles */
+    /** @return the name of the Azure container where to store tiles */
     public String getContainer() {
         return container;
     }
 
-    /** Sets the name of the AWS S3 bucket where to store tiles */
+    /** Sets the name of the Azure container where to store tiles */
     public void setContainer(String container) {
         this.container = container;
     }
@@ -109,7 +109,7 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
 
     /**
      * Returns the base prefix, which is a prefix path to use as the root to store tiles under the
-     * bucket.
+     * container.
      *
      * @return optional string for a "base prefix"
      */
@@ -132,12 +132,14 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
         this.maxConnections = maxConnections;
     }
 
-    /** @return whether to use HTTPS (true) or HTTP (false) when talking to S3 (defaults to true) */
+    /**
+     * @return whether to use HTTPS (true) or HTTP (false) when talking to Azure (defaults to true)
+     */
     public Boolean isUseHTTPS() {
         return useHTTPS;
     }
 
-    /** @param useHTTPS whether to use HTTPS (true) or HTTP (false) when talking to S3 */
+    /** @param useHTTPS whether to use HTTPS (true) or HTTP (false) when talking to Azure */
     public void setUseHTTPS(Boolean useHTTPS) {
         this.useHTTPS = useHTTPS;
     }
@@ -241,18 +243,18 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
         checkState(getName() != null);
         checkState(
                 isEnabled(),
-                "Can't call S3BlobStoreConfig.createInstance() is blob store is not enabled");
+                "Can't call AzureBlobStoreConfig.createInstance() is blob store is not enabled");
         return new AzureBlobStore(this, layers, lockProvider);
     }
 
     @Override
     public String getLocation() {
-        String bucket = this.getContainer();
+        String container = this.getContainer();
         String prefix = this.getPrefix();
         if (prefix == null) {
-            return String.format("container: %s", bucket);
+            return String.format("container: %s", container);
         } else {
-            return String.format("container: %s prefix: %s", bucket, prefix);
+            return String.format("container: %s prefix: %s", container, prefix);
         }
     }
 

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -1,0 +1,233 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import com.microsoft.azure.storage.blob.BlockBlobURL;
+import com.microsoft.azure.storage.blob.ContainerURL;
+import com.microsoft.azure.storage.blob.DownloadResponse;
+import com.microsoft.azure.storage.blob.ListBlobsOptions;
+import com.microsoft.azure.storage.blob.PipelineOptions;
+import com.microsoft.azure.storage.blob.ServiceURL;
+import com.microsoft.azure.storage.blob.SharedKeyCredentials;
+import com.microsoft.azure.storage.blob.StorageURL;
+import com.microsoft.azure.storage.blob.models.BlobFlatListSegment;
+import com.microsoft.azure.storage.blob.models.BlobHTTPHeaders;
+import com.microsoft.azure.storage.blob.models.BlobItem;
+import com.microsoft.azure.storage.blob.models.ContainerListBlobFlatSegmentResponse;
+import com.microsoft.rest.v2.RestException;
+import com.microsoft.rest.v2.http.HttpClient;
+import com.microsoft.rest.v2.http.HttpClientConfiguration;
+import com.microsoft.rest.v2.http.NettyClient;
+import com.microsoft.rest.v2.http.SharedChannelPoolOptions;
+import com.microsoft.rest.v2.util.FlowableUtil;
+import io.netty.bootstrap.Bootstrap;
+import io.reactivex.Flowable;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Proxy;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import javax.annotation.Nullable;
+import org.geowebcache.storage.StorageException;
+import org.springframework.http.HttpStatus;
+
+class AzureClient implements Closeable {
+
+    private final NettyClient.Factory factory;
+    private AzureBlobStoreInfo configuration;
+    private final ContainerURL container;
+
+    public AzureClient(AzureBlobStoreInfo configuration) throws StorageException {
+        this.configuration = configuration;
+        try {
+            SharedKeyCredentials creds =
+                    new SharedKeyCredentials(
+                            configuration.getAccountName(), configuration.getAccountKey());
+
+            // setup the HTTPClient, keep the factory on the side to close it down on destroy
+            factory =
+                    new NettyClient.Factory(
+                            new Bootstrap(),
+                            0,
+                            new SharedChannelPoolOptions()
+                                    .withPoolSize(configuration.getMaxConnections()),
+                            null);
+            final HttpClient client;
+            Proxy proxy = configuration.getProxy();
+            // not clear how to use credentials for proxy,
+            // https://github.com/Azure/autorest-clientruntime-for-java/issues/624
+            if (proxy != null) {
+                HttpClientConfiguration clientConfiguration = new HttpClientConfiguration(proxy);
+                client = factory.create(clientConfiguration);
+            } else {
+                client = factory.create(null);
+            }
+
+            // build the container access
+            PipelineOptions options = new PipelineOptions().withClient(client);
+            ServiceURL serviceURL =
+                    new ServiceURL(
+                            new URL(getServiceURL(configuration)),
+                            StorageURL.createPipeline(creds, options));
+
+            String containerName = configuration.getContainer();
+            this.container = serviceURL.createContainerURL(containerName);
+            // no way to see if the containerURL already exists, try to create and see if
+            // we get a 409 CONFLICT
+            try {
+                int status = this.container.create(null, null, null).blockingGet().statusCode();
+                if (!HttpStatus.valueOf(status).is2xxSuccessful()
+                        && status != HttpStatus.CONFLICT.value()) {
+                    throw new StorageException(
+                            "Failed to create container "
+                                    + containerName
+                                    + ", REST API returned a "
+                                    + status);
+                }
+            } catch (RestException e) {
+                if (e.response().statusCode() != HttpStatus.CONFLICT.value()) {
+                    throw new StorageException("Failed to create container", e);
+                }
+            }
+        } catch (Exception e) {
+            throw new StorageException("Failed to setup Azure connection and container", e);
+        }
+    }
+
+    public String getServiceURL(AzureBlobStoreInfo configuration) {
+        String serviceURL = configuration.getServiceURL();
+        if (serviceURL == null) {
+            // default to account name based location
+            serviceURL =
+                    (configuration.isUseHTTPS() ? "https" : "http")
+                            + "://"
+                            + configuration.getAccountName()
+                            + ".blob.core.windows.net";
+        }
+        return serviceURL;
+    }
+
+    /**
+     * Returns a blob for the given key (may not exist yet, and in need of being created)
+     *
+     * @param key The blob key
+     */
+    public BlockBlobURL getBlockBlobURL(String key) {
+        return container.createBlockBlobURL(key);
+    }
+
+    @Nullable
+    public byte[] getBytes(String key) throws StorageException {
+        BlockBlobURL blob = getBlockBlobURL(key);
+        try {
+            DownloadResponse response = blob.download().blockingGet();
+            ByteBuffer buffer =
+                    FlowableUtil.collectBytesInBuffer(response.body(null)).blockingGet();
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            return result;
+        } catch (RestException e) {
+            if (e.response().statusCode() == 404) {
+                return null;
+            }
+            throw new StorageException("Failed to retreive bytes for " + key, e);
+        }
+    }
+
+    public Properties getProperties(String key) throws StorageException {
+        Properties properties = new Properties();
+        byte[] bytes = getBytes(key);
+        if (bytes != null) {
+            try {
+                properties.load(
+                        new InputStreamReader(
+                                new ByteArrayInputStream(bytes), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return properties;
+    }
+
+    public void putProperties(String resourceKey, Properties properties) throws StorageException {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            properties.store(out, "");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            BlockBlobURL blob = getBlockBlobURL(resourceKey);
+            byte[] bytes = out.toByteArray();
+            ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            BlobHTTPHeaders headers = new BlobHTTPHeaders();
+            headers.withBlobContentType("text/plain");
+
+            int status =
+                    blob.upload(Flowable.just(buffer), bytes.length, headers, null, null, null)
+                            .blockingGet()
+                            .statusCode();
+            if (!HttpStatus.valueOf(status).is2xxSuccessful()) {
+                throw new StorageException(
+                        "Upload request failed with status "
+                                + status
+                                + " on resource "
+                                + resourceKey);
+            }
+        } catch (RestException e) {
+            throw new StorageException("Failed to update e property file at " + resourceKey, e);
+        }
+    }
+
+    public List<BlobItem> listBlobs(String prefix, Integer maxResults) {
+        ContainerListBlobFlatSegmentResponse response =
+                container
+                        .listBlobsFlatSegment(
+                                null,
+                                new ListBlobsOptions()
+                                        .withPrefix(prefix)
+                                        .withMaxResults(maxResults))
+                        .blockingGet();
+
+        BlobFlatListSegment segment = response.body().segment();
+        List<BlobItem> items = new ArrayList<>();
+        if (segment != null) {
+            items.addAll(segment.blobItems());
+        }
+        return items;
+    }
+
+    @Override
+    public void close() {
+        factory.close();
+    }
+
+    public String getContainerName() {
+        return configuration.getContainer();
+    }
+
+    public ContainerURL getContainer() {
+        return container;
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
@@ -229,7 +229,7 @@ class DeleteManager implements Closeable {
             } else {
                 log.info(
                         String.format(
-                                "bulk delete finished but there's a newer one ongoing for bucket '%s/%s'",
+                                "bulk delete finished but there's a newer one ongoing for container '%s/%s'",
                                 client.getContainerName(), prefix));
             }
         } catch (StorageException e) {
@@ -298,7 +298,7 @@ class DeleteManager implements Closeable {
             } catch (Exception e) {
                 AzureBlobStore.log.warn(
                         String.format(
-                                "Unknown error performing bulk S3 delete of '%s/%s'",
+                                "Unknown error performing bulk Azure blobs delete of '%s/%s'",
                                 client.getContainerName(), prefix),
                         e);
                 throw e;

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
@@ -258,7 +258,7 @@ class DeleteManager implements Closeable {
             long count = 0L;
             try {
                 checkInterrupted();
-                AzureBlobStore.log.info(
+                log.info(
                         String.format(
                                 "Running bulk delete on '%s/%s':%d",
                                 client.getContainerName(), prefix, timestamp));
@@ -290,13 +290,13 @@ class DeleteManager implements Closeable {
                     }
                 }
             } catch (InterruptedException | IllegalStateException e) {
-                AzureBlobStore.log.info(
+                log.info(
                         String.format(
                                 "Azure bulk delete aborted for '%s/%s'. Will resume on next startup.",
                                 client.getContainerName(), prefix));
                 throw e;
             } catch (Exception e) {
-                AzureBlobStore.log.warn(
+                log.warn(
                         String.format(
                                 "Unknown error performing bulk Azure blobs delete of '%s/%s'",
                                 client.getContainerName(), prefix),
@@ -304,7 +304,7 @@ class DeleteManager implements Closeable {
                 throw e;
             }
 
-            AzureBlobStore.log.info(
+            log.info(
                     String.format(
                             "Finished bulk delete on '%s/%s':%d. %d objects deleted",
                             client.getContainerName(), prefix, timestamp, count));
@@ -370,11 +370,13 @@ class DeleteManager implements Closeable {
             long count = 0L;
             try {
                 checkInterrupted();
-                AzureBlobStore.log.info(
-                        String.format(
-                                "Running delete delete on list of items on '%s':%s ... (only the first 100 items listed)",
-                                client.getContainerName(),
-                                keys.subList(0, Math.min(keys.size(), 100))));
+                if (log.isTraceEnabled()) {
+                    log.trace(
+                            String.format(
+                                    "Running delete delete on list of items on '%s':%s ... (only the first 100 items listed)",
+                                    client.getContainerName(),
+                                    keys.subList(0, Math.min(keys.size(), 100))));
+                }
 
                 ContainerURL container = client.getContainer();
 
@@ -382,14 +384,14 @@ class DeleteManager implements Closeable {
                     deleteItems(container, keys.subList(i, Math.min(i + PAGE_SIZE, keys.size())));
                 }
             } catch (InterruptedException | IllegalStateException e) {
-                AzureBlobStore.log.info("Azure bulk delete aborted", e);
+                log.info("Azure bulk delete aborted", e);
                 throw e;
             } catch (Exception e) {
-                AzureBlobStore.log.warn("Unknown error performing bulk Azure delete", e);
+                log.warn("Unknown error performing bulk Azure delete", e);
                 throw e;
             }
 
-            AzureBlobStore.log.info(
+            log.info(
                     String.format(
                             "Finished bulk delete on %s, %d objects deleted",
                             client.getContainerName(), count));

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
@@ -1,0 +1,444 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static org.geowebcache.azure.AzureBlobStore.log;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.microsoft.azure.storage.blob.ContainerURL;
+import com.microsoft.azure.storage.blob.ListBlobsOptions;
+import com.microsoft.azure.storage.blob.models.BlobFlatListSegment;
+import com.microsoft.azure.storage.blob.models.BlobItem;
+import com.microsoft.azure.storage.blob.models.ContainerListBlobFlatSegmentResponse;
+import com.microsoft.rest.v2.RestException;
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.LockProvider.Lock;
+import org.geowebcache.storage.StorageException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Class handling deletes, which are normally handled in an asynchronous way in all other stores as
+ * well. These are bulk operations like deleting an entire layer, or a rangeset, with potentially
+ * million of tiles involved.
+ *
+ * <p>Unfortunately the Azure BLOB API has no concept of bulk delete, and no concept of containment
+ * either, so tiles have to be enumerated one by one and a delete issued on each one. This calls for
+ * a parallel execution, and requires avoiding accumulation of references to all tiles that need
+ * removing in memory, as they could be millions or more, hence code that tries to run over the
+ * tiles in pages
+ */
+class DeleteManager implements Closeable {
+    /**
+     * the page size here is not about limiting the requests, but ensures that we don't end up using
+     * too much memory while processing millions of tiles, that would be otherwise all queued on the
+     * {@link ExecutorService}
+     */
+    static final int PAGE_SIZE = 1000;
+
+    private final TMSKeyBuilder keyBuilder;
+    private final AzureClient client;
+    private final LockProvider locks;
+    private final int concurrency;
+    private ExecutorService deleteExecutor;
+    private Map<String, Long> pendingDeletesKeyTime = new ConcurrentHashMap<>();
+
+    public DeleteManager(
+            AzureClient client, LockProvider locks, TMSKeyBuilder keyBuilder, int maxConnections) {
+        this.keyBuilder = keyBuilder;
+        this.client = client;
+        this.locks = locks;
+        this.concurrency = maxConnections;
+        this.deleteExecutor =
+                createDeleteExecutorService(client.getContainerName(), maxConnections);
+    }
+
+    private static ExecutorService createDeleteExecutorService(
+            String containerName, int parallelism) {
+        ThreadFactory tf =
+                new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat(
+                                "GWC AzureBlobStore bulk delete thread-%d. Container: "
+                                        + containerName)
+                        .setPriority(Thread.MIN_PRIORITY)
+                        .build();
+        return Executors.newFixedThreadPool(parallelism, tf);
+    }
+
+    // Azure, like S3, truncates timestamps to seconds precision and does not allow to
+    // programmatically set the last modified time
+    private long currentTimeSeconds() {
+        final long timestamp = (long) Math.ceil(System.currentTimeMillis() / 1000D) * 1000L;
+        return timestamp;
+    }
+
+    /**
+     * Executes the provided iterator of callables on the delete executor, returning their results
+     *
+     * @param callables
+     * @return
+     */
+    public void executeParallel(List<Callable> callables) throws StorageException {
+        List<Future> futures = new ArrayList<>();
+        for (Callable callable : callables) {
+            futures.add(deleteExecutor.submit(callable));
+        }
+        for (Future future : futures) {
+            try {
+                future.get();
+            } catch (Exception e) {
+                throw new StorageException("Failed to execute parallel delete", e);
+            }
+        }
+    }
+
+    /**
+     * Executes the removal of the specified keys in a parallel fashion, returning the number of
+     * removed keys
+     */
+    public Long deleteParallel(List<String> keys) throws StorageException {
+        try {
+            return new KeysBulkDelete(keys).call();
+        } catch (Exception e) {
+            throw new StorageException("Failed to submit parallel keys execution", e);
+        }
+    }
+
+    public boolean scheduleAsyncDelete(final String prefix) throws StorageException {
+        final long timestamp = currentTimeSeconds();
+        String msg =
+                String.format(
+                        "Issuing bulk delete on '%s/%s' for objects older than %d",
+                        client.getContainerName(), prefix, timestamp);
+        log.info(msg);
+
+        try {
+            Lock lock = locks.getLock(prefix);
+            try {
+                boolean taskRuns = asyncDelete(prefix, timestamp);
+                if (taskRuns) {
+                    final String pendingDeletesKey = keyBuilder.pendingDeletes();
+                    Properties deletes = client.getProperties(pendingDeletesKey);
+                    deletes.setProperty(prefix, String.valueOf(timestamp));
+                    client.putProperties(pendingDeletesKey, deletes);
+                }
+                return taskRuns;
+            } finally {
+                lock.release();
+            }
+        } catch (GeoWebCacheException e) {
+            throw new StorageException("Failed to schedule asynch delete ", e);
+        }
+    }
+
+    public void issuePendingBulkDeletes() throws StorageException {
+        final String pendingDeletesKey = keyBuilder.pendingDeletes();
+        Lock lock;
+        try {
+            lock = locks.getLock(pendingDeletesKey);
+        } catch (GeoWebCacheException e) {
+            throw new StorageException("Unable to lock pending deletes", e);
+        }
+
+        try {
+            Properties deletes = client.getProperties(pendingDeletesKey);
+            for (Map.Entry<Object, Object> e : deletes.entrySet()) {
+                final String prefix = e.getKey().toString();
+                final long timestamp = Long.parseLong(e.getValue().toString());
+                log.info(
+                        String.format(
+                                "Restarting pending bulk delete on '%s/%s':%d",
+                                client.getContainerName(), prefix, timestamp));
+                asyncDelete(prefix, timestamp);
+            }
+        } finally {
+            try {
+                lock.release();
+            } catch (GeoWebCacheException e) {
+                throw new StorageException("Unable to unlock pending deletes", e);
+            }
+        }
+    }
+
+    public synchronized boolean asyncDelete(String prefix, long timestamp) {
+        // do we have anything to delete?
+        if (client.listBlobs(prefix, 1).size() == 0) {
+            return false;
+        }
+
+        // is there any task already deleting a larger set of times in the same prefix folder?
+        Long currentTaskTime = pendingDeletesKeyTime.get(prefix);
+        if (currentTaskTime != null && currentTaskTime.longValue() > timestamp) {
+            return false;
+        }
+
+        PrefixTimeBulkDelete task = new PrefixTimeBulkDelete(prefix, timestamp);
+        deleteExecutor.submit(task);
+        pendingDeletesKeyTime.put(prefix, timestamp);
+
+        return true;
+    }
+
+    private void clearPendingBulkDelete(final String prefix, final long timestamp)
+            throws GeoWebCacheException {
+        Long taskTime = pendingDeletesKeyTime.get(prefix);
+        if (taskTime == null) {
+            return; // someone else cleared it up for us. A task that run after this one but
+            // finished before?
+        }
+        if (taskTime.longValue() > timestamp) {
+            return; // someone else issued a bulk delete after this one for the same key prefix
+        }
+        final String pendingDeletesKey = keyBuilder.pendingDeletes();
+        final Lock lock = locks.getLock(pendingDeletesKey);
+
+        try {
+            Properties deletes = client.getProperties(pendingDeletesKey);
+            String storedVal = (String) deletes.remove(prefix);
+            long storedTimestamp = storedVal == null ? Long.MIN_VALUE : Long.parseLong(storedVal);
+            if (timestamp >= storedTimestamp) {
+                client.putProperties(pendingDeletesKey, deletes);
+            } else {
+                log.info(
+                        String.format(
+                                "bulk delete finished but there's a newer one ongoing for bucket '%s/%s'",
+                                client.getContainerName(), prefix));
+            }
+        } catch (StorageException e) {
+            throw new RuntimeException(e);
+        } finally {
+            lock.release();
+        }
+    }
+
+    @Override
+    public void close() {
+        deleteExecutor.shutdownNow();
+    }
+
+    public class PrefixTimeBulkDelete implements Callable<Long> {
+        private final String prefix;
+        private final long timestamp;
+
+        public PrefixTimeBulkDelete(String prefix, long timestamp) {
+            this.prefix = prefix;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Long call() throws Exception {
+            long count = 0L;
+            try {
+                checkInterrupted();
+                AzureBlobStore.log.info(
+                        String.format(
+                                "Running bulk delete on '%s/%s':%d",
+                                client.getContainerName(), prefix, timestamp));
+
+                ContainerURL container = client.getContainer();
+
+                int jobPageSize = Math.max(concurrency, PAGE_SIZE);
+                ListBlobsOptions options =
+                        new ListBlobsOptions().withPrefix(prefix).withMaxResults(jobPageSize);
+                ContainerListBlobFlatSegmentResponse response =
+                        container.listBlobsFlatSegment(null, options, null).blockingGet();
+
+                Predicate<BlobItem> filter =
+                        blobItem -> {
+                            long lastModified =
+                                    blobItem.properties().lastModified().toEpochSecond() * 1000;
+                            return timestamp >= lastModified;
+                        };
+
+                while (response.body().segment() != null) {
+                    checkInterrupted();
+                    deleteItems(container, response.body().segment(), filter);
+                    String marker = response.body().nextMarker();
+                    if (marker != null) {
+                        response =
+                                container.listBlobsFlatSegment(marker, options, null).blockingGet();
+                    } else {
+                        break;
+                    }
+                }
+            } catch (InterruptedException | IllegalStateException e) {
+                AzureBlobStore.log.info(
+                        String.format(
+                                "Azure bulk delete aborted for '%s/%s'. Will resume on next startup.",
+                                client.getContainerName(), prefix));
+                throw e;
+            } catch (Exception e) {
+                AzureBlobStore.log.warn(
+                        String.format(
+                                "Unknown error performing bulk S3 delete of '%s/%s'",
+                                client.getContainerName(), prefix),
+                        e);
+                throw e;
+            }
+
+            AzureBlobStore.log.info(
+                    String.format(
+                            "Finished bulk delete on '%s/%s':%d. %d objects deleted",
+                            client.getContainerName(), prefix, timestamp, count));
+
+            clearPendingBulkDelete(prefix, timestamp);
+            return count;
+        }
+
+        private long deleteItems(
+                ContainerURL container, BlobFlatListSegment segment, Predicate<BlobItem> filter)
+                throws ExecutionException, InterruptedException {
+            List<Future<Object>> collect =
+                    segment.blobItems()
+                            .stream()
+                            .filter(item -> filter.test(item))
+                            .map(
+                                    item ->
+                                            deleteExecutor.submit(
+                                                    () -> {
+                                                        deleteItem(container, item);
+                                                        return null;
+                                                    }))
+                            .collect(Collectors.toList());
+
+            for (Future<Object> f : collect) {
+                f.get();
+            }
+            return collect.size();
+        }
+
+        private void deleteItem(ContainerURL container, BlobItem item) {
+            String key = item.name();
+            try {
+
+                int status = container.createBlobURL(key).delete().blockingGet().statusCode();
+                if (status != NOT_FOUND.value() && !HttpStatus.valueOf(status).is2xxSuccessful()) {
+                    throw new RuntimeException(
+                            "Deletion failed with status " + status + " on resource " + key);
+                }
+            } catch (RestException e) {
+                if (e.response().statusCode() != NOT_FOUND.value()) {
+                    throw new RuntimeException(
+                            "Deletion failed with status "
+                                    + e.response().statusCode()
+                                    + " on resource "
+                                    + key,
+                            e);
+                }
+            }
+        }
+    }
+
+    public class KeysBulkDelete implements Callable<Long> {
+
+        private final List<String> keys;
+
+        public KeysBulkDelete(List<String> keys) {
+            this.keys = keys;
+        }
+
+        @Override
+        public Long call() throws Exception {
+            long count = 0L;
+            try {
+                checkInterrupted();
+                AzureBlobStore.log.info(
+                        String.format(
+                                "Running delete delete on list of items on '%s':%s ... (only the first 100 items listed)",
+                                client.getContainerName(),
+                                keys.subList(0, Math.min(keys.size(), 100))));
+
+                ContainerURL container = client.getContainer();
+
+                for (int i = 0; i < keys.size(); i += PAGE_SIZE) {
+                    deleteItems(container, keys.subList(i, Math.min(i + PAGE_SIZE, keys.size())));
+                }
+            } catch (InterruptedException | IllegalStateException e) {
+                AzureBlobStore.log.info("Azure bulk delete aborted", e);
+                throw e;
+            } catch (Exception e) {
+                AzureBlobStore.log.warn("Unknown error performing bulk Azure delete", e);
+                throw e;
+            }
+
+            AzureBlobStore.log.info(
+                    String.format(
+                            "Finished bulk delete on %s, %d objects deleted",
+                            client.getContainerName(), count));
+            return count;
+        }
+
+        private long deleteItems(ContainerURL container, List<String> itemNames)
+                throws ExecutionException, InterruptedException {
+            List<Future<Object>> collect =
+                    itemNames
+                            .stream()
+                            .map(
+                                    item ->
+                                            deleteExecutor.submit(
+                                                    () -> {
+                                                        return deleteItem(container, item);
+                                                    }))
+                            .collect(Collectors.toList());
+
+            for (Future<Object> f : collect) {
+                f.get();
+            }
+            return collect.size();
+        }
+
+        private Object deleteItem(ContainerURL container, String item) {
+            try {
+                int status = container.createBlobURL(item).delete().blockingGet().statusCode();
+                if (status != NOT_FOUND.value() && !HttpStatus.valueOf(status).is2xxSuccessful()) {
+                    throw new RuntimeException(
+                            "Deletion failed with status " + status + " on resource " + item);
+                }
+            } catch (RestException e) {
+                if (e.response().statusCode() != NOT_FOUND.value()) {
+                    throw new RuntimeException(
+                            "Deletion failed with status "
+                                    + e.response().statusCode()
+                                    + " on resource "
+                                    + item,
+                            e);
+                }
+            }
+            return null;
+        }
+    }
+
+    void checkInterrupted() throws InterruptedException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/TMSKeyBuilder.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/TMSKeyBuilder.java
@@ -1,0 +1,248 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Strings;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+
+// TODO: move to core?
+final class TMSKeyBuilder {
+
+    private static final String DELIMITER = "/";
+
+    public static final String LAYER_METADATA_OBJECT_NAME = "metadata.properties";
+    public static final String PARAMETERS_METADATA_OBJECT_PREFIX = "parameters-";
+    public static final String PARAMETERS_METADATA_OBJECT_SUFFIX = ".properties";
+
+    private String prefix;
+
+    private TileLayerDispatcher layers;
+
+    public TMSKeyBuilder(final String prefix, TileLayerDispatcher layers) {
+        this.prefix = prefix;
+        this.layers = layers;
+    }
+
+    public String layerId(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getId();
+    }
+
+    public Set<String> layerGridsets(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getGridSubsets();
+    }
+
+    public Set<String> layerFormats(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getMimeTypes()
+                .stream()
+                .map(MimeType::getFileExtension)
+                .collect(Collectors.toSet());
+    }
+
+    public String forTile(TileObject obj) {
+        checkNotNull(obj.getLayerName());
+        checkNotNull(obj.getGridSetId());
+        checkNotNull(obj.getBlobFormat());
+        checkNotNull(obj.getXYZ());
+
+        String layer = layerId(obj.getLayerName());
+        String gridset = obj.getGridSetId();
+        String shortFormat;
+        String parametersId = obj.getParametersId();
+        if (parametersId == null) {
+            Map<String, String> parameters = obj.getParameters();
+            parametersId = ParametersUtils.getId(parameters);
+            if (parametersId == null) {
+                parametersId = "default";
+            } else {
+                obj.setParametersId(parametersId);
+            }
+        }
+        Long x = Long.valueOf(obj.getXYZ()[0]);
+        Long y = Long.valueOf(obj.getXYZ()[1]);
+        Long z = Long.valueOf(obj.getXYZ()[2]);
+        String extension;
+        try {
+            String format = obj.getBlobFormat();
+            MimeType mimeType = MimeType.createFromFormat(format);
+            shortFormat = mimeType.getFileExtension(); // png, png8, png24, etc
+            extension = mimeType.getInternalName(); // png, jpeg, etc
+        } catch (MimeException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Key format, comprised of
+        // {@code <prefix>/<layer name>/<gridset id>/<format id>/<parameters
+        // hash>/<z>/<x>/<y>.<extension>}
+        String key =
+                join(
+                        false,
+                        prefix,
+                        layer,
+                        gridset,
+                        shortFormat,
+                        parametersId,
+                        z,
+                        x,
+                        y + "." + extension);
+        return key;
+    }
+
+    public String forLocation(String prefix, long[] loc, MimeType mime) {
+        Long x = loc[0];
+        Long y = loc[1];
+        Long z = loc[2];
+        String extension = mime.getInternalName();
+
+        return join(false, prefix, z, x, y + "." + extension);
+    }
+
+    public String forLayer(final String layerName) {
+        String layerId = layerId(layerName);
+        // Layer prefix format, comprised of {@code <prefix>/<layer name>/}
+        return join(true, prefix, layerId);
+    }
+
+    public String forGridset(final String layerName, final String gridsetId) {
+        String layerId = layerId(layerName);
+        // Layer prefix format, comprised of {@code <prefix>/<layer name>/}
+        return join(true, prefix, layerId, gridsetId);
+    }
+
+    public Set<String> forParameters(final String layerName, final String parametersId) {
+        String layerId = layerId(layerName);
+        // Coordinates prefix: {@code <prefix>/<layer name>/<gridset id>/<format id>/<parameters
+        // hash>/}
+        return layerGridsets(layerName)
+                .stream()
+                .flatMap(
+                        gridsetId ->
+                                layerFormats(layerName)
+                                        .stream()
+                                        .map(
+                                                format ->
+                                                        join(
+                                                                true,
+                                                                prefix,
+                                                                layerId,
+                                                                gridsetId,
+                                                                format,
+                                                                parametersId)))
+                .collect(Collectors.toSet());
+    }
+
+    public String layerMetadata(final String layerName) {
+        String layerId = layerId(layerName);
+        return join(false, prefix, layerId, LAYER_METADATA_OBJECT_NAME);
+    }
+
+    public String storeMetadata() {
+        return join(false, prefix, LAYER_METADATA_OBJECT_NAME);
+    }
+
+    public String parametersMetadata(final String layerName, final String parametersId) {
+        String layerId = layerId(layerName);
+        return join(
+                false,
+                prefix,
+                layerId,
+                PARAMETERS_METADATA_OBJECT_PREFIX
+                        + parametersId
+                        + PARAMETERS_METADATA_OBJECT_SUFFIX);
+    }
+
+    public String parametersMetadataPrefix(final String layerName) {
+        String layerId = layerId(layerName);
+        return join(false, prefix, layerId, PARAMETERS_METADATA_OBJECT_PREFIX);
+    }
+
+    /**
+     * @return the key prefix up to the coordinates (i.e. {@code
+     *     "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
+     */
+    public String coordinatesPrefix(TileRange obj) {
+        checkNotNull(obj.getLayerName());
+        checkNotNull(obj.getGridSetId());
+        checkNotNull(obj.getMimeType());
+
+        String layer = layerId(obj.getLayerName());
+        String gridset = obj.getGridSetId();
+        MimeType mimeType = obj.getMimeType();
+
+        String shortFormat;
+        String parametersId = obj.getParametersId();
+        if (parametersId == null) {
+            Map<String, String> parameters = obj.getParameters();
+            parametersId = ParametersUtils.getId(parameters);
+            if (parametersId == null) {
+                parametersId = "default";
+            } else {
+                obj.setParametersId(parametersId);
+            }
+        }
+        shortFormat = mimeType.getFileExtension(); // png, png8, png24, etc
+
+        String key = join(false, prefix, layer, gridset, shortFormat, parametersId);
+        return key;
+    }
+
+    public String pendingDeletes() {
+        return String.format("%s/%s", prefix, "_pending_deletes.properties");
+    }
+
+    private static String join(boolean closing, Object... elements) {
+        StringJoiner joiner = new StringJoiner(DELIMITER);
+        for (Object o : elements) {
+            String s = o == null ? null : o.toString();
+            if (!Strings.isNullOrEmpty(s)) {
+                joiner.add(s);
+            }
+        }
+        if (closing) {
+            joiner.add("");
+        }
+        return joiner.toString();
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AbstractAzureBlobStoreIntegrationTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AbstractAzureBlobStoreIntegrationTest.java
@@ -1,0 +1,688 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.DefaultGridsets;
+import org.geowebcache.grid.GridSet;
+import org.geowebcache.grid.GridSetBroker;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.grid.GridSubsetFactory;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.FileResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.NoOpLockProvider;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.BlobStoreListener;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Integration tests for {@link AzureBlobStore}.
+ *
+ * <p>This is an abstract class for both online and offline integration tests.
+ */
+public abstract class AbstractAzureBlobStoreIntegrationTest {
+
+    private static Log log = LogFactory.getLog(PropertiesLoader.class);
+
+    private static final String DEFAULT_FORMAT = "png";
+
+    private static final String DEFAULT_GRIDSET = "EPSG:4326";
+
+    private static final String DEFAULT_LAYER = "topp:world";
+
+    public PropertiesLoader testConfigLoader = new PropertiesLoader();
+
+    private AzureBlobStore blobStore;
+
+    protected abstract AzureBlobStoreInfo getConfiguration();
+
+    @Before
+    public void before() throws Exception {
+        AzureBlobStoreInfo config = getConfiguration();
+
+        TileLayerDispatcher layers = mock(TileLayerDispatcher.class);
+        LockProvider lockProvider = new NoOpLockProvider();
+        TileLayer layer = mock(TileLayer.class);
+        when(layers.getTileLayer(eq(DEFAULT_LAYER))).thenReturn(layer);
+        when(layer.getName()).thenReturn(DEFAULT_LAYER);
+        when(layer.getId()).thenReturn(DEFAULT_LAYER);
+        blobStore = new AzureBlobStore(config, layers, lockProvider);
+    }
+
+    @After
+    public void after() {
+        if (blobStore != null) {
+            blobStore.destroy();
+        }
+    }
+
+    @Test
+    public void testPutGet() throws MimeException, StorageException {
+        byte[] bytes = new byte[1024];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(bytes));
+
+        blobStore.put(tile);
+
+        TileObject queryTile = queryTile(20, 30, 12);
+        boolean found = blobStore.get(queryTile);
+        assertTrue(found);
+        Resource resource = queryTile.getBlob();
+        assertNotNull(resource);
+        assertEquals(bytes.length, resource.getSize());
+    }
+
+    @Test
+    public void testPutGetBlobIsNotByteArrayResource() throws MimeException, IOException {
+        File tileFile = File.createTempFile("tile", ".png");
+        Files.write(new byte[1024], tileFile);
+        Resource blob = new FileResource(tileFile);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(blob);
+
+        blobStore.put(tile);
+
+        TileObject queryTile = queryTile(20, 30, 12);
+        boolean found = blobStore.get(queryTile);
+        assertTrue(found);
+        Resource resource = queryTile.getBlob();
+        assertNotNull(resource);
+        assertEquals(1024, resource.getSize());
+    }
+
+    @Test
+    public void testPutWithListener() throws MimeException, StorageException {
+        byte[] bytes = new byte[1024];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(bytes));
+
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+        blobStore.put(tile);
+
+        verify(listener)
+                .tileStored(
+                        eq(tile.getLayerName()),
+                        eq(tile.getGridSetId()),
+                        eq(tile.getBlobFormat()),
+                        anyString(),
+                        eq(20L),
+                        eq(30L),
+                        eq(12),
+                        eq((long) bytes.length));
+
+        // update tile
+        tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(new byte[512]));
+
+        blobStore.put(tile);
+
+        verify(listener)
+                .tileUpdated(
+                        eq(tile.getLayerName()),
+                        eq(tile.getGridSetId()),
+                        eq(tile.getBlobFormat()),
+                        anyString(),
+                        eq(20L),
+                        eq(30L),
+                        eq(12),
+                        eq(512L),
+                        eq(1024L));
+    }
+
+    @Test
+    public void testDelete() throws MimeException, StorageException {
+        byte[] bytes = new byte[1024];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(bytes));
+
+        blobStore.put(tile);
+
+        tile.getXYZ()[0] = 21;
+        blobStore.put(tile);
+
+        tile.getXYZ()[0] = 22;
+        blobStore.put(tile);
+
+        tile = queryTile(20, 30, 12);
+
+        assertTrue(blobStore.delete(tile));
+
+        tile.getXYZ()[0] = 21;
+        assertTrue(blobStore.delete(tile));
+
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+        tile.getXYZ()[0] = 22;
+        assertTrue(blobStore.delete(tile));
+        assertFalse(blobStore.delete(tile));
+
+        verify(listener, times(1))
+                .tileDeleted(
+                        eq(tile.getLayerName()),
+                        eq(tile.getGridSetId()),
+                        eq(tile.getBlobFormat()),
+                        anyString(),
+                        eq(22L),
+                        eq(30L),
+                        eq(12),
+                        eq(1024L));
+    }
+
+    @Test
+    public void testRenameNoTiles() throws StorageException {
+        String newName = "foobarLayer";
+        blobStore.rename(DEFAULT_LAYER, newName);
+
+        // no rename event should be sent
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+        verify(listener, times(0)).layerRenamed(DEFAULT_LAYER, newName);
+    }
+
+    @Test
+    public void testRenameWithTiles() throws StorageException {
+        // put a tile in the layer storage
+        byte[] bytes = new byte[1024];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(bytes));
+        blobStore.put(tile);
+
+        // rename
+        String newName = "foobarLayer";
+        blobStore.rename(DEFAULT_LAYER, newName);
+
+        // rename event should have been sent
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+        verify(listener, times(0)).layerRenamed(DEFAULT_LAYER, newName);
+    }
+
+    @Test
+    public void testDeleteLayer() throws Exception {
+        // put some metadata
+        blobStore.putLayerMetadata(DEFAULT_LAYER, "prop1", "value1");
+
+        byte[] bytes = new byte[1024];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(20, 30, 12);
+        tile.setBlob(new ByteArrayResource(bytes));
+
+        blobStore.put(tile);
+
+        tile.getXYZ()[0] = 21;
+        blobStore.put(tile);
+
+        tile.getXYZ()[0] = 22;
+        blobStore.put(tile);
+
+        // check that the layer reports as existing
+        assertTrue(blobStore.layerExists(DEFAULT_LAYER));
+
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+        String layerName = tile.getLayerName();
+        blobStore.delete(layerName);
+        verify(listener, Mockito.atLeastOnce()).layerDeleted(eq(layerName));
+
+        // check the tiles are gone too, give it up to 100 seconds
+        long start = System.currentTimeMillis();
+        boolean allDeleted = false;
+        boolean t20Deleted = false, t21Deleted = false, t22Deleted = false;
+        while (System.currentTimeMillis() - start < 100000
+                && (!t20Deleted || !t21Deleted || !t22Deleted)) {
+
+            if (!t20Deleted) {
+                tile.getXYZ()[0] = 20;
+                t20Deleted = !blobStore.get(tile);
+            }
+            if (!t21Deleted) {
+                tile.getXYZ()[0] = 21;
+                t21Deleted = !blobStore.get(tile);
+            }
+            if (!t22Deleted) {
+                tile.getXYZ()[0] = 22;
+                t22Deleted = !blobStore.get(tile);
+            }
+            if (!t20Deleted || !t21Deleted || !t22Deleted) {
+                Thread.sleep(500);
+            }
+        }
+        assertTrue(t20Deleted);
+        assertTrue(t21Deleted);
+        assertTrue(t22Deleted);
+
+        // and now check the layer reports as not existing instead
+        assertFalse(blobStore.layerExists(DEFAULT_LAYER));
+    }
+
+    @Test
+    public void testDeleteGridSubset() throws Exception {
+        seed(0, 1, "EPSG:4326", "png", null);
+        seed(0, 1, "EPSG:4326", "jpeg", ImmutableMap.of("param", "value"));
+        seed(0, 1, "EPSG:3857", "png", null);
+        seed(0, 1, "EPSG:3857", "jpeg", ImmutableMap.of("param", "value"));
+
+        assertFalse(blobStore.deleteByGridsetId(DEFAULT_LAYER, "EPSG:26986"));
+        assertTrue(blobStore.deleteByGridsetId(DEFAULT_LAYER, "EPSG:4326"));
+
+        // deletion by gridset is asynch, so we might have to wait a bit
+        boolean t4326PngDeleted = false, t4326JpegDeleted = false;
+        long start = System.currentTimeMillis();
+        while (System.currentTimeMillis() - start < 100000
+                && (!t4326PngDeleted || !t4326JpegDeleted)) {
+
+            if (!t4326PngDeleted) {
+                t4326PngDeleted =
+                        !blobStore.get(queryTile(DEFAULT_LAYER, "EPSG:4326", "png", 0, 0, 0));
+            }
+            if (!t4326JpegDeleted) {
+                t4326JpegDeleted =
+                        !blobStore.get(
+                                queryTile(
+                                        DEFAULT_LAYER,
+                                        "EPSG:4326",
+                                        "jpeg",
+                                        0,
+                                        0,
+                                        0,
+                                        "param",
+                                        "value"));
+            }
+        }
+        assertTrue(t4326PngDeleted);
+        assertTrue(t4326JpegDeleted);
+        // these two should not have been touched
+        assertTrue(blobStore.get(queryTile(DEFAULT_LAYER, "EPSG:3857", "png", 0, 0, 0)));
+        assertTrue(
+                blobStore.get(
+                        queryTile(DEFAULT_LAYER, "EPSG:3857", "jpeg", 0, 0, 0, "param", "value")));
+    }
+
+    @Test
+    public void testLayerMetadata() {
+        blobStore.putLayerMetadata(DEFAULT_LAYER, "prop1", "value1");
+        blobStore.putLayerMetadata(DEFAULT_LAYER, "prop2", "value2");
+
+        assertNull(blobStore.getLayerMetadata(DEFAULT_LAYER, "nonExistingKey"));
+        assertEquals("value1", blobStore.getLayerMetadata(DEFAULT_LAYER, "prop1"));
+        assertEquals("value2", blobStore.getLayerMetadata(DEFAULT_LAYER, "prop2"));
+    }
+
+    @Test
+    public void testTruncateShortCutsIfNoTilesInParametersPrefix()
+            throws StorageException, MimeException {
+        final int zoomStart = 0;
+        final int zoomStop = 1;
+        seed(zoomStart, zoomStop);
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+
+        GridSet gridset =
+                new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, false)))
+                        .getWorldEpsg4326();
+        GridSubset gridSubSet = GridSubsetFactory.createGridSubSet(gridset);
+
+        long[][] rangeBounds = { //
+            gridSubSet.getCoverage(0), //
+            gridSubSet.getCoverage(1) //
+        };
+
+        MimeType mimeType = MimeType.createFromExtension(DEFAULT_FORMAT);
+        // use a parameters map for which there're no tiles
+        Map<String, String> parameters = ImmutableMap.of("someparam", "somevalue");
+        TileRange tileRange =
+                tileRange(
+                        DEFAULT_LAYER,
+                        DEFAULT_GRIDSET,
+                        zoomStart,
+                        zoomStop,
+                        rangeBounds,
+                        mimeType,
+                        parameters);
+
+        assertFalse(blobStore.delete(tileRange));
+        verify(listener, times(0))
+                .tileDeleted(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyLong(),
+                        anyLong(),
+                        anyInt(),
+                        anyLong());
+    }
+
+    @Test
+    public void testTruncateShortCutsIfNoTilesInGridsetPrefix()
+            throws StorageException, MimeException {
+
+        final int zoomStart = 0;
+        final int zoomStop = 1;
+        seed(zoomStart, zoomStop);
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+
+        // use a gridset for which there're no tiles
+        GridSet gridset =
+                new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, true)))
+                        .getWorldEpsg3857();
+        GridSubset gridSubSet = GridSubsetFactory.createGridSubSet(gridset);
+
+        long[][] rangeBounds = { //
+            gridSubSet.getCoverage(0), //
+            gridSubSet.getCoverage(1) //
+        };
+
+        MimeType mimeType = MimeType.createFromExtension(DEFAULT_FORMAT);
+
+        Map<String, String> parameters = null;
+        TileRange tileRange =
+                tileRange(
+                        DEFAULT_LAYER,
+                        gridset.getName(),
+                        zoomStart,
+                        zoomStop,
+                        rangeBounds,
+                        mimeType,
+                        parameters);
+
+        assertFalse(blobStore.delete(tileRange));
+        verify(listener, times(0))
+                .tileDeleted(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyLong(),
+                        anyLong(),
+                        anyInt(),
+                        anyLong());
+    }
+
+    /** Seed levels 0 to 2, truncate levels 0 and 1, check level 2 didn't get deleted */
+    @Test
+    public void testTruncateRespectsLevels() throws StorageException, MimeException {
+
+        final int zoomStart = 0;
+        final int zoomStop = 2;
+
+        // use a gridset for which there're no tiles
+        GridSet gridset =
+                new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, true)))
+                        .getWorldEpsg3857();
+        GridSubset gridSubSet = GridSubsetFactory.createGridSubSet(gridset);
+
+        long[][] rangeBounds = gridSubSet.getCoverages();
+
+        seed(zoomStart, zoomStop, gridset.getName(), DEFAULT_FORMAT, null);
+
+        BlobStoreListener listener = mock(BlobStoreListener.class);
+        blobStore.addListener(listener);
+
+        MimeType mimeType = MimeType.createFromExtension(DEFAULT_FORMAT);
+
+        Map<String, String> parameters = null;
+
+        final int truncateStart = 0, truncateStop = 1;
+
+        TileRange tileRange =
+                tileRange(
+                        DEFAULT_LAYER,
+                        gridset.getName(),
+                        truncateStart,
+                        truncateStop,
+                        rangeBounds,
+                        mimeType,
+                        parameters);
+
+        assertTrue(blobStore.delete(tileRange));
+
+        int expectedCount = 5; // 1 for level 0, 4 for level 1, as per seed()
+
+        verify(listener, times(expectedCount))
+                .tileDeleted(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyLong(),
+                        anyLong(),
+                        anyInt(),
+                        anyLong());
+    }
+
+    /**
+     * If there are not {@link BlobStoreListener}s, use an optimized code path (not calling delete()
+     * for each tile)
+     */
+    @Test
+    public void testTruncateOptimizationIfNoListeners() throws StorageException, MimeException {
+
+        final int zoomStart = 0;
+        final int zoomStop = 2;
+
+        long[][] rangeBounds = { //
+            {0, 0, 0, 0, 0}, //
+            {0, 0, 1, 1, 1}, //
+            {0, 0, 3, 3, 2} //
+        };
+
+        seed(zoomStart, zoomStop);
+
+        MimeType mimeType = MimeType.createFromExtension(DEFAULT_FORMAT);
+
+        Map<String, String> parameters = null;
+
+        final int truncateStart = 0, truncateStop = 1;
+
+        TileRange tileRange =
+                tileRange(
+                        DEFAULT_LAYER,
+                        DEFAULT_GRIDSET,
+                        truncateStart,
+                        truncateStop,
+                        rangeBounds,
+                        mimeType,
+                        parameters);
+
+        blobStore = Mockito.spy(blobStore);
+        assertTrue(blobStore.delete(tileRange));
+
+        verify(blobStore, times(0)).delete(Mockito.any(TileObject.class));
+        assertFalse(blobStore.get(queryTile(0, 0, 0)));
+        assertFalse(blobStore.get(queryTile(0, 0, 1)));
+        assertFalse(blobStore.get(queryTile(0, 1, 1)));
+        assertFalse(blobStore.get(queryTile(1, 0, 1)));
+        assertFalse(blobStore.get(queryTile(1, 1, 1)));
+
+        assertTrue(blobStore.get(queryTile(0, 0, 2)));
+        assertTrue(blobStore.get(queryTile(0, 1, 2)));
+        assertTrue(blobStore.get(queryTile(0, 2, 2)));
+        // ...
+        assertTrue(blobStore.get(queryTile(3, 0, 2)));
+        assertTrue(blobStore.get(queryTile(3, 1, 2)));
+        assertTrue(blobStore.get(queryTile(3, 2, 2)));
+        assertTrue(blobStore.get(queryTile(3, 3, 2)));
+    }
+
+    private TileRange tileRange(
+            String layerName,
+            String gridSetId,
+            int zoomStart,
+            int zoomStop,
+            long[][] rangeBounds,
+            MimeType mimeType,
+            Map<String, String> parameters) {
+
+        TileRange tileRange =
+                new TileRange(
+                        layerName,
+                        gridSetId,
+                        zoomStart,
+                        zoomStop,
+                        rangeBounds,
+                        mimeType,
+                        parameters);
+        return tileRange;
+    }
+
+    private void seed(int zoomStart, int zoomStop) throws StorageException {
+        seed(zoomStart, zoomStop, DEFAULT_GRIDSET, DEFAULT_FORMAT, null);
+    }
+
+    private void seed(
+            int zoomStart,
+            int zoomStop,
+            String gridset,
+            String formatExtension,
+            Map<String, String> parameters)
+            throws StorageException {
+
+        Preconditions.checkArgument(
+                zoomStop < 5, "don't use high zoom levels for integration testing");
+        for (int z = zoomStart; z <= zoomStop; z++) {
+            int max = (int) Math.pow(2, z);
+            for (int x = 0; x < max; x++) {
+                for (int y = 0; y < max; y++) {
+                    log.debug(String.format("seeding %d,%d,%d", x, y, z));
+                    put(x, y, z, gridset, formatExtension, parameters);
+                }
+            }
+        }
+    }
+
+    private TileObject put(long x, long y, int z) throws StorageException {
+        return put(x, y, z, DEFAULT_GRIDSET, DEFAULT_FORMAT, null);
+    }
+
+    private TileObject put(
+            long x,
+            long y,
+            int z,
+            String gridset,
+            String formatExtension,
+            Map<String, String> parameters)
+            throws StorageException {
+        return put(x, y, z, DEFAULT_LAYER, gridset, formatExtension, parameters);
+    }
+
+    private TileObject put(
+            long x,
+            long y,
+            int z,
+            String layerName,
+            String gridset,
+            String formatExtension,
+            Map<String, String> parameters)
+            throws StorageException {
+        byte[] bytes = new byte[256];
+        Arrays.fill(bytes, (byte) 0xaf);
+        TileObject tile = queryTile(layerName, gridset, formatExtension, x, y, z, parameters);
+        tile.setBlob(new ByteArrayResource(bytes));
+        blobStore.put(tile);
+        return tile;
+    }
+
+    private TileObject queryTile(long x, long y, int z) {
+        return queryTile(DEFAULT_LAYER, DEFAULT_GRIDSET, DEFAULT_FORMAT, x, y, z);
+    }
+
+    private TileObject queryTile(
+            String layer, String gridset, String extension, long x, long y, int z) {
+        return queryTile(layer, gridset, extension, x, y, z, (Map<String, String>) null);
+    }
+
+    private TileObject queryTile(
+            String layer,
+            String gridset,
+            String extension,
+            long x,
+            long y,
+            int z,
+            String... parameters) {
+
+        Map<String, String> parametersMap = null;
+        if (parameters != null) {
+            parametersMap = new HashMap<>();
+            for (int i = 0; i < parameters.length; i += 2) {
+                parametersMap.put(parameters[i], parameters[i + 1]);
+            }
+        }
+        return queryTile(layer, gridset, extension, x, y, z, parametersMap);
+    }
+
+    private TileObject queryTile(
+            String layer,
+            String gridset,
+            String extension,
+            long x,
+            long y,
+            int z,
+            Map<String, String> parameters) {
+
+        String format;
+        try {
+            format = MimeType.createFromExtension(extension).getFormat();
+        } catch (MimeException e) {
+            throw new RuntimeException(e);
+        }
+
+        TileObject tile =
+                TileObject.createQueryTileObject(
+                        layer, new long[] {x, y, z}, gridset, format, parameters);
+        return tile;
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConfigProviderTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConfigProviderTest.java
@@ -1,0 +1,62 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.thoughtworks.xstream.XStream;
+import org.geowebcache.GeoWebCacheExtensions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class AzureBlobStoreConfigProviderTest {
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("CONTAINER", "MYCONTAINER");
+        System.setProperty("CONNECTIONS", "30");
+        System.setProperty("ENABLED", "true");
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+        ClassPathXmlApplicationContext context =
+                new ClassPathXmlApplicationContext("appContextTestAzure.xml");
+
+        GeoWebCacheExtensions gse = new GeoWebCacheExtensions();
+        gse.setApplicationContext(context);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("CONTAINER");
+        System.clearProperty("CONNECTIONS");
+        System.clearProperty("ENABLED");
+        System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
+    }
+
+    @Test
+    public void testValuesFromEnvironment() {
+        AzureBlobStoreConfigProvider provider = new AzureBlobStoreConfigProvider();
+        XStream stream = new XStream();
+        stream = provider.getConfiguredXStream(stream);
+        Object config = stream.fromXML(getClass().getResourceAsStream("blobstore.xml"));
+        assertTrue(config instanceof AzureBlobStoreInfo);
+        AzureBlobStoreInfo abConfig = (AzureBlobStoreInfo) config;
+        assertEquals("MYCONTAINER", abConfig.getContainer());
+        assertEquals(30, abConfig.getMaxConnections().intValue());
+        assertEquals(true, abConfig.isEnabled());
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
@@ -1,0 +1,72 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin Smith, Boundless, 2017
+ */
+package org.geowebcache.azure;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.easymock.EasyMock;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.NoOpLockProvider;
+import org.geowebcache.storage.AbstractBlobStoreTest;
+import org.junit.Assume;
+import org.junit.Rule;
+
+public class AzureBlobStoreConformanceTest extends AbstractBlobStoreTest<AzureBlobStore> {
+    public PropertiesLoader testConfigLoader = new PropertiesLoader();
+
+    @Rule
+    public TemporaryAzureFolder tempFolder =
+            new TemporaryAzureFolder(testConfigLoader.getProperties());
+
+    @Override
+    public void createTestUnit() throws Exception {
+        Assume.assumeTrue(tempFolder.isConfigured());
+        AzureBlobStoreInfo config = tempFolder.getConfig();
+
+        TileLayerDispatcher layers = createMock(TileLayerDispatcher.class);
+        LockProvider lockProvider = new NoOpLockProvider();
+        Stream.of("testLayer", "testLayer1", "testLayer2")
+                .map(
+                        name -> {
+                            TileLayer mock = createMock(name, TileLayer.class);
+                            expect(mock.getName()).andStubReturn(name);
+                            expect(mock.getId()).andStubReturn(name);
+                            expect(mock.getGridSubsets())
+                                    .andStubReturn(Collections.singleton("testGridSet"));
+                            expect(mock.getMimeTypes())
+                                    .andStubReturn(
+                                            Arrays.asList(org.geowebcache.mime.ImageMime.png));
+                            try {
+                                expect(layers.getTileLayer(eq(name))).andStubReturn(mock);
+                            } catch (GeoWebCacheException e) {
+                                fail();
+                            }
+                            return mock;
+                        })
+                .forEach(EasyMock::replay);
+        replay(layers);
+        store = new AzureBlobStore(config, layers, lockProvider);
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
@@ -1,0 +1,122 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin Smith, Boundless, 2018
+ */
+package org.geowebcache.azure;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import org.easymock.EasyMock;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.locks.NoOpLockProvider;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.BlobStoreSuitabilityTest;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.springframework.http.HttpStatus;
+
+@RunWith(AzureBlobStoreSuitabilityTest.MyTheories.class)
+public class AzureBlobStoreSuitabilityTest extends BlobStoreSuitabilityTest {
+
+    public PropertiesLoader testConfigLoader = new PropertiesLoader();
+
+    @Rule
+    public TemporaryAzureFolder tempFolder =
+            new TemporaryAzureFolder(testConfigLoader.getProperties());
+
+    @DataPoints
+    public static String[][] persistenceLocations =
+            new String[][] {
+                {},
+                {"metadata.properties"},
+                {"something"},
+                {"something", "metadata.properties"},
+                {"something/metadata.properties"}
+            };
+
+    TileLayerDispatcher tld;
+    LockProvider locks;
+
+    @Before
+    public void setup() throws Exception {
+        tld = EasyMock.createMock("tld", TileLayerDispatcher.class);
+        locks = new NoOpLockProvider();
+        EasyMock.replay(tld);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    protected Matcher<Object> existing() {
+        return (Matcher) hasItemInArray(equalTo("metadata.properties"));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    protected Matcher<Object> empty() {
+        return (Matcher) Matchers.emptyArray();
+    }
+
+    @Override
+    public BlobStore create(Object dir) throws Exception {
+        AzureBlobStoreInfo info = tempFolder.getConfig();
+        for (String path : (String[]) dir) {
+            String fullPath = info.getPrefix() + "/" + path;
+            ByteBuffer byteBuffer = ByteBuffer.wrap("testAbc".getBytes());
+            int statusCode =
+                    tempFolder
+                            .getClient()
+                            .getBlockBlobURL(fullPath)
+                            .upload(Flowable.just(byteBuffer), byteBuffer.limit())
+                            .blockingGet()
+                            .statusCode();
+            assertTrue(HttpStatus.valueOf(statusCode).is2xxSuccessful());
+        }
+        return new AzureBlobStore(info, tld, locks);
+    }
+
+    // Sorry, this bit of evil makes the Theories runner gracefully ignore the
+    // tests if S3 is unavailable.  There's probably a better way to do this.
+    public static class MyTheories extends Theories {
+
+        public MyTheories(Class<?> klass) throws InitializationError {
+            super(klass);
+        }
+
+        @Override
+        public Statement methodBlock(FrameworkMethod method) {
+            if (new PropertiesLoader().getProperties().containsKey("container")) {
+                return super.methodBlock(method);
+            } else {
+                return new Statement() {
+                    public void evaluate() {
+                        assumeFalse("Azure unavailable", true);
+                    }
+                };
+            }
+        }
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
@@ -99,7 +99,7 @@ public class AzureBlobStoreSuitabilityTest extends BlobStoreSuitabilityTest {
     }
 
     // Sorry, this bit of evil makes the Theories runner gracefully ignore the
-    // tests if S3 is unavailable.  There's probably a better way to do this.
+    // tests if Azure is unavailable.  There's probably a better way to do this.
     public static class MyTheories extends Theories {
 
         public MyTheories(Class<?> klass) throws InitializationError {

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/OnlineAzureBlobStoreIntegrationTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/OnlineAzureBlobStoreIntegrationTest.java
@@ -1,0 +1,50 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+public class OnlineAzureBlobStoreIntegrationTest extends AbstractAzureBlobStoreIntegrationTest {
+
+    @Rule
+    public TemporaryAzureFolder tempFolder =
+            new TemporaryAzureFolder(testConfigLoader.getProperties());
+
+    protected AzureBlobStoreInfo getConfiguration() {
+        Assume.assumeTrue("Configuration not found or incomplee", tempFolder.isConfigured());
+        return tempFolder.getConfig();
+    }
+
+    @Test
+    public void testCreatesStoreMetadataOnStart() {
+        String prefix = tempFolder.getConfig().getPrefix();
+        String container = tempFolder.getConfig().getContainer();
+        // if the file does not exist a StorageException will be thrown
+        int status =
+                tempFolder
+                        .getClient()
+                        .getBlockBlobURL(prefix + "/metadata.properties")
+                        .getProperties()
+                        .blockingGet()
+                        .statusCode();
+        assertTrue(
+                "Expected success but got " + status, HttpStatus.valueOf(status).is2xxSuccessful());
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/PropertiesLoader.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/PropertiesLoader.java
@@ -1,0 +1,73 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Loads the configuration from a properties file {@code $HOME/.gwc_azure_tests.properties}, which
+ * must exist and contain entries for {@code container}, {@code accountName}, and {@code
+ * accountKey}.
+ *
+ * <p>If the file doesn't exist, the returned {@link #getProperties()} will be empty.
+ *
+ * <p>If the file does exist and doesn't contain one of the required keys, the constructor fails
+ * with an {@link IllegalArgumentException}.
+ */
+public class PropertiesLoader {
+
+    private static Log log = LogFactory.getLog(PropertiesLoader.class);
+
+    private Properties properties = new Properties();
+
+    public PropertiesLoader() {
+        String home = System.getProperty("user.home");
+        File configFile = new File(home, ".gwc_azure_tests.properties");
+        log.info(
+                "Loading Azure tests config. File must have keys 'container', 'accountName', and 'accountKey'");
+        if (configFile.exists()) {
+            try (InputStream in = new FileInputStream(configFile)) {
+                properties.load(in);
+                checkArgument(
+                        null != properties.getProperty("container"),
+                        "container not provided in config file " + configFile.getAbsolutePath());
+                checkArgument(
+                        null != properties.getProperty("accountName"),
+                        "accountName not provided in config file " + configFile.getAbsolutePath());
+                checkArgument(
+                        null != properties.getProperty("accountKey"),
+                        "accountKey not provided in config file " + configFile.getAbsolutePath());
+            } catch (IOException e) {
+                log.fatal("Error loading Azure tests config: " + configFile.getAbsolutePath(), e);
+            }
+        } else {
+            log.warn(
+                    "Azure storage config file not found. Azure Azure tests will be ignored. "
+                            + configFile.getAbsolutePath());
+        }
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
@@ -26,7 +26,7 @@ import org.junit.rules.ExternalResource;
 import org.springframework.http.HttpStatus;
 
 /**
- * The TemporaryAzureFolder provides a path prefix for S3 storage and deletes all resources under
+ * The TemporaryAzureFolder provides a path prefix for Azure storage and deletes all resources under
  * the given prefix at shutdown.
  */
 public class TemporaryAzureFolder extends ExternalResource {

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
@@ -1,0 +1,130 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Andrea Aime, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.junit.Assert.assertTrue;
+
+import com.microsoft.azure.storage.blob.BlockBlobURL;
+import com.microsoft.azure.storage.blob.models.BlobItem;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import org.junit.rules.ExternalResource;
+import org.springframework.http.HttpStatus;
+
+/**
+ * The TemporaryAzureFolder provides a path prefix for S3 storage and deletes all resources under
+ * the given prefix at shutdown.
+ */
+public class TemporaryAzureFolder extends ExternalResource {
+
+    private Properties properties;
+
+    private String container;
+
+    private String accountName;
+
+    private String accountKey;
+
+    private String temporaryPrefix;
+
+    private AzureClient client;
+
+    public TemporaryAzureFolder(Properties properties) {
+        this.properties = properties;
+        this.container = properties.getProperty("container");
+        this.accountName = properties.getProperty("accountName");
+        this.accountKey = properties.getProperty("accountKey");
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        if (!isConfigured()) {
+            return;
+        }
+        this.temporaryPrefix = "tmp_" + UUID.randomUUID().toString().replace("-", "");
+        client = new AzureClient(getConfig());
+    }
+
+    @Override
+    protected void after() {
+        if (!isConfigured()) {
+            return;
+        }
+        try {
+            delete();
+        } finally {
+            temporaryPrefix = null;
+            client.close();
+        }
+    }
+
+    public AzureClient getClient() {
+        checkState(isConfigured(), "client not configured.");
+        return client;
+    }
+
+    public AzureBlobStoreInfo getConfig() {
+        checkState(isConfigured(), "Azure connection not configured.");
+        AzureBlobStoreInfo config = new AzureBlobStoreInfo();
+        config.setContainer(container);
+        config.setAccountName(accountName);
+        config.setAccountKey(accountKey);
+        config.setPrefix(temporaryPrefix);
+        if (properties.getProperty("serviceURL") != null) {
+            config.setServiceURL(properties.getProperty("serviceURL"));
+        }
+        if (properties.getProperty("maxConnections") != null) {
+            config.setMaxConnections(Integer.valueOf(properties.getProperty("maxConnections")));
+        }
+        if (properties.getProperty("useHTTPS") != null) {
+            config.setUseHTTPS(Boolean.valueOf(properties.getProperty("useHTTPS")));
+        }
+        if (properties.getProperty("proxyHost") != null) {
+            config.setProxyHost(properties.getProperty("proxyHost"));
+        }
+        if (properties.getProperty("proxyPort") != null) {
+            config.setProxyPort(Integer.valueOf(properties.getProperty("proxyPort")));
+        }
+        if (properties.getProperty("proxyUsername") != null) {
+            config.setProxyUsername(properties.getProperty("proxyUsername"));
+        }
+        if (properties.getProperty("proxyPassword") != null) {
+            config.setProxyPassword(properties.getProperty("proxyPassword"));
+        }
+        return config;
+    }
+
+    public void delete() {
+        checkState(isConfigured(), "client not configured.");
+        if (temporaryPrefix == null) {
+            return;
+        }
+
+        List<BlobItem> blobs = client.listBlobs(temporaryPrefix, Integer.MAX_VALUE);
+        for (BlobItem blob : blobs) {
+            BlockBlobURL blockBlobURL = client.getBlockBlobURL(blob.name());
+            int status = blockBlobURL.delete().blockingGet().statusCode();
+            assertTrue(
+                    "Expected success but got " + status + " while deleting " + blob.name(),
+                    HttpStatus.valueOf(status).is2xxSuccessful());
+        }
+    }
+
+    public boolean isConfigured() {
+        return container != null && accountName != null && accountKey != null;
+    }
+}

--- a/geowebcache/azureblob/src/test/resources/appContextTestAzure.xml
+++ b/geowebcache/azureblob/src/test/resources/appContextTestAzure.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  (c) 2019 Open Source Geospatial Foundation - all rights reserved
+  ~  This code is licensed under the GPL 2.0 license, available at the root
+  ~  application directory.
+  ~  
+  -->
+
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+  <description>
+   Bean configuration file for the gwc-azure-blob tests
+  </description>
+
+  <bean id="geoWebCacheExtensions" class="org.geowebcache.GeoWebCacheExtensions"/>
+  
+  <bean id="geoWebCacheEnvironment" class="org.geowebcache.GeoWebCacheEnvironment" depends-on="geoWebCacheExtensions"/>
+</beans>

--- a/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
+++ b/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  (c) 2019 Open Source Geospatial Foundation - all rights reserved
+  ~  This code is licensed under the GPL 2.0 license, available at the root
+  ~  application directory.
+  ~  
+  -->
+
+<AzureBlobStore default="true">
+  <id>S3-BlobStore</id>
+  <enabled>${ENABLED}</enabled>
+  <container>${CONTAINER}</container>
+  <accountName>myname</accountName>
+  <accountKey>mykey</accountKey>
+  <maxConnections>${CONNECTIONS}</maxConnections>
+</AzureBlobStore>

--- a/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
+++ b/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
@@ -7,7 +7,7 @@
   -->
 
 <AzureBlobStore default="true">
-  <id>S3-BlobStore</id>
+  <id>Azure-BlobStore</id>
   <enabled>${ENABLED}</enabled>
   <container>${CONTAINER}</container>
   <accountName>myname</accountName>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -789,5 +789,6 @@
 	<module>distributed</module>
     <module>s3storage</module>
     <module>sqlite</module>
+    <module>azureblob</module>
   </modules>
 </project>


### PR DESCRIPTION
The backport per se is trivial, but doing it I noticed that all the blobstores are actually part of the final WAR file, while I did not add the azure one to it.
Thinking out loud, should I:

- Add it to the GWC war on master, since it's a dev series
- Skip adding in on 1.15.x (or make it available as a profile), since it's a stable series 

@smithkm what do you think?