### PR TITLE
[#777] Allow runtime parametrization of Azure blobstore configuration

### DIFF
--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
@@ -70,7 +70,7 @@ public class AzureBlobStore implements BlobStore {
     private volatile boolean shutDown = false;
 
     public AzureBlobStore(
-            AzureBlobStoreInfo configuration, TileLayerDispatcher layers, LockProvider lockProvider)
+            AzureBlobStoreData configuration, TileLayerDispatcher layers, LockProvider lockProvider)
             throws StorageException {
         this.client = new AzureClient(configuration);
 

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreConfigProvider.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreConfigProvider.java
@@ -14,90 +14,16 @@
  */
 package org.geowebcache.azure;
 
-import com.google.common.base.Strings;
 import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.converters.SingleValueConverter;
-import com.thoughtworks.xstream.converters.basic.BooleanConverter;
-import com.thoughtworks.xstream.converters.basic.IntConverter;
-import com.thoughtworks.xstream.converters.basic.StringConverter;
-import org.geowebcache.GeoWebCacheEnvironment;
-import org.geowebcache.GeoWebCacheExtensions;
-import org.geowebcache.config.BlobStoreInfo;
 import org.geowebcache.config.Info;
 import org.geowebcache.config.XMLConfigurationProvider;
 
 public class AzureBlobStoreConfigProvider implements XMLConfigurationProvider {
 
-    private static GeoWebCacheEnvironment gwcEnvironment = null;
-
-    private static SingleValueConverter EnvironmentNullableIntConverter =
-            new IntConverter() {
-
-                @Override
-                public Object fromString(String str) {
-                    str = resolveFromEnv(str);
-                    if (Strings.isNullOrEmpty(str)) {
-                        return null;
-                    }
-                    return super.fromString(str);
-                }
-            };
-
-    private static SingleValueConverter EnvironmentNullableBooleanConverter =
-            new BooleanConverter() {
-
-                @Override
-                public Object fromString(String str) {
-                    str = resolveFromEnv(str);
-                    if (Strings.isNullOrEmpty(str)) {
-                        return null;
-                    }
-                    return super.fromString(str);
-                }
-            };
-
-    private static SingleValueConverter EnvironmentStringConverter =
-            new StringConverter() {
-                @Override
-                public Object fromString(String str) {
-                    str = resolveFromEnv(str);
-                    if (Strings.isNullOrEmpty(str)) {
-                        return null;
-                    }
-                    return str;
-                }
-            };
-
-    private static String resolveFromEnv(String str) {
-        if (gwcEnvironment == null) {
-            gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
-        }
-        if (gwcEnvironment != null
-                && str != null
-                && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-            Object result = gwcEnvironment.resolveValue(str);
-            if (result == null) {
-                return null;
-            }
-            return result.toString();
-        }
-        return str;
-    }
-
     @Override
     public XStream getConfiguredXStream(XStream xs) {
         Class<AzureBlobStoreInfo> clazz = AzureBlobStoreInfo.class;
         xs.alias("AzureBlobStore", clazz);
-        xs.registerLocalConverter(clazz, "maxConnections", EnvironmentNullableIntConverter);
-        xs.registerLocalConverter(clazz, "proxyPort", EnvironmentNullableIntConverter);
-        xs.registerLocalConverter(clazz, "useHTTPS", EnvironmentNullableBooleanConverter);
-        xs.registerLocalConverter(clazz, "container", EnvironmentStringConverter);
-        xs.registerLocalConverter(clazz, "accountName", EnvironmentStringConverter);
-        xs.registerLocalConverter(clazz, "accountKey", EnvironmentStringConverter);
-        xs.registerLocalConverter(clazz, "prefix", EnvironmentStringConverter);
-        xs.registerLocalConverter(clazz, "proxyHost", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                BlobStoreInfo.class, "enabled", EnvironmentNullableBooleanConverter);
         xs.aliasField("id", clazz, "name");
         return xs;
     }

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreData.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreData.java
@@ -1,0 +1,182 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Fernando Mino, GeoSolutions, Copyright 2019
+ */
+package org.geowebcache.azure;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import org.geowebcache.GeoWebCacheEnvironment;
+
+/**
+ * Azure Blobstore type-resolved data from a {@link AzureBlobStoreInfo} using enviroment variables
+ * if enabled.
+ */
+class AzureBlobStoreData {
+
+    private String container;
+    private String prefix;
+    private String accountName;
+    private String accountKey;
+    private Integer maxConnections;
+    private Boolean useHTTPS;
+    private String proxyHost;
+    private Integer proxyPort;
+    private String proxyUsername;
+    private String proxyPassword;
+    private String serviceURL;
+
+    AzureBlobStoreData() {}
+
+    public AzureBlobStoreData(
+            final AzureBlobStoreInfo storeInfo, final GeoWebCacheEnvironment environment) {
+        environment
+                .resolveValueIfEnabled(storeInfo.getContainer(), String.class)
+                .ifPresent(x -> this.container = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getPrefix(), String.class)
+                .ifPresent(x -> this.prefix = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getAccountName(), String.class)
+                .ifPresent(x -> this.accountName = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getAccountKey(), String.class)
+                .ifPresent(x -> this.accountKey = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getMaxConnections(), Integer.class)
+                .ifPresent(x -> this.maxConnections = x);
+        this.useHTTPS = storeInfo.isUseHTTPS();
+        environment
+                .resolveValueIfEnabled(storeInfo.getProxyHost(), String.class)
+                .ifPresent(x -> this.proxyHost = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getProxyPort(), Integer.class)
+                .ifPresent(x -> this.proxyPort = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getProxyUsername(), String.class)
+                .ifPresent(x -> this.proxyUsername = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getProxyPassword(), String.class)
+                .ifPresent(x -> this.proxyPassword = x);
+        environment
+                .resolveValueIfEnabled(storeInfo.getServiceURL(), String.class)
+                .ifPresent(x -> this.serviceURL = x);
+    }
+
+    public String getContainer() {
+        return container;
+    }
+
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public void setAccountName(String accountName) {
+        this.accountName = accountName;
+    }
+
+    public String getAccountKey() {
+        return accountKey;
+    }
+
+    public void setAccountKey(String accountKey) {
+        this.accountKey = accountKey;
+    }
+
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    public Boolean isUseHTTPS() {
+        return useHTTPS;
+    }
+
+    public void setUseHTTPS(Boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    public void setProxyUsername(String proxyUsername) {
+        this.proxyUsername = proxyUsername;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
+    public String getServiceURL() {
+        return serviceURL;
+    }
+
+    public void setServiceURL(String serviceURL) {
+        this.serviceURL = serviceURL;
+    }
+
+    public String getLocation() {
+        String container = this.getContainer();
+        String prefix = this.getPrefix();
+        if (prefix == null) {
+            return String.format("container: %s", container);
+        } else {
+            return String.format("container: %s prefix: %s", container, prefix);
+        }
+    }
+
+    Proxy getProxy() {
+        if (proxyHost != null) {
+            return new Proxy(
+                    Proxy.Type.HTTP,
+                    new InetSocketAddress(proxyHost, proxyPort != null ? proxyPort : 8888));
+        }
+        return null;
+    }
+}

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -53,10 +53,10 @@ import org.springframework.http.HttpStatus;
 class AzureClient implements Closeable {
 
     private final NettyClient.Factory factory;
-    private AzureBlobStoreInfo configuration;
+    private AzureBlobStoreData configuration;
     private final ContainerURL container;
 
-    public AzureClient(AzureBlobStoreInfo configuration) throws StorageException {
+    public AzureClient(AzureBlobStoreData configuration) throws StorageException {
         this.configuration = configuration;
         try {
             SharedKeyCredentials creds =
@@ -113,7 +113,7 @@ class AzureClient implements Closeable {
         }
     }
 
-    public String getServiceURL(AzureBlobStoreInfo configuration) {
+    public String getServiceURL(AzureBlobStoreData configuration) {
         String serviceURL = configuration.getServiceURL();
         if (serviceURL == null) {
             // default to account name based location

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AbstractAzureBlobStoreIntegrationTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AbstractAzureBlobStoreIntegrationTest.java
@@ -81,11 +81,11 @@ public abstract class AbstractAzureBlobStoreIntegrationTest {
 
     private AzureBlobStore blobStore;
 
-    protected abstract AzureBlobStoreInfo getConfiguration();
+    protected abstract AzureBlobStoreData getConfiguration();
 
     @Before
     public void before() throws Exception {
-        AzureBlobStoreInfo config = getConfiguration();
+        AzureBlobStoreData config = getConfiguration();
 
         TileLayerDispatcher layers = mock(TileLayerDispatcher.class);
         LockProvider lockProvider = new NoOpLockProvider();

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
@@ -43,7 +43,7 @@ public class AzureBlobStoreConformanceTest extends AbstractBlobStoreTest<AzureBl
     @Override
     public void createTestUnit() throws Exception {
         Assume.assumeTrue(tempFolder.isConfigured());
-        AzureBlobStoreInfo config = tempFolder.getConfig();
+        AzureBlobStoreData config = tempFolder.getConfig();
 
         TileLayerDispatcher layers = createMock(TileLayerDispatcher.class);
         LockProvider lockProvider = new NoOpLockProvider();

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreDataTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreDataTest.java
@@ -10,32 +10,30 @@
  * <p>You should have received a copy of the GNU Lesser General Public License along with this
  * program. If not, see <http://www.gnu.org/licenses/>.
  *
- * @author Andrea Aime, GeoSolutions, Copyright 2019
+ * @author Fernando Mino, GeoSolutions, Copyright 2019
  */
 package org.geowebcache.azure;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import com.thoughtworks.xstream.XStream;
+import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-public class AzureBlobStoreConfigProviderTest {
+public class AzureBlobStoreDataTest {
 
     @Before
     public void setUp() throws Exception {
         System.setProperty("CONTAINER", "MYCONTAINER");
-        System.setProperty("MYKEY", "99942777gfa+");
+        System.setProperty("ACCOUNT_NAME", "MYNAME");
+        System.setProperty("ACCOUNT_KEY", "MYKEY");
         System.setProperty("CONNECTIONS", "30");
-        System.setProperty("ENABLED", "true");
         System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
         ClassPathXmlApplicationContext context =
                 new ClassPathXmlApplicationContext("appContextTestAzure.xml");
-
         GeoWebCacheExtensions gse = new GeoWebCacheExtensions();
         gse.setApplicationContext(context);
     }
@@ -43,24 +41,26 @@ public class AzureBlobStoreConfigProviderTest {
     @After
     public void tearDown() throws Exception {
         System.clearProperty("CONTAINER");
-        System.clearProperty("MYKEY");
         System.clearProperty("CONNECTIONS");
-        System.clearProperty("ENABLED");
+        System.clearProperty("ACCOUNT_NAME");
+        System.clearProperty("ACCOUNT_KEY");
         System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
     }
 
     @Test
-    public void testValuesFromEnvironment() {
-        AzureBlobStoreConfigProvider provider = new AzureBlobStoreConfigProvider();
-        XStream stream = new XStream();
-        stream = provider.getConfiguredXStream(stream);
-        Object config = stream.fromXML(getClass().getResourceAsStream("blobstore.xml"));
-        assertTrue(config instanceof AzureBlobStoreInfo);
-        AzureBlobStoreInfo abConfig = (AzureBlobStoreInfo) config;
-        assertEquals("${CONTAINER}", abConfig.getContainer());
-        assertEquals("myname", abConfig.getAccountName());
-        assertEquals("${MYKEY}", abConfig.getAccountKey());
-        assertEquals("30", abConfig.getMaxConnections());
-        assertEquals(true, abConfig.isEnabled());
+    public void testEnvironmentProperties() {
+        GeoWebCacheEnvironment typedEnvironment =
+                GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
+        final AzureBlobStoreInfo storeInfo = new AzureBlobStoreInfo("info1");
+        storeInfo.setContainer("${CONTAINER}");
+        storeInfo.setAccountName("${ACCOUNT_NAME}");
+        storeInfo.setAccountKey("${ACCOUNT_KEY}");
+        storeInfo.setMaxConnections("${CONNECTIONS}");
+        storeInfo.setEnabled(true);
+        final AzureBlobStoreData storeData = new AzureBlobStoreData(storeInfo, typedEnvironment);
+        assertEquals(Integer.valueOf(30), storeData.getMaxConnections());
+        assertEquals("MYCONTAINER", storeData.getContainer());
+        assertEquals("MYNAME", storeData.getAccountName());
+        assertEquals("MYKEY", storeData.getAccountKey());
     }
 }

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreSuitabilityTest.java
@@ -82,7 +82,7 @@ public class AzureBlobStoreSuitabilityTest extends BlobStoreSuitabilityTest {
 
     @Override
     public BlobStore create(Object dir) throws Exception {
-        AzureBlobStoreInfo info = tempFolder.getConfig();
+        AzureBlobStoreData info = tempFolder.getConfig();
         for (String path : (String[]) dir) {
             String fullPath = info.getPrefix() + "/" + path;
             ByteBuffer byteBuffer = ByteBuffer.wrap("testAbc".getBytes());

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/OnlineAzureBlobStoreIntegrationTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/OnlineAzureBlobStoreIntegrationTest.java
@@ -27,7 +27,7 @@ public class OnlineAzureBlobStoreIntegrationTest extends AbstractAzureBlobStoreI
     public TemporaryAzureFolder tempFolder =
             new TemporaryAzureFolder(testConfigLoader.getProperties());
 
-    protected AzureBlobStoreInfo getConfiguration() {
+    protected AzureBlobStoreData getConfiguration() {
         Assume.assumeTrue("Configuration not found or incomplee", tempFolder.isConfigured());
         return tempFolder.getConfig();
     }

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/TemporaryAzureFolder.java
@@ -77,9 +77,9 @@ public class TemporaryAzureFolder extends ExternalResource {
         return client;
     }
 
-    public AzureBlobStoreInfo getConfig() {
+    public AzureBlobStoreData getConfig() {
         checkState(isConfigured(), "Azure connection not configured.");
-        AzureBlobStoreInfo config = new AzureBlobStoreInfo();
+        AzureBlobStoreData config = new AzureBlobStoreData();
         config.setContainer(container);
         config.setAccountName(accountName);
         config.setAccountKey(accountKey);

--- a/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
+++ b/geowebcache/azureblob/src/test/resources/org/geowebcache/azure/blobstore.xml
@@ -8,9 +8,9 @@
 
 <AzureBlobStore default="true">
   <id>Azure-BlobStore</id>
-  <enabled>${ENABLED}</enabled>
+  <enabled>true</enabled>
   <container>${CONTAINER}</container>
   <accountName>myname</accountName>
-  <accountKey>mykey</accountKey>
-  <maxConnections>${CONNECTIONS}</maxConnections>
+  <accountKey>${MYKEY}</accountKey>
+  <maxConnections>30</maxConnections>
 </AzureBlobStore>


### PR DESCRIPTION
This PR fixes runtime parametrization on Azure blobstore configuration, leveraging placeholders resolving on blobstore creation runtime instead of Xstream resolvers.

Issue:
https://github.com/GeoWebCache/geowebcache/issues/777