### PR TITLE
Bump com.thoughtworks.xstream:xstream from 1.4.10 to 1.4.11.1

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -14,7 +14,7 @@
     <jts.version>1.16.1</jts.version>
     <jaiext.version>1.1.12</jaiext.version>
     <spring.version>5.1.1.RELEASE</spring.version>
-    <xstream.version>1.4.10</xstream.version>
+    <xstream.version>1.4.11.1</xstream.version>
     <spring.security.version>5.1.1.RELEASE</spring.security.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
this bump fixes [CVE-2013-7285](https://nvd.nist.gov/vuln/detail/CVE-2013-7285) and [CVE-2019-10173](https://nvd.nist.gov/vuln/detail/CVE-2019-10173)

I haven't checked if GWC is vulnerable since this bump is trivial.

see also: 
- https://github.com/geoserver/geoserver/pull/3716
- https://x-stream.github.io/changes.html