### PR TITLE
Mass Truncate for GWC Cache

### DIFF
--- a/documentation/en/user/source/rest/masstruncate.rst
+++ b/documentation/en/user/source/rest/masstruncate.rst
@@ -158,3 +158,12 @@ Checks the layer ``points`` for cached tiles that are not accessible to its curr
      </entry>
    </parameters>
  </truncateParameters>
+
+Truncate All Layers
+++++++++++++++++++++++++++++++++++++
+
+To clear the entire GWC cache.
+
+.. code-block:: xml 
+
+	<truncateAll></truncateAll>

--- a/documentation/en/user/source/webinterface/demo.rst
+++ b/documentation/en/user/source/webinterface/demo.rst
@@ -35,3 +35,8 @@ Reload configuration
 --------------------
 
 There is also a button to :ref:`Reload Configuration <configuration.reload>`.  Click this to make any configuration changes known to GeoWebCache.  You will have to :ref:`authenticate <configuration.security>` as an administrator first.
+
+Clear GWC Cache
+--------------------
+
+There is also a button to wipe the GWC cache clean. This will internally truncate all layers. 

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -75,6 +75,7 @@ import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.mime.FormatModifier;
 import org.geowebcache.seed.SeedRequest;
+import org.geowebcache.seed.TruncateAllRequest;
 import org.geowebcache.seed.TruncateLayerRequest;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.storage.UnsuitableStorageException;
@@ -461,6 +462,7 @@ public class XMLConfiguration
         xs.omitField(ServiceInformation.class, "citeCompliant");
 
         xs.processAnnotations(TruncateLayerRequest.class);
