### PR TITLE
Removing maven build warnings

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -176,11 +176,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-legacy</artifactId>
       <scope>test</scope>

--- a/geowebcache/gmaps/pom.xml
+++ b/geowebcache/gmaps/pom.xml
@@ -41,11 +41,6 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
     
     
   </dependencies>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -49,6 +49,7 @@
     <checkstyle.skip>false</checkstyle.skip>
     <qa>false</qa>
     <lint>deprecation</lint>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   
   <repositories>
@@ -508,6 +509,7 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -525,27 +527,19 @@
             <manifestEntries>
               <Specification-Title>org.geowebcache</Specification-Title>
               <Specification-Version>${project.version}</Specification-Version>
-              <Specification-Vendor>${pom.url}</Specification-Vendor>
+              <Specification-Vendor>${project.url}</Specification-Vendor>
               <Implementation-Title>org.geowebcache</Implementation-Title>
               <Implementation-Version>${build.branch}/${build.commit.id}</Implementation-Version>
-              <Implementation-Vendor>${pom.url}</Implementation-Vendor>
+              <Implementation-Vendor>${project.url}</Implementation-Vendor>
             </manifestEntries>
           </archive>
         </configuration>
       </plugin>
 
-     <plugin>
-    <groupId>org.codehaus.mojo</groupId>
-    <artifactId>tomcat-maven-plugin</artifactId>
-    <configuration>
-      <url>http://localhost:8080/manager</url>
-      <server>localhost</server>
-    </configuration>
-      </plugin>
-      
       <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-compiler-plugin</artifactId>
+    <version>3.8.0</version>
     <configuration>
       <source>1.8</source>
       <target>1.8</target>
@@ -555,6 +549,7 @@
       
       <plugin>
     <artifactId>maven-source-plugin</artifactId>
+    <version>2.2.1</version>
     <configuration>
       <attach>true</attach>
     </configuration>

--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -28,13 +28,12 @@
      <groupId>org.freemarker</groupId>
      <artifactId>freemarker</artifactId>
     </dependency>
-
-    <!-- test dependencies  -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <!-- test dependencies  -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -62,10 +61,6 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-      </dependency>
       <dependency>
           <groupId>org.springframework</groupId>
           <artifactId>spring-test</artifactId>

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -158,6 +158,7 @@
         <inherited>true</inherited>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
         <configuration>
           <warName>geowebcache</warName>
           <webappDirectory>${project.build.directory}/geowebcache</webappDirectory>


### PR DESCRIPTION
The current maven build complains about lack of versions in some plugins, duplicate dependency definitions, and lack of file encoding indication in reporting. Cleaning those away.