### PR TITLE
[fixes #796] Improve concurrency and performance of config classes equals and hashcode

### DIFF
--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStoreInfo.java
@@ -18,9 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheEnvironment;
@@ -33,6 +30,7 @@ import org.geowebcache.storage.StorageException;
 
 /** Plain old java object representing the configuration for an Azure blob store. */
 public class AzureBlobStoreInfo extends BlobStoreInfo {
+    private static final long serialVersionUID = -8068069256598987874L;
 
     /**
      * Max number of connections used inside the Netty HTTP client. Might seem a lot, but when
@@ -221,21 +219,6 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    @Override
     public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
             throws StorageException {
         checkNotNull(layers);
@@ -260,5 +243,100 @@ public class AzureBlobStoreInfo extends BlobStoreInfo {
         } else {
             return String.format("container: %s prefix: %s", container, prefix);
         }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((accountKey == null) ? 0 : accountKey.hashCode());
+        result = prime * result + ((accountName == null) ? 0 : accountName.hashCode());
+        result = prime * result + ((container == null) ? 0 : container.hashCode());
+        result = prime * result + ((maxConnections == null) ? 0 : maxConnections.hashCode());
+        result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
+        result = prime * result + ((proxyHost == null) ? 0 : proxyHost.hashCode());
+        result = prime * result + ((proxyPassword == null) ? 0 : proxyPassword.hashCode());
+        result = prime * result + ((proxyPort == null) ? 0 : proxyPort.hashCode());
+        result = prime * result + ((proxyUsername == null) ? 0 : proxyUsername.hashCode());
+        result = prime * result + ((serviceURL == null) ? 0 : serviceURL.hashCode());
+        result = prime * result + ((useHTTPS == null) ? 0 : useHTTPS.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        AzureBlobStoreInfo other = (AzureBlobStoreInfo) obj;
+        if (accountKey == null) {
+            if (other.accountKey != null) return false;
+        } else if (!accountKey.equals(other.accountKey)) return false;
+        if (accountName == null) {
+            if (other.accountName != null) return false;
+        } else if (!accountName.equals(other.accountName)) return false;
+        if (container == null) {
+            if (other.container != null) return false;
+        } else if (!container.equals(other.container)) return false;
+        if (maxConnections == null) {
+            if (other.maxConnections != null) return false;
+        } else if (!maxConnections.equals(other.maxConnections)) return false;
+        if (prefix == null) {
+            if (other.prefix != null) return false;
+        } else if (!prefix.equals(other.prefix)) return false;
+        if (proxyHost == null) {
+            if (other.proxyHost != null) return false;
+        } else if (!proxyHost.equals(other.proxyHost)) return false;
+        if (proxyPassword == null) {
+            if (other.proxyPassword != null) return false;
+        } else if (!proxyPassword.equals(other.proxyPassword)) return false;
+        if (proxyPort == null) {
+            if (other.proxyPort != null) return false;
+        } else if (!proxyPort.equals(other.proxyPort)) return false;
+        if (proxyUsername == null) {
+            if (other.proxyUsername != null) return false;
+        } else if (!proxyUsername.equals(other.proxyUsername)) return false;
+        if (serviceURL == null) {
+            if (other.serviceURL != null) return false;
+        } else if (!serviceURL.equals(other.serviceURL)) return false;
+        if (useHTTPS == null) {
+            if (other.useHTTPS != null) return false;
+        } else if (!useHTTPS.equals(other.useHTTPS)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureBlobStoreInfo [container="
+                + container
+                + ", prefix="
+                + prefix
+                + ", accountName="
+                + accountName
+                + ", accountKey="
+                + accountKey
+                + ", maxConnections="
+                + maxConnections
+                + ", useHTTPS="
+                + useHTTPS
+                + ", proxyHost="
+                + proxyHost
+                + ", proxyPort="
+                + proxyPort
+                + ", proxyUsername="
+                + proxyUsername
+                + ", proxyPassword="
+                + proxyPassword
+                + ", serviceURL="
+                + serviceURL
+                + ", getName()="
+                + getName()
+                + ", getId()="
+                + getId()
+                + ", isEnabled()="
+                + isEnabled()
+                + ", isDefault()="
+                + isDefault()
+                + "]";
     }
 }

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -34,10 +34,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-     <groupId>org.apache.commons</groupId>
-     <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
     </dependency>

--- a/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreInfo.java
@@ -15,8 +15,6 @@
 package org.geowebcache.config;
 
 import java.io.Serializable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.storage.BlobStore;
@@ -133,16 +131,6 @@ public abstract class BlobStoreInfo implements Serializable, Cloneable, Info {
     public abstract String toString();
 
     @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
     public Object clone() {
         try {
             return super.clone();
@@ -173,4 +161,28 @@ public abstract class BlobStoreInfo implements Serializable, Cloneable, Info {
      * @return String representation of this BlobStoreInfo's location.
      */
     public abstract String getLocation();
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (_default ? 1231 : 1237);
+        result = prime * result + (enabled ? 1231 : 1237);
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        BlobStoreInfo other = (BlobStoreInfo) obj;
+        if (_default != other._default) return false;
+        if (enabled != other.enabled) return false;
+        if (name == null) {
+            if (other.name != null) return false;
+        } else if (!name.equals(other.name)) return false;
+        return true;
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreInfo.java
@@ -126,4 +126,26 @@ public class FileBlobStoreInfo extends BlobStoreInfo {
     public String getLocation() {
         return getBaseDirectory();
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((baseDirectory == null) ? 0 : baseDirectory.hashCode());
+        result = prime * result + fileSystemBlockSize;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        FileBlobStoreInfo other = (FileBlobStoreInfo) obj;
+        if (baseDirectory == null) {
+            if (other.baseDirectory != null) return false;
+        } else if (!baseDirectory.equals(other.baseDirectory)) return false;
+        if (fileSystemBlockSize != other.fileSystemBlockSize) return false;
+        return true;
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLGridSet.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLGridSet.java
@@ -15,10 +15,7 @@
 package org.geowebcache.config;
 
 import java.io.Serializable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Arrays;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetFactory;
@@ -348,17 +345,101 @@ public class XMLGridSet implements Serializable {
     }
 
     @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
-    }
-
-    @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((alignTopLeft == null) ? 0 : alignTopLeft.hashCode());
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((extent == null) ? 0 : extent.hashCode());
+        result = prime * result + ((levels == null) ? 0 : levels.hashCode());
+        result = prime * result + ((metersPerUnit == null) ? 0 : metersPerUnit.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((pixelSize == null) ? 0 : pixelSize.hashCode());
+        result = prime * result + Arrays.hashCode(resolutions);
+        result = prime * result + Arrays.hashCode(scaleDenominators);
+        result = prime * result + Arrays.hashCode(scaleNames);
+        result = prime * result + ((srs == null) ? 0 : srs.hashCode());
+        result = prime * result + ((tileHeight == null) ? 0 : tileHeight.hashCode());
+        result = prime * result + ((tileWidth == null) ? 0 : tileWidth.hashCode());
+        result = prime * result + ((yCoordinateFirst == null) ? 0 : yCoordinateFirst.hashCode());
+        return result;
     }
 
     @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        XMLGridSet other = (XMLGridSet) obj;
+        if (alignTopLeft == null) {
+            if (other.alignTopLeft != null) return false;
+        } else if (!alignTopLeft.equals(other.alignTopLeft)) return false;
+        if (description == null) {
+            if (other.description != null) return false;
+        } else if (!description.equals(other.description)) return false;
+        if (extent == null) {
+            if (other.extent != null) return false;
+        } else if (!extent.equals(other.extent)) return false;
+        if (levels == null) {
+            if (other.levels != null) return false;
+        } else if (!levels.equals(other.levels)) return false;
+        if (metersPerUnit == null) {
+            if (other.metersPerUnit != null) return false;
+        } else if (!metersPerUnit.equals(other.metersPerUnit)) return false;
+        if (name == null) {
+            if (other.name != null) return false;
+        } else if (!name.equals(other.name)) return false;
+        if (pixelSize == null) {
+            if (other.pixelSize != null) return false;
+        } else if (!pixelSize.equals(other.pixelSize)) return false;
+        if (!Arrays.equals(resolutions, other.resolutions)) return false;
+        if (!Arrays.equals(scaleDenominators, other.scaleDenominators)) return false;
+        if (!Arrays.equals(scaleNames, other.scaleNames)) return false;
+        if (srs == null) {
+            if (other.srs != null) return false;
+        } else if (!srs.equals(other.srs)) return false;
+        if (tileHeight == null) {
+            if (other.tileHeight != null) return false;
+        } else if (!tileHeight.equals(other.tileHeight)) return false;
+        if (tileWidth == null) {
+            if (other.tileWidth != null) return false;
+        } else if (!tileWidth.equals(other.tileWidth)) return false;
+        if (yCoordinateFirst == null) {
+            if (other.yCoordinateFirst != null) return false;
+        } else if (!yCoordinateFirst.equals(other.yCoordinateFirst)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLGridSet [name="
+                + name
+                + ", description="
+                + description
+                + ", srs="
+                + srs
+                + ", extent="
+                + extent
+                + ", alignTopLeft="
+                + alignTopLeft
+                + ", resolutions="
+                + Arrays.toString(resolutions)
+                + ", scaleDenominators="
+                + Arrays.toString(scaleDenominators)
+                + ", levels="
+                + levels
+                + ", metersPerUnit="
+                + metersPerUnit
+                + ", pixelSize="
+                + pixelSize
+                + ", scaleNames="
+                + Arrays.toString(scaleNames)
+                + ", tileHeight="
+                + tileHeight
+                + ", tileWidth="
+                + tileWidth
+                + ", yCoordinateFirst="
+                + yCoordinateFirst
+                + "]";
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLGridSubset.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLGridSubset.java
@@ -15,10 +15,6 @@
 package org.geowebcache.config;
 
 import java.io.Serializable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.grid.BoundingBox;
@@ -144,21 +140,6 @@ public class XMLGridSubset implements Serializable, Cloneable {
         this.zoomStop = zoomStop;
     }
 
-    @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
     public Integer getMinCachedLevel() {
         return minCachedLevel;
     }
@@ -173,5 +154,62 @@ public class XMLGridSubset implements Serializable, Cloneable {
 
     public void setMaxCachedLevel(Integer maxCachedLevel) {
         this.maxCachedLevel = maxCachedLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((extent == null) ? 0 : extent.hashCode());
+        result = prime * result + ((gridSetName == null) ? 0 : gridSetName.hashCode());
+        result = prime * result + ((maxCachedLevel == null) ? 0 : maxCachedLevel.hashCode());
+        result = prime * result + ((minCachedLevel == null) ? 0 : minCachedLevel.hashCode());
+        result = prime * result + ((zoomStart == null) ? 0 : zoomStart.hashCode());
+        result = prime * result + ((zoomStop == null) ? 0 : zoomStop.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        XMLGridSubset other = (XMLGridSubset) obj;
+        if (extent == null) {
+            if (other.extent != null) return false;
+        } else if (!extent.equals(other.extent)) return false;
+        if (gridSetName == null) {
+            if (other.gridSetName != null) return false;
+        } else if (!gridSetName.equals(other.gridSetName)) return false;
+        if (maxCachedLevel == null) {
+            if (other.maxCachedLevel != null) return false;
+        } else if (!maxCachedLevel.equals(other.maxCachedLevel)) return false;
+        if (minCachedLevel == null) {
+            if (other.minCachedLevel != null) return false;
+        } else if (!minCachedLevel.equals(other.minCachedLevel)) return false;
+        if (zoomStart == null) {
+            if (other.zoomStart != null) return false;
+        } else if (!zoomStart.equals(other.zoomStart)) return false;
+        if (zoomStop == null) {
+            if (other.zoomStop != null) return false;
+        } else if (!zoomStop.equals(other.zoomStop)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLGridSubset [gridSetName="
+                + gridSetName
+                + ", extent="
+                + extent
+                + ", zoomStart="
+                + zoomStart
+                + ", zoomStop="
+                + zoomStop
+                + ", minCachedLevel="
+                + minCachedLevel
+                + ", maxCachedLevel="
+                + maxCachedLevel
+                + "]";
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
@@ -26,6 +26,8 @@ import javax.annotation.Nullable;
  * @author Kevin Smith, Boundless
  */
 public class CaseNormalizer implements Function<String, String>, Serializable, Cloneable {
+    private static final long serialVersionUID = -4175693577236472098L;
+
     /**
      * Ways to normalize case
      *
@@ -151,5 +153,32 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
     @Override
     public CaseNormalizer clone() {
         return new CaseNormalizer(kase, locale);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((kase == null) ? 0 : kase.hashCode());
+        result = prime * result + ((locale == null) ? 0 : locale.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        CaseNormalizer other = (CaseNormalizer) obj;
+        if (kase != other.kase) return false;
+        if (locale == null) {
+            if (other.locale != null) return false;
+        } else if (!locale.equals(other.locale)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "CaseNormalizer [kase=" + kase + ", locale=" + locale + "]";
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
@@ -18,6 +18,7 @@ import com.google.common.base.Function;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import java.io.Serializable;
 import java.util.Locale;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -170,11 +171,7 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         CaseNormalizer other = (CaseNormalizer) obj;
-        if (kase != other.kase) return false;
-        if (locale == null) {
-            if (other.locale != null) return false;
-        } else if (!locale.equals(other.locale)) return false;
-        return true;
+        return Objects.equals(kase, other.kase) && Objects.equals(locale, other.locale);
     }
 
     @Override

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
@@ -16,11 +16,12 @@ package org.geowebcache.filter.parameters;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
     private static final long serialVersionUID = 1761619452677321350L;
-    private CaseNormalizer normalize;
+    protected CaseNormalizer normalize;
 
     public CaseNormalizingParameterFilter() {
         super();
@@ -34,6 +35,11 @@ public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
 
     public CaseNormalizingParameterFilter(String key) {
         super(key);
+    }
+
+    protected @Override Object readResolve() {
+        super.readResolve();
+        return this;
     }
 
     public CaseNormalizer getNormalize() {
@@ -62,7 +68,8 @@ public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + ((normalize == null) ? 0 : normalize.hashCode());
+        // hashCode based on getNormalize() as it provides an transient default value when null
+        result = prime * result + getNormalize().hashCode();
         return result;
     }
 
@@ -72,10 +79,8 @@ public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
         if (!super.equals(obj)) return false;
         if (getClass() != obj.getClass()) return false;
         CaseNormalizingParameterFilter other = (CaseNormalizingParameterFilter) obj;
-        if (normalize == null) {
-            if (other.normalize != null) return false;
-        } else if (!normalize.equals(other.normalize)) return false;
-        return true;
+        // equals based on getNormalize() as it provides an transient default value when null
+        return Objects.equals(getNormalize(), other.getNormalize());
     }
 
     @Override

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizingParameterFilter.java
@@ -19,7 +19,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
-
+    private static final long serialVersionUID = 1761619452677321350L;
     private CaseNormalizer normalize;
 
     public CaseNormalizingParameterFilter() {
@@ -56,5 +56,34 @@ public abstract class CaseNormalizingParameterFilter extends ParameterFilter {
         } else {
             return Lists.transform(values, getNormalize());
         }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((normalize == null) ? 0 : normalize.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        CaseNormalizingParameterFilter other = (CaseNormalizingParameterFilter) obj;
+        if (normalize == null) {
+            if (other.normalize != null) return false;
+        } else if (!normalize.equals(other.normalize)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "CaseNormalizingParameterFilter [normalize="
+                + normalize
+                + ", "
+                + super.toString()
+                + "]";
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
@@ -42,7 +42,7 @@ public class FloatParameterFilter extends ParameterFilter {
         values = new ArrayList<Float>(0);
     }
 
-    protected Object readResolve() {
+    protected @Override Object readResolve() {
         super.readResolve();
         if (values == null) {
             values = new ArrayList<Float>(0);

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/FloatParameterFilter.java
@@ -156,4 +156,39 @@ public class FloatParameterFilter extends ParameterFilter {
         clone.setThreshold(this.threshold);
         return clone;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((threshold == null) ? 0 : threshold.hashCode());
+        result = prime * result + ((values == null) ? 0 : values.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        FloatParameterFilter other = (FloatParameterFilter) obj;
+        if (threshold == null) {
+            if (other.threshold != null) return false;
+        } else if (!threshold.equals(other.threshold)) return false;
+        if (values == null) {
+            if (other.values != null) return false;
+        } else if (!values.equals(other.values)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "FloatParameterFilter [values="
+                + values
+                + ", threshold="
+                + threshold
+                + ", "
+                + super.toString()
+                + "]";
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
@@ -42,7 +42,7 @@ public class IntegerParameterFilter extends ParameterFilter {
         values = new ArrayList<Integer>(0);
     }
 
-    protected Object readResolve() {
+    protected @Override Object readResolve() {
         super.readResolve();
         if (values == null) {
             values = new ArrayList<Integer>(0);

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/IntegerParameterFilter.java
@@ -28,6 +28,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @XStreamAlias("integerParameterFilter")
 public class IntegerParameterFilter extends ParameterFilter {
+    private static final long serialVersionUID = 659566920877534621L;
 
     private static Integer DEFAULT_THRESHOLD = Integer.valueOf(1);
 
@@ -154,5 +155,40 @@ public class IntegerParameterFilter extends ParameterFilter {
         }
         clone.setThreshold(this.threshold);
         return clone;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((threshold == null) ? 0 : threshold.hashCode());
+        result = prime * result + ((values == null) ? 0 : values.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        IntegerParameterFilter other = (IntegerParameterFilter) obj;
+        if (threshold == null) {
+            if (other.threshold != null) return false;
+        } else if (!threshold.equals(other.threshold)) return false;
+        if (values == null) {
+            if (other.values != null) return false;
+        } else if (!values.equals(other.values)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "IntegerParameterFilter [values="
+                + values
+                + ", threshold="
+                + threshold
+                + ", "
+                + super.toString()
+                + "]";
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -21,10 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** A filter for a WMS parameter that ensure that it fits within a finite set of defined values. */
 @ParametersAreNonnullByDefault
@@ -131,21 +127,6 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         this.defaultValue = defaultValue;
     }
 
-    @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
     protected Object readResolve() {
         // Make sure XStream found a Key
         Preconditions.checkNotNull(key);
@@ -175,5 +156,29 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         } catch (ParameterException ex) {
             return false;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        ParameterFilter other = (ParameterFilter) obj;
+        if (defaultValue == null) {
+            if (other.defaultValue != null) return false;
+        } else if (!defaultValue.equals(other.defaultValue)) return false;
+        if (key == null) {
+            if (other.key != null) return false;
+        } else if (!key.equals(other.key)) return false;
+        return true;
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
@@ -33,10 +33,11 @@ public class RegexParameterFilter extends CaseNormalizingParameterFilter {
 
     private String regex = DEFAULT_EXPRESSION;
 
-    private transient Pattern pat = compile(regex, getNormalize().getCase());
+    private transient Pattern pat;
 
     public RegexParameterFilter() {
         super();
+        pat = compile(regex, getNormalize().getCase());
     }
 
     /**
@@ -58,10 +59,10 @@ public class RegexParameterFilter extends CaseNormalizingParameterFilter {
         return Pattern.compile(regex, flags);
     }
 
-    protected Object readResolve() {
+    protected @Override Object readResolve() {
         super.readResolve();
         Preconditions.checkNotNull(regex);
-        this.pat = Pattern.compile(regex);
+        this.pat = compile(regex, getNormalize().getCase());
         return this;
     }
 
@@ -119,7 +120,9 @@ public class RegexParameterFilter extends CaseNormalizingParameterFilter {
         clone.setDefaultValue(getDefaultValue());
         clone.setKey(getKey());
         clone.regex = regex;
-        clone.setNormalize(getNormalize().clone());
+        if (super.normalize != null) {
+            clone.setNormalize(super.normalize.clone());
+        }
         return clone;
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
@@ -127,4 +127,29 @@ public class RegexParameterFilter extends CaseNormalizingParameterFilter {
     public List<String> getValues() {
         return null;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((regex == null) ? 0 : regex.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        RegexParameterFilter other = (RegexParameterFilter) obj;
+        if (regex == null) {
+            if (other.regex != null) return false;
+        } else if (!regex.equals(other.regex)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RegexParameterFilter [regex=" + regex + ", " + super.toString() + "]";
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/StringParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/StringParameterFilter.java
@@ -98,4 +98,29 @@ public class StringParameterFilter extends CaseNormalizingParameterFilter {
         clone.setNormalize(getNormalize().clone());
         return clone;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((values == null) ? 0 : values.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        StringParameterFilter other = (StringParameterFilter) obj;
+        if (values == null) {
+            if (other.values != null) return false;
+        } else if (!values.equals(other.values)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "StringParameterFilter [values=" + values + ", " + super.toString() + "]";
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/StringParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/StringParameterFilter.java
@@ -31,13 +31,13 @@ public class StringParameterFilter extends CaseNormalizingParameterFilter {
     private List<String> values;
 
     public StringParameterFilter() {
-        values = new ArrayList<String>(0);
+        values = new ArrayList<String>();
     }
 
-    protected Object readResolve() {
+    protected @Override Object readResolve() {
         super.readResolve();
         if (values == null) {
-            values = new ArrayList<String>(0);
+            values = new ArrayList<String>();
         }
         for (String value : values) {
             Preconditions.checkNotNull(value, "Value list included a null pointer.");
@@ -95,7 +95,9 @@ public class StringParameterFilter extends CaseNormalizingParameterFilter {
         if (values != null) {
             clone.values = new ArrayList<String>(values);
         }
-        clone.setNormalize(getNormalize().clone());
+        if (normalize != null) {
+            clone.setNormalize(normalize.clone());
+        }
         return clone;
     }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
@@ -308,13 +308,21 @@ public class RegexParameterFilterTest {
 
     @Test
     public void testCloneable() throws Exception {
-        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
         RegexParameterFilter clone = filter.clone();
         assertThat(clone.getDefaultValue(), equalTo(filter.getDefaultValue()));
         assertThat(clone.getRegex(), equalTo(filter.getRegex()));
+        assertThat(clone.normalize, equalTo(filter.normalize));
+
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
+
+        clone = filter.clone();
+        assertThat(clone.getDefaultValue(), equalTo(filter.getDefaultValue()));
+        assertThat(clone.getRegex(), equalTo(filter.getRegex()));
+        assertNotSame(filter.normalize, clone.normalize);
+        assertThat(clone.normalize, equalTo(filter.normalize));
         assertThat(
-                clone.getNormalize().getConfiguredLocale(),
-                equalTo(filter.getNormalize().getConfiguredLocale()));
-        assertThat(clone.getNormalize().getCase(), equalTo(filter.getNormalize().getCase()));
+                clone.normalize.getConfiguredLocale(),
+                equalTo(filter.normalize.getConfiguredLocale()));
+        assertThat(clone.normalize.getCase(), equalTo(filter.normalize.getCase()));
     }
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
@@ -336,13 +336,15 @@ public class StringParameterFilterTest {
 
     @Test
     public void testCloneable() throws Exception {
-        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
         StringParameterFilter clone = filter.clone();
         assertThat(clone.getDefaultValue(), equalTo(filter.getDefaultValue()));
         assertThat(clone.getValues(), equalTo(filter.getValues()));
-        assertThat(
-                clone.getNormalize().getConfiguredLocale(),
-                equalTo(filter.getNormalize().getConfiguredLocale()));
-        assertThat(clone.getNormalize().getCase(), equalTo(filter.getNormalize().getCase()));
+        assertThat(clone.normalize, equalTo(filter.normalize));
+
+        filter.setNormalize(new CaseNormalizer(Case.UPPER, Locale.ENGLISH));
+        clone = filter.clone();
+        assertThat(clone.getDefaultValue(), equalTo(filter.getDefaultValue()));
+        assertThat(clone.getValues(), equalTo(filter.getValues()));
+        assertThat(clone.normalize, equalTo(filter.normalize));
     }
 }

--- a/geowebcache/diskquota/core/pom.xml
+++ b/geowebcache/diskquota/core/pom.xml
@@ -20,10 +20,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-     <groupId>org.apache.commons</groupId>
-     <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -19,7 +19,6 @@
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
-    <commons-lang.version>3.8.1</commons-lang.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-text.version>1.4</commons-text.version>
@@ -141,11 +140,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons-io.version}</version>
-    </dependency>
-    <dependency>
-     <groupId>org.apache.commons</groupId>
-     <artifactId>commons-lang3</artifactId>
-     <version>${commons-lang.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
@@ -25,9 +25,6 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.config.BlobStoreInfo;
@@ -326,21 +323,6 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    @Override
     public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
             throws StorageException {
 
@@ -414,5 +396,122 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
             };
         }
         return new DefaultAWSCredentialsProviderChain();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((access == null) ? 0 : access.hashCode());
+        result = prime * result + ((awsAccessKey == null) ? 0 : awsAccessKey.hashCode());
+        result = prime * result + ((awsSecretKey == null) ? 0 : awsSecretKey.hashCode());
+        result = prime * result + ((bucket == null) ? 0 : bucket.hashCode());
+        result = prime * result + ((endpoint == null) ? 0 : endpoint.hashCode());
+        result = prime * result + ((maxConnections == null) ? 0 : maxConnections.hashCode());
+        result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
+        result = prime * result + ((proxyDomain == null) ? 0 : proxyDomain.hashCode());
+        result = prime * result + ((proxyHost == null) ? 0 : proxyHost.hashCode());
+        result = prime * result + ((proxyPassword == null) ? 0 : proxyPassword.hashCode());
+        result = prime * result + ((proxyPort == null) ? 0 : proxyPort.hashCode());
+        result = prime * result + ((proxyUsername == null) ? 0 : proxyUsername.hashCode());
+        result = prime * result + ((proxyWorkstation == null) ? 0 : proxyWorkstation.hashCode());
+        result = prime * result + ((useGzip == null) ? 0 : useGzip.hashCode());
+        result = prime * result + ((useHTTPS == null) ? 0 : useHTTPS.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        S3BlobStoreInfo other = (S3BlobStoreInfo) obj;
+        if (access != other.access) return false;
+        if (awsAccessKey == null) {
+            if (other.awsAccessKey != null) return false;
+        } else if (!awsAccessKey.equals(other.awsAccessKey)) return false;
+        if (awsSecretKey == null) {
+            if (other.awsSecretKey != null) return false;
+        } else if (!awsSecretKey.equals(other.awsSecretKey)) return false;
+        if (bucket == null) {
+            if (other.bucket != null) return false;
+        } else if (!bucket.equals(other.bucket)) return false;
+        if (endpoint == null) {
+            if (other.endpoint != null) return false;
+        } else if (!endpoint.equals(other.endpoint)) return false;
+        if (maxConnections == null) {
+            if (other.maxConnections != null) return false;
+        } else if (!maxConnections.equals(other.maxConnections)) return false;
+        if (prefix == null) {
+            if (other.prefix != null) return false;
+        } else if (!prefix.equals(other.prefix)) return false;
+        if (proxyDomain == null) {
+            if (other.proxyDomain != null) return false;
+        } else if (!proxyDomain.equals(other.proxyDomain)) return false;
+        if (proxyHost == null) {
+            if (other.proxyHost != null) return false;
+        } else if (!proxyHost.equals(other.proxyHost)) return false;
+        if (proxyPassword == null) {
+            if (other.proxyPassword != null) return false;
+        } else if (!proxyPassword.equals(other.proxyPassword)) return false;
+        if (proxyPort == null) {
+            if (other.proxyPort != null) return false;
+        } else if (!proxyPort.equals(other.proxyPort)) return false;
+        if (proxyUsername == null) {
+            if (other.proxyUsername != null) return false;
+        } else if (!proxyUsername.equals(other.proxyUsername)) return false;
+        if (proxyWorkstation == null) {
+            if (other.proxyWorkstation != null) return false;
+        } else if (!proxyWorkstation.equals(other.proxyWorkstation)) return false;
+        if (useGzip == null) {
+            if (other.useGzip != null) return false;
+        } else if (!useGzip.equals(other.useGzip)) return false;
+        if (useHTTPS == null) {
+            if (other.useHTTPS != null) return false;
+        } else if (!useHTTPS.equals(other.useHTTPS)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "S3BlobStoreInfo [bucket="
+                + bucket
+                + ", prefix="
+                + prefix
+                + ", awsAccessKey="
+                + awsAccessKey
+                + ", awsSecretKey="
+                + awsSecretKey
+                + ", access="
+                + access
+                + ", maxConnections="
+                + maxConnections
+                + ", useHTTPS="
+                + useHTTPS
+                + ", proxyDomain="
+                + proxyDomain
+                + ", proxyWorkstation="
+                + proxyWorkstation
+                + ", proxyHost="
+                + proxyHost
+                + ", proxyPort="
+                + proxyPort
+                + ", proxyUsername="
+                + proxyUsername
+                + ", proxyPassword="
+                + proxyPassword
+                + ", useGzip="
+                + useGzip
+                + ", endpoint="
+                + endpoint
+                + ", getName()="
+                + getName()
+                + ", getId()="
+                + getId()
+                + ", isEnabled()="
+                + isEnabled()
+                + ", isDefault()="
+                + isDefault()
+                + "]";
     }
 }

--- a/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/MbtilesInfo.java
+++ b/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/MbtilesInfo.java
@@ -21,6 +21,7 @@ import org.geowebcache.storage.StorageException;
 
 /** Holder for the properties needed to configure a mbtiles blob store. */
 public class MbtilesInfo extends SqliteInfo {
+    private static final long serialVersionUID = -6618985107587790155L;
 
     public MbtilesInfo() {
         super();
@@ -69,5 +70,35 @@ public class MbtilesInfo extends SqliteInfo {
     @Override
     public String toString() {
         return "MBTiles BlobStore";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + executorConcurrency;
+        result = prime * result + ((gzipVector == null) ? 0 : gzipVector.hashCode());
+        result =
+                prime * result
+                        + ((mbtilesMetadataDirectory == null)
+                                ? 0
+                                : mbtilesMetadataDirectory.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        MbtilesInfo other = (MbtilesInfo) obj;
+        if (executorConcurrency != other.executorConcurrency) return false;
+        if (gzipVector == null) {
+            if (other.gzipVector != null) return false;
+        } else if (!gzipVector.equals(other.gzipVector)) return false;
+        if (mbtilesMetadataDirectory == null) {
+            if (other.mbtilesMetadataDirectory != null) return false;
+        } else if (!mbtilesMetadataDirectory.equals(other.mbtilesMetadataDirectory)) return false;
+        return true;
     }
 }

--- a/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/SqliteInfo.java
+++ b/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/SqliteInfo.java
@@ -20,6 +20,7 @@ import org.geowebcache.config.BlobStoreInfo;
 
 /** Holder for the common properties needed to configure a sqlite based blob store. */
 public abstract class SqliteInfo extends BlobStoreInfo {
+    private static final long serialVersionUID = 2300159159094621077L;
 
     public SqliteInfo() {
         this(UUID.randomUUID().toString());
@@ -130,5 +131,41 @@ public abstract class SqliteInfo extends BlobStoreInfo {
             connectionManager = new SqliteConnectionManager(this);
         }
         return connectionManager;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + (int) (columnRangeCount ^ (columnRangeCount >>> 32));
+        result = prime * result + (eagerDelete ? 1231 : 1237);
+        result = prime * result + (int) (poolReaperIntervalMs ^ (poolReaperIntervalMs >>> 32));
+        result = prime * result + (int) (poolSize ^ (poolSize >>> 32));
+        result = prime * result + ((rootDirectory == null) ? 0 : rootDirectory.hashCode());
+        result = prime * result + (int) (rowRangeCount ^ (rowRangeCount >>> 32));
+        result = prime * result + ((templatePath == null) ? 0 : templatePath.hashCode());
+        result = prime * result + (useCreateTime ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!super.equals(obj)) return false;
+        if (getClass() != obj.getClass()) return false;
+        SqliteInfo other = (SqliteInfo) obj;
+        if (columnRangeCount != other.columnRangeCount) return false;
+        if (eagerDelete != other.eagerDelete) return false;
+        if (poolReaperIntervalMs != other.poolReaperIntervalMs) return false;
+        if (poolSize != other.poolSize) return false;
+        if (rootDirectory == null) {
+            if (other.rootDirectory != null) return false;
+        } else if (!rootDirectory.equals(other.rootDirectory)) return false;
+        if (rowRangeCount != other.rowRangeCount) return false;
+        if (templatePath == null) {
+            if (other.templatePath != null) return false;
+        } else if (!templatePath.equals(other.templatePath)) return false;
+        if (useCreateTime != other.useCreateTime) return false;
+        return true;
     }
 }

--- a/geowebcache/wms/src/main/java/org/geowebcache/config/wms/parameters/NaiveWMSDimensionFilter.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/config/wms/parameters/NaiveWMSDimensionFilter.java
@@ -16,8 +16,7 @@ package org.geowebcache.config.wms.parameters;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.Objects;
 import org.geotools.ows.wms.xml.Dimension;
 import org.geotools.ows.wms.xml.Extent;
 import org.geowebcache.filter.parameters.ParameterException;
@@ -84,16 +83,84 @@ public class NaiveWMSDimensionFilter extends ParameterFilter implements WMSDimen
 
     @Override
     public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
+        return ((o instanceof NaiveWMSDimensionFilter) && super.equals(o))
+                && equals(dimension, ((NaiveWMSDimensionFilter) o).dimension)
+                && equals(extent, ((NaiveWMSDimensionFilter) o).extent);
     }
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        int hashCode = 1;
+        hashCode = 31 * hashCode + hashCode(dimension);
+        hashCode = 31 * hashCode + hashCode(extent);
+        return hashCode;
     }
 
     @Override
     public NaiveWMSDimensionFilter clone() {
         return new NaiveWMSDimensionFilter(dimension, extent);
+    }
+
+    // Extent does not implement equals, so do it here
+    // protected String name;
+    // protected String defaultValue;
+    // protected boolean nearestValue = false;
+    // protected boolean multipleValues;
+    // protected boolean current = false;
+    private boolean equals(Extent a, Extent b) {
+        if (a == null || b == null) return a == b;
+        return Objects.equals(a.getName(), b.getName())
+                && Objects.equals(a.getDefaultValue(), b.getDefaultValue())
+                && Objects.equals(a.getNearestValue(), b.getNearestValue())
+                && Objects.equals(a.isMultipleValues(), b.isMultipleValues())
+                && Objects.equals(a.isCurrent(), b.isCurrent());
+    }
+
+    // Extent does not implement hashCode, so do it here
+    // protected String name;
+    // protected String defaultValue;
+    // protected boolean nearestValue = false;
+    // protected boolean multipleValues;
+    // protected boolean current = false;
+    private int hashCode(Extent a) {
+        return a == null
+                ? 1
+                : Objects.hash(
+                        a.getName(),
+                        a.getDefaultValue(),
+                        a.getNearestValue(),
+                        a.isMultipleValues(),
+                        a.isCurrent());
+    }
+
+    // Dimension does not implement equals, so do it here
+    // protected String name;
+    // protected String units;
+    // protected String unitSymbol;
+    // protected boolean current;
+    // protected Extent extent = null;
+    private boolean equals(Dimension a, Dimension b) {
+        if (a == null || b == null) return a == b;
+        return Objects.equals(a.getName(), b.getName())
+                && Objects.equals(a.getUnits(), b.getUnits())
+                && Objects.equals(a.getUnitSymbol(), b.getUnitSymbol())
+                && Objects.equals(a.isCurrent(), b.isCurrent())
+                && equals(a.getExtent(), b.getExtent());
+    }
+
+    // Dimension does not implement hashCode, so do it here
+    // protected String name;
+    // protected String units;
+    // protected String unitSymbol;
+    // protected boolean current;
+    // protected Extent extent = null;
+    private int hashCode(Dimension a) {
+        int hash = Objects.hash(a.getName(), a.getUnits(), a.getUnitSymbol(), a.isCurrent());
+        return 31 * hash + hashCode(a.getExtent());
+    }
+
+    @Override
+    public String toString() {
+        return "NaiveWMSDimensionFilter [dimension=" + dimension + ", extent=" + extent + "]";
     }
 }


### PR DESCRIPTION
Fixes #796

Using commons-lang's EqualsBuilder and HashcodeBuilder imposes
severe concurrency penalties due to synchronization at the
reflection core, that mostly chokes at
java.lang.reflect.Field.declaredAnnotations().

Also, some config objects missed implementations of equals()
and hashCode().

This patch uses lombok to provide correct and performant
implementations where appropriate, and removes the dependency
on commons-lang3 altogether, as it was used solely to provide
convenient equals and hashcode.