+        xs.processAnnotations(TruncateAllRequest.class);
 
         if (context != null) {
             /*

--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -119,6 +119,7 @@ public class Demo {
             TileLayerDispatcher tileLayerDispatcher, GridSetBroker gridSetBroker)
             throws GeoWebCacheException {
         String reloadPath = "rest/reload";
+        String truncatePath = "rest/masstruncate";
 
         StringBuffer buf = new StringBuffer();
 
@@ -151,8 +152,6 @@ public class Demo {
                                 + "<p>You can reload the configuration by pressing the following button. "
                                 + "The username / password is configured in WEB-INF/user.properties, or the admin "
                                 + " user in GeoServer if you are using the plugin.</p>\n"
-                                + "<strong>Truncate All Layers:</strong><br />\n"
-                                + "<p>You can truncate all layers by pressing <a href=\"rest/masstruncate/all\">Empty GWC Cache</a></p>\n "
                                 + "<form form id=\"kill\" action=\"")
                 .append(reloadPath)
                 .append(
@@ -160,6 +159,14 @@ public class Demo {
                                 + "<input type=\"hidden\" name=\"reload_configuration\"  value=\"1\" />"
                                 + "<span><input style=\"padding: 0; margin-bottom: -12px; border: 1;\"type=\"submit\" value=\"Reload TileLayerConfiguration\"></span>"
                                 + "</form>"
+                                + "<br /><strong>Truncate All Layers:</strong><br />\n"
+                                + "<p>Truncate all layers"
+                                + "<form form id=\"truncate\" action=\"")
+                .append(truncatePath)
+                .append(
+                        "\" method=\"post\"><input type=\"hidden\" name=\"<truncateAll>\" value=\"</truncateAll>\"/>"
+                                + "<span><input style=\"padding: 0; margin-bottom: -12px; border: 1;background-color:LightCoral;\"type=\"submit\" value=\"Clear GWC\"></span>"
+                                + "</form><br />"
                                 + "</body></html>");
 
         return buf.toString();

--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -151,6 +151,8 @@ public class Demo {
                                 + "<p>You can reload the configuration by pressing the following button. "
                                 + "The username / password is configured in WEB-INF/user.properties, or the admin "
                                 + " user in GeoServer if you are using the plugin.</p>\n"
+                                + "<strong>Truncate All Layers:</strong><br />\n"
+                                + "<p>You can truncate all layers by pressing <a href=\"rest/masstruncate/all\">Empty GWC Cache</a></p>\n "
                                 + "<form form id=\"kill\" action=\"")
                 .append(reloadPath)
                 .append(

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
@@ -17,6 +17,8 @@ package org.geowebcache.seed;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 /**
  * Represents a requests to truncate multiple gridsets or layers at once
@@ -35,4 +37,8 @@ public interface MassTruncateRequest {
      */
     public boolean doTruncate(StorageBroker sb, TileBreeder breeder)
             throws StorageException, GeoWebCacheException;
+
+    public default ResponseEntity<String> getResponse(String contentType) {
+        return new ResponseEntity<String>(HttpStatus.OK);
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateAllRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TruncateAllRequest.java
@@ -1,0 +1,76 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Imran Rajjad / Geosolutions 2019
+ */
+package org.geowebcache.seed;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import java.io.Serializable;
+import java.util.Iterator;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.StorageException;
+
+/** @author ImranR */
+@XStreamAlias("truncateAll")
+public class TruncateAllRequest implements MassTruncateRequest, Serializable {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = -4730372010898498464L;
+
+    private static final Log log = LogFactory.getLog(TruncateAllRequest.class);
+
+    @XStreamOmitField private StringBuilder trucatedLayers = new StringBuilder();
+
+    @Override
+    public boolean doTruncate(StorageBroker sb, TileBreeder breeder)
+            throws StorageException, GeoWebCacheException {
+        Iterator<TileLayer> iterator = breeder.getLayers().iterator();
+        TileLayer toTruncate;
+        boolean truncated = false;
+        while (iterator.hasNext()) {
+            toTruncate = iterator.next();
+            truncated = sb.delete(toTruncate.getName());
+            if (!truncated) {
+                // did we hit a layer that has nothing on storage, or a layer that is not there?
+                try {
+                    breeder.findTileLayer(toTruncate.getName());
+                } catch (GeoWebCacheException e) {
+                    throw new IllegalArgumentException(
+                            "Could not find layer " + toTruncate.getName());
+                }
+            } else {
+                log.info("Truncate All Job: Finished deleting layer " + toTruncate.getName());
+                if (getTrucatedLayers().length() > 0) getTrucatedLayers().append(",");
+                getTrucatedLayers().append(toTruncate.getName());
+            }
+        }
+
+        return true;
+    }
+
+    public StringBuilder getTrucatedLayers() {
+        // null safe
+        if (trucatedLayers == null) trucatedLayers = new StringBuilder();
+        return trucatedLayers;
+    }
+
+    public String getTrucatedLayersList() {
+        if (getTrucatedLayers().length() == 0) return "No Layers were truncated";
+        else return getTrucatedLayers().toString();
+    }
+}

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/seed/MassTruncateControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/seed/MassTruncateControllerTest.java
@@ -15,7 +15,6 @@
 package org.geowebcache.rest.seed;
 
 import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -28,7 +27,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.DefaultGridsets;
 import org.geowebcache.config.MockConfigurationResourceProvider;
@@ -74,15 +76,25 @@ public class MassTruncateControllerTest {
 
     @Test
     public void testTruncateLayer() throws Exception {
+        Set<String> layer1GridSet = new HashSet<String>(Arrays.asList("test_grid1", "test_grid2"));
         String layerName = "test";
+        TileLayer tl1 = createMock(TileLayer.class);
+        expect(tl1.getGridSubsets()).andReturn(layer1GridSet).anyTimes();
         String requestBody =
                 "<truncateLayer><layerName>" + layerName + "</layerName></truncateLayer>";
 
+        TileBreeder tb = createMock(TileBreeder.class);
+        expect(tb.findTileLayer(layerName)).andReturn(tl1);
+
         StorageBroker sb = createMock(StorageBroker.class);
-        expect(sb.delete(eq(layerName))).andReturn(true);
+        for (String grid : layer1GridSet)
+            expect(sb.deleteByGridSetId(layerName, grid)).andReturn(true);
+        replay(tl1);
         replay(sb);
+        replay(tb);
 
         mtc.setStorageBroker(sb);
+        mtc.setTileBreeder(tb);
 
         this.mockMvc
                 .perform(
@@ -96,18 +108,23 @@ public class MassTruncateControllerTest {
 
     @Test
     public void testTruncateLayerTwice() throws Exception {
+        Set<String> layer1GridSet = new HashSet<String>(Arrays.asList("test_grid1", "test_grid2"));
         String layerName = "test";
+        TileLayer tileLayer = createMock(TileLayer.class);
+        expect(tileLayer.getName()).andReturn(layerName).anyTimes();
+        expect(tileLayer.getGridSubsets()).andReturn(layer1GridSet);
+        expect(tileLayer.getGridSubsets()).andReturn(new HashSet<String>());
+        replay(tileLayer);
         String requestBody =
                 "<truncateLayer><layerName>" + layerName + "</layerName></truncateLayer>";
 
         StorageBroker sb = createMock(StorageBroker.class);
-        expect(sb.delete(eq(layerName))).andReturn(true);
-        expect(sb.delete(eq(layerName))).andReturn(false);
+        for (String grid : layer1GridSet)
+            expect(sb.deleteByGridSetId(layerName, grid)).andReturn(true);
         replay(sb);
 
         TileBreeder tb = createMock(TileBreeder.class);
-        TileLayer tileLayer = createMock(TileLayer.class);
-        expect(tb.findTileLayer(layerName)).andReturn(tileLayer); // just do not throw an
+        expect(tb.findTileLayer(layerName)).andReturn(tileLayer).times(2); // just do not throw an
         replay(tb);
 
         mtc.setStorageBroker(sb);
@@ -139,7 +156,6 @@ public class MassTruncateControllerTest {
                 "<truncateLayer><layerName>" + layerName + "</layerName></truncateLayer>";
 
         StorageBroker sb = createMock(StorageBroker.class);
-        expect(sb.delete(eq(layerName))).andReturn(false);
         replay(sb);
 
         TileBreeder tb = createMock(TileBreeder.class);
@@ -178,6 +194,11 @@ public class MassTruncateControllerTest {
 
     @Test
     public void testTruncateAllLayers() throws Exception {
+        Set<String> layer1GridSet =
+                new HashSet<String>(Arrays.asList("test1_grid1", "test1_grid2"));
+        Set<String> layer2GridSet =
+                new HashSet<String>(Arrays.asList("test22_grid1", "test22_grid2"));
+
         String layerName = "test11";
         String layerName2 = "test22";
         // setting up calls
@@ -185,7 +206,10 @@ public class MassTruncateControllerTest {
         TileLayer tl2 = createMock(TileLayer.class);
 
         expect(tl1.getName()).andReturn(layerName).anyTimes();
+        expect(tl1.getGridSubsets()).andReturn(layer1GridSet).anyTimes();
+
         expect(tl2.getName()).andReturn(layerName2).anyTimes();
+        expect(tl2.getGridSubsets()).andReturn(layer2GridSet).anyTimes();
 
         replay(tl1);
         replay(tl2);
@@ -200,8 +224,12 @@ public class MassTruncateControllerTest {
         expect(tb.getLayers()).andReturn(mockList);
 
         StorageBroker sb = createMock(StorageBroker.class);
-        expect(sb.delete(layerName)).andReturn(true);
-        expect(sb.delete(layerName2)).andReturn(true);
+
+        for (String grid : layer1GridSet)
+            expect(sb.deleteByGridSetId(layerName, grid)).andReturn(true);
+
+        for (String grid : layer2GridSet)
+            expect(sb.deleteByGridSetId(layerName2, grid)).andReturn(true);
 
         replay(sb);
         replay(tb);
@@ -220,7 +248,12 @@ public class MassTruncateControllerTest {
     }
 
     @Test
-    public void testTruncateAllLayersWithGET() throws Exception {
+    public void testTruncateAllLayersFromHTMLForm() throws Exception {
+        Set<String> layer1GridSet =
+                new HashSet<String>(Arrays.asList("test1_grid1", "test1_grid2"));
+        Set<String> layer2GridSet =
+                new HashSet<String>(Arrays.asList("test2_grid1", "test2_grid2"));
+
         String layerName = "test1";
         String layerName2 = "test2";
         // setting up calls
@@ -228,7 +261,10 @@ public class MassTruncateControllerTest {
         TileLayer tl2 = createMock(TileLayer.class);
 
         expect(tl1.getName()).andReturn(layerName).anyTimes();
+        expect(tl1.getGridSubsets()).andReturn(layer1GridSet).anyTimes();
+
         expect(tl2.getName()).andReturn(layerName2).anyTimes();
+        expect(tl2.getGridSubsets()).andReturn(layer2GridSet).anyTimes();
 
         replay(tl1);
         replay(tl2);
@@ -241,18 +277,26 @@ public class MassTruncateControllerTest {
         expect(tb.getLayers()).andReturn(mockList);
 
         StorageBroker sb = createMock(StorageBroker.class);
-        expect(sb.delete(layerName)).andReturn(true);
-        expect(sb.delete(layerName2)).andReturn(true);
+        for (String grid : layer1GridSet)
+            expect(sb.deleteByGridSetId(layerName, grid)).andReturn(true);
+
+        for (String grid : layer2GridSet)
+            expect(sb.deleteByGridSetId(layerName2, grid)).andReturn(true);
 
         replay(sb);
         replay(tb);
 
         mtc.setStorageBroker(sb);
         mtc.setTileBreeder(tb);
+        String requestBody = "<truncateAll>=</truncateAll>";
 
         MvcResult result =
                 this.mockMvc
-                        .perform(get("/rest/masstruncate/all").contextPath(""))
+                        .perform(
+                                post("/rest/masstruncate")
+                                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                        .content(requestBody)
+                                        .contextPath(""))
                         .andExpect(status().is2xxSuccessful())
                         .andReturn();
         assertTrue(

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/seed/MassTruncateControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/seed/MassTruncateControllerTest.java
@@ -14,14 +14,20 @@
  */
 package org.geowebcache.rest.seed;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.DefaultGridsets;
@@ -168,6 +174,89 @@ public class MassTruncateControllerTest {
         assertEquals(200, result.getResponse().getStatus());
 
         System.out.print(result);
+    }
+
+    @Test
+    public void testTruncateAllLayers() throws Exception {
+        String layerName = "test11";
+        String layerName2 = "test22";
+        // setting up calls
+        TileLayer tl1 = createMock(TileLayer.class);
+        TileLayer tl2 = createMock(TileLayer.class);
+
+        expect(tl1.getName()).andReturn(layerName).anyTimes();
+        expect(tl2.getName()).andReturn(layerName2).anyTimes();
+
+        replay(tl1);
+        replay(tl2);
+
+        ArrayList<TileLayer> mockList = new ArrayList<TileLayer>();
+        mockList.add(tl1);
+        mockList.add(tl2);
+
+        String requestBody = "<truncateAll></truncateAll>";
+
+        TileBreeder tb = createMock(TileBreeder.class);
+        expect(tb.getLayers()).andReturn(mockList);
+
+        StorageBroker sb = createMock(StorageBroker.class);
+        expect(sb.delete(layerName)).andReturn(true);
+        expect(sb.delete(layerName2)).andReturn(true);
+
+        replay(sb);
+        replay(tb);
+
+        mtc.setStorageBroker(sb);
+        mtc.setTileBreeder(tb);
+
+        this.mockMvc
+                .perform(
+                        post("/rest/masstruncate")
+                                .contentType(MediaType.TEXT_XML)
+                                .content(requestBody)
+                                .contextPath(""))
+                .andExpect(status().is2xxSuccessful());
+        verify(sb);
+    }
+
+    @Test
+    public void testTruncateAllLayersWithGET() throws Exception {
+        String layerName = "test1";
+        String layerName2 = "test2";
+        // setting up calls
+        TileLayer tl1 = createMock(TileLayer.class);
+        TileLayer tl2 = createMock(TileLayer.class);
+
+        expect(tl1.getName()).andReturn(layerName).anyTimes();
+        expect(tl2.getName()).andReturn(layerName2).anyTimes();
+
+        replay(tl1);
+        replay(tl2);
+
+        ArrayList<TileLayer> mockList = new ArrayList<TileLayer>();
+        mockList.add(tl1);
+        mockList.add(tl2);
+
+        TileBreeder tb = createMock(TileBreeder.class);
+        expect(tb.getLayers()).andReturn(mockList);
+
+        StorageBroker sb = createMock(StorageBroker.class);
+        expect(sb.delete(layerName)).andReturn(true);
+        expect(sb.delete(layerName2)).andReturn(true);
+
+        replay(sb);
+        replay(tb);
+
+        mtc.setStorageBroker(sb);
+        mtc.setTileBreeder(tb);
+
+        MvcResult result =
+                this.mockMvc
+                        .perform(get("/rest/masstruncate/all").contextPath(""))
+                        .andExpect(status().is2xxSuccessful())
+                        .andReturn();
+        assertTrue(
+                result.getResponse().getContentAsString().contains("Truncated Layers:test1,test2"));
     }
 
     private XMLConfiguration loadXMLConfig() {


### PR DESCRIPTION
-added support to clear entire GWC cache through REST and GUI
-updated documentation

mass truncate can be invoked from REST using

`curl -v -u geowebcache:secured -X POST -H "Content-type: text/xml" -d "<truncateAll></truncateAll>"  "http://localhost:8080/geowebcache/rest/masstruncate"`

Demo page GUI also includes a link to invoke Mass Truncate of all layers

Issue discussed at : https://github.com/geosolutions-it/support/issues/381