### PR TITLE
Expose failure control tunables in SeedRequest and associated form #809

### DIFF
--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -78,7 +78,7 @@ Seed Failure Tolerance
 
 As of version 1.2.5, it is possible to control how GWC behaves in the event that a backend (WMS for example) request fails during seeding, by using the following environment variables:
 
-* ``GWC_SEED_RETRY_COUNT`` : specifies how many times to retry a failed request for each tile being seeded. Use ``0`` for no retries, or any higher number. Defaults to ``0``, meaning no retries are performed. It also means that the defaults to the other two variables do not apply at least you specify a higher value for ``GWC_SEED_RETRY_COUNT``.
+* ``GWC_SEED_RETRY_COUNT`` : specifies how many times to retry a failed request for each tile being seeded. Use ``0`` for no retries, or any higher number. Defaults to ``0``, meaning no retries are performed. Defaults to -1, which also implies that defaults to the other two variables (for backwards compatibility).
 * ``GWC_SEED_RETRY_WAIT`` : specifies how much to wait before each retry upon a failure to seed a tile, in milliseconds. Defaults to ``100ms``
 * ``GWC_SEED_ABORT_LIMIT`` : specifies the aggregated number of failures that a group of seeding threads should reach before aborting the seeding operation as a whole. This value is shared by all the threads launched as a single thread group; so if the value is ``10`` and you launch a seed task with four threads, when ``10`` failures are reached by all or any of those four threads the four threads will abort the seeding task. The default is ``1000``.
 

--- a/documentation/en/user/source/rest/seed.rst
+++ b/documentation/en/user/source/rest/seed.rst
@@ -77,7 +77,7 @@ Sample response:
  < HTTP/1.1 200 OK
 
 
-Here's a more complete xml fragment for a seed request, including parameter filters:
+Here's a more complete xml fragment for a seed request, including parameter filters and failure handling policies:
 
 .. code-block:: xml
 
@@ -117,6 +117,10 @@ Here's a more complete xml fragment for a seed request, including parameter filt
        <string>TOTPOP > 10000</string>
      </entry>
    </parameters>
+
+   <tileFailureRetryCount>2</tileFailureRetryCount>
+   <tileFailureRetryWaitTime>1000</tileFailureRetryWaitTime>
+   <totalFailuresBeforeAborting>10000</totalFailuresBeforeAborting>
  </seedRequest>
 
 

--- a/documentation/en/user/source/webinterface/seed.rst
+++ b/documentation/en/user/source/webinterface/seed.rst
@@ -36,6 +36,14 @@ To create a new seed task, fill out the form with the following information:
      - The final/maximum zoom level for the seed task.
    * - :guilabel:`Bounding box`
      - An optional subset of the layer's maximum extent, useful for seeding only certain (more important) areas.  Values are given in the units of the grid set.  If ommitted, the layer's maximum exten will be assumed.
+   * - :guilabel:`Tile failure retries`
+     - Number of times a tile creation should be retried, before giving up. Defaults to zero. Set it to -1 to have the seeding thread stop all its activities at the first failure.
+   * - :guilabel:`Pause before retry (ms)`
+     - Time, in milliseconds, GeoWebCache will wait before retrying to compute a failed tile. This allows the system to recover to temporary/contextual failures.
+   * - :guilabel:`Total failures before aborting`
+     - Time, in milliseconds, GeoWebCache will wait before retrying to compute a failed tile. This allows the system to recover to temporary/contextual failures.
+
+  
 
 When ready to start the task, click :guilabel:`Submit`.
 

--- a/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
@@ -249,16 +249,16 @@ public class ConveyorTile extends Conveyor implements TileResponseReceiver {
         str.append("ConveyorTile[");
         long[] idx = stObj.getXYZ();
 
-        if (idx != null && idx.length == 3) {
-            str.append("{" + idx[0] + "," + idx[1] + "," + idx[2] + "} ");
-        }
-
-        if (getLayer() != null) {
+        if (getLayerId() != null) {
             str.append(getLayerId()).append(" ");
         }
 
         if (this.gridSetId != null) {
             str.append(gridSetId).append(" ");
+        }
+
+        if (idx != null && idx.length == 3) {
+            str.append("{" + idx[0] + "," + idx[1] + "," + idx[2] + "} ");
         }
 
         if (this.mimeType != null) {

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedRequest.java
@@ -51,6 +51,12 @@ public class SeedRequest {
 
     private Boolean filterUpdate = null;
 
+    private int tileFailureRetryCount = TileBreeder.TILE_FAILURE_RETRY_COUNT_DEFAULT;
+
+    private long tileFailureRetryWaitTime = TileBreeder.TILE_FAILURE_RETRY_WAIT_TIME_DEFAULT;
+
+    private long totalFailuresBeforeAborting = TileBreeder.TOTAL_FAILURES_BEFORE_ABORTING_DEFAULT;
+
     public SeedRequest() {
         // do nothing, i guess
     }
@@ -210,5 +216,44 @@ public class SeedRequest {
      */
     public Map<String, String> getParameters() {
         return parameters;
+    }
+
+    /**
+     * Number of retries to build a tile before giving up on it. -1 disables also the wait and total
+     * failures counters.
+     *
+     * @return
+     */
+    public int getTileFailureRetryCount() {
+        return tileFailureRetryCount;
+    }
+
+    public void setTileFailureRetryCount(int tileFailureRetryCount) {
+        this.tileFailureRetryCount = tileFailureRetryCount;
+    }
+
+    /**
+     * Time to wait between tile computation failures, in milliseconds
+     *
+     * @return
+     */
+    public long getTileFailureRetryWaitTime() {
+        return tileFailureRetryWaitTime;
+    }
+
+    public void setTileFailureRetryWaitTime(long tileFailureRetryWaitTime) {
+        this.tileFailureRetryWaitTime = tileFailureRetryWaitTime;
+    }
+
+    /**
+     * Total amount of failures before stopping the seeding process, computed across all threads in
+     * the seed request.
+     */
+    public long getTotalFailuresBeforeAborting() {
+        return totalFailuresBeforeAborting;
+    }
+
+    public void setTotalFailuresBeforeAborting(long totalFailuresBeforeAborting) {
+        this.totalFailuresBeforeAborting = totalFailuresBeforeAborting;
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
@@ -148,7 +148,7 @@ class SeedTask extends GWCTask {
                 } catch (Exception e) {
                     // if GWC_SEED_RETRY_COUNT was not set then none of the settings have effect, in
                     // order to keep backwards compatibility with the old behaviour
-                    if (tileFailureRetryCount == 0) {
+                    if (tileFailureRetryCount < 0) {
                         if (e instanceof GeoWebCacheException) {
                             throw (GeoWebCacheException) e;
                         }
@@ -181,10 +181,11 @@ class SeedTask extends GWCTask {
                             waitToRetry();
                         }
                     } else {
-                        log.info(
+                        log.warn(
                                 logMsg
-                                        + " Skipping and continuing with next tile. Original error: "
-                                        + e.getMessage());
+                                        + " Skipping and continuing with next tile. Total failure count across threads is at: "
+                                        + sharedFailureCount,
+                                e);
                     }
                 }
             }


### PR DESCRIPTION
Hi @groldan you seem to be the original author of the seeding failure handling policies. In this PR I've exposed them on a per job basis, both on the REST API and the form based UI.

![Selezione_999(059)](https://user-images.githubusercontent.com/325433/71512957-a5cc6f80-2898-11ea-865c-d5c5c62983d8.png)
