### PR TITLE
Adding blobstore package which supports Swift

### DIFF
--- a/documentation/en/user/source/configuration/storage.rst
+++ b/documentation/en/user/source/configuration/storage.rst
@@ -791,3 +791,63 @@ In this section are described other available configuration parameters to config
 		
 		.. note:: A value of *max-size* bigger or equal to Integer.MAX_VALUE cannot be used in order to avoid an uncontrollable growth of the cache size.
 
+OpenStack Swift (Swift) Blob Store
++++++++++++++++++++++++++++++++++++++++++++++
+
+The following documentation assumes you're familiar with the `Openstack Swift Documentation <https://docs.openstack.org/swift/latest/>`_.
+
+This blob store allows to configure a cache for layers using a Swift container with the following `TMS <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_-like
+key structure:
+
+    [prefix]/<layer id>/<gridset id>/<format id>/<parameters hash | "default">/<z>/<x>/<y>.<extension>
+    
+* prefix: if provided in the configuration, it will be used as the "root path" for tile keys. Otherwise the keys will be built starting at the bucket's root.
+* layer id: the unique identifier for the layer. Note it equals to the layer name for standalone configured layers, but to the geoserver catalog's object id for GeoServer tile layers.
+* gridset id: the name of the gridset of the tile
+* format id: the gwc internal name for the tile format. E.g.: ``png``, ``png8``, ``jpeg``, etc.
+* parameters hash: if the request that originated that tiles included parameter filters, a unique hash code of the set of parameter filters, otherwise the constant ``default``.
+* z: the z ordinate of the tile in the gridset space.
+* x: the x ordinate of the tile in the gridset space.
+* y: the y ordinate of the tile in the gridset space.
+* extension: the file extension associated to the tile format. E.g. ``png``, ``jpeg``, etc. (Note the extension is the same for the ``png`` and ``png8`` formats, for example).
+
+Configuration example:
+
+.. code-block:: xml
+
+    <SwiftBlobStore default="true">
+        <id>ObjectStorageCache</id>
+        <enabled>true</enabled>
+        <container>put-your-actual-container-name-here</container>
+        <prefix>test-cache</prefix>
+        <endpoint>endpoint</endpoint>
+        <provider>openstack-swift</provider>
+        <region>put-region-here</region>
+        <keystoneVersion>3</keystoneVersion>
+        <keystoneScope>project</keystoneScope>
+        <keystoneDomainName>Default</keystoneDomainName>
+        <identity>put-tenant-name-here:put-username-here</identity>
+        <password>put-password-here</password>
+    </SwiftBlobStore>
+
+Properties:
+
+* **container**: Mandatory. The name of the Swift container where to store tiles.
+* **prefix**: Optional. A prefix path to use as the "root folder" to store tiles at. For example, if the bucket is ``bucket.gwc.example`` and 
+  prefix is "mycache", all tiles will be stored under ``bucket.gwc.example/mycache/{layer name}`` instead of ``bucket.gwc.example/{layer name}``.
+* **endpoint**: Manditory. Endpoint of the server
+* **provider**: Mandatory. Jclouds provider (shouldn't need modifying)
+* **region**: Mandatory. Swift region for container.
+* **keystoneVersion**: Mandatory. Keystone version
+* **keystoneScope**: Optional. For scoped keystone authorization (project or domain scoped)
+* **keystoneDomainName**: Optional. Keystone domain name (if different than the user domain)
+* **identity**: Mandatory. Identity used to authenticate with the swift API (format - tenantName:username)
+* **password**: Mandatory. Password used to authenticate with the swift API.
+
+Additional Information:
+```````````````````````
+**Some links that might be useful:**
+
+* The package makes use of the open source multi-cloud toolkit `jclouds <https://jclouds.apache.org/>`_ 
+* Jclouds documentation for `getting started with Openstack <https://jclouds.apache.org/guides/openstack/>`_
+* Jclouds documentation for `OpenStack Keystone V3 Support <https://jclouds.apache.org/blog/2018/01/16/keystone-v3/>`_ used in config 

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -56,7 +56,7 @@
         <keystoneVersion>3</keystoneVersion>
         <keystoneScope>project</keystoneScope>
         <keystoneDomainName>Default</keystoneDomainName>
-        <identity>Default:put-username-here</identity>
+        <identity>tenant-name-here:put-username-here</identity>
         <password>put-password-here</password>
     </SwiftBlobStore> -->
 

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -43,7 +43,27 @@
       <baseDirectory>/tmp/defaultCache</baseDirectory>
       <fileSystemBlockSize>4096</fileSystemBlockSize>
     </FileBlobStore>
-    <!-- A sample AWS S3 blob store configuration.   -->
+
+    <!-- A sample Swift blob store configuration.   
+    <SwiftBlobStore default="true">
+        <id>ObjectStorageCache</id>
+        <enabled>true</enabled>
+        <bucket>put-your-actual-bucket-name-here</bucket>
+        <prefix>test-cache</prefix>
+        <maxConnections>200</maxConnections>
+        <useHTTPS>false</useHTTPS>
+        <endpoint>endpoint</endpoint>
+        <jcloudsProvider>openstack-swift</jcloudsProvider>
+        <jcloudsRegion>put-region-here</jcloudsRegion>
+        <jcloudsKeystoneVersion>3</jcloudsKeystoneVersion>
+        <jcloudsKeystoneScope>project</jcloudsKeystoneScope>
+        <jcloudsKeystoneDomainName>Default</jcloudsKeystoneDomainName>
+        <jcloudsIdentity>Default:put-username-here</jcloudsIdentity>
+        <jcloudsCredential>password</jcloudsCredential>
+        <useGzip>false</useGzip>
+    </SwiftBlobStore> -->
+
+   <!-- A sample AWS S3 blob store configuration.   -->
     <!-- 
     <S3BlobStore>
       <id>myS3Cache</id>
@@ -80,6 +100,7 @@
       <mbtilesMetadataDirectory>/tmp/gwc-mbtiles/layersMetadata</mbtilesMetadataDirectory>
     </MbtilesBlobStore>
     -->
+
   </blobStores>
 
   <gridSets>

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -48,19 +48,16 @@
     <SwiftBlobStore default="true">
         <id>ObjectStorageCache</id>
         <enabled>true</enabled>
-        <bucket>put-your-actual-bucket-name-here</bucket>
+        <container>put-your-actual-container-name-here</container>
         <prefix>test-cache</prefix>
-        <maxConnections>200</maxConnections>
-        <useHTTPS>false</useHTTPS>
         <endpoint>endpoint</endpoint>
-        <jcloudsProvider>openstack-swift</jcloudsProvider>
-        <jcloudsRegion>put-region-here</jcloudsRegion>
-        <jcloudsKeystoneVersion>3</jcloudsKeystoneVersion>
-        <jcloudsKeystoneScope>project</jcloudsKeystoneScope>
-        <jcloudsKeystoneDomainName>Default</jcloudsKeystoneDomainName>
-        <jcloudsIdentity>Default:put-username-here</jcloudsIdentity>
-        <jcloudsCredential>password</jcloudsCredential>
-        <useGzip>false</useGzip>
+        <provider>openstack-swift</provider>
+        <region>put-region-here</region>
+        <keystoneVersion>3</keystoneVersion>
+        <keystoneScope>project</keystoneScope>
+        <keystoneDomainName>Default</keystoneDomainName>
+        <identity>Default:put-username-here</identity>
+        <password>put-password-here</password>
     </SwiftBlobStore> -->
 
    <!-- A sample AWS S3 blob store configuration.   -->

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -891,9 +891,10 @@
     <module>web</module>
     <module>diskquota</module>
     <module>arcgiscache</module>
-	<module>distributed</module>
+    <module>distributed</module>
     <module>s3storage</module>
     <module>sqlite</module>
     <module>azureblob</module>
+    <module>swiftblob</module>
   </modules>
 </project>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.geowebcache</groupId>
         <artifactId>geowebcache</artifactId>
-        <version>1.17-SNAPSHOT</version><!-- GWC VERSION -->
+        <version>1.18-SNAPSHOT</version><!-- GWC VERSION -->
     </parent>
 
     <groupId>org.geowebcache</groupId>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!-- mvn -Dtest=StorageBrokerTest -Dmaven.test.jvmargs='-XX:+HeapDumpOnOutOfMemoryError -Xms32m -Xmx32m' test -->
+    <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <jclouds.version>2.2.0</jclouds.version>
+    </properties>
+
+    <parent>
+        <groupId>org.geowebcache</groupId>
+        <artifactId>geowebcache</artifactId>
+        <version>1.17-SNAPSHOT</version><!-- GWC VERSION -->
+    </parent>
+
+    <groupId>org.geowebcache</groupId>
+    <artifactId>gwc-swift</artifactId>
+    <packaging>jar</packaging>
+    <name>Swift Storage</name>
+    <url>http://geowebcache.org</url>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geowebcache</groupId>
+            <artifactId>gwc-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- jclouds OpenStack dependencies -->
+        <dependency>
+            <groupId>org.apache.jclouds.api</groupId>
+            <artifactId>openstack-swift</artifactId>
+            <version>${jclouds.version}</version>
+        </dependency>
+        <!-- 3rd party dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+</project>

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
@@ -22,9 +22,11 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
+
 import java.io.IOException;
 import java.util.*;
 import javax.annotation.Nullable;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.io.ByteArrayResource;
@@ -45,6 +47,9 @@ import org.jclouds.openstack.swift.v1.features.BulkApi;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 import org.jclouds.openstack.swift.v1.options.ListContainerOptions;
 
+/**
+ * Blobstore class compatatble with Openstack Swift.
+ */
 public class SwiftBlobStore implements BlobStore {
 
     static Log log = LogFactory.getLog(SwiftBlobStore.class);
@@ -57,13 +62,19 @@ public class SwiftBlobStore implements BlobStore {
 
     private volatile boolean shutDown;
 
-    /** JClouds Swift API */
+    /**
+     * JClouds Swift API
+     */
     private SwiftApi swiftApi;
 
-    /** Swift Object API */
+    /**
+     * Swift Object API
+     */
     private ObjectApi objectApi;
 
-    /** Swift Bulk API */
+    /**
+     * Swift Bulk API
+     */
     private BulkApi bulkApi;
 
     private RegionScopedBlobStoreContext blobStoreContext;
@@ -84,9 +95,7 @@ public class SwiftBlobStore implements BlobStore {
         bulkApi = this.swiftApi.getBulkApi(config.getJcloudsRegion());
 
         blobStoreContext = config.getBlobStore();
-        blobStore =
-                (RegionScopedSwiftBlobStore)
-                        blobStoreContext.getBlobStore(config.getJcloudsRegion());
+        blobStore = (RegionScopedSwiftBlobStore) blobStoreContext.getBlobStore(config.getJcloudsRegion());
     }
 
     @Override
@@ -239,32 +248,24 @@ public class SwiftBlobStore implements BlobStore {
             return false;
         }
 
-        final Iterator<long[]> tileLocations =
-                new AbstractIterator<long[]>() {
+        final Iterator<long[]> tileLocations = new AbstractIterator<long[]>() {
 
-                    // TileRange iterator with 1x1 meta tiling factor
-                    private TileRangeIterator trIter =
-                            new TileRangeIterator(
-                                    tileRange,
-                                    new int[] {
-                                        1, 1
-                                    }); // This depends on the tile range which I assume
+            // TileRange iterator with 1x1 meta tiling factor
+            private TileRangeIterator trIter = new TileRangeIterator(tileRange, new int[]{1, 1});
 
-                    @Override
-                    protected long[] computeNext() {
-                        long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
-                        return gridLoc == null ? endOfData() : gridLoc;
-                    }
-                };
+            @Override
+            protected long[] computeNext() {
+                long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
+                return gridLoc == null ? endOfData() : gridLoc;
+            }
+        };
 
         if (listeners.isEmpty()) {
 
             // if there are no listeners, don't bother requesting every tile
             // metadata to notify the listeners
-            Iterator<List<long[]>> partition =
-                    Iterators.partition(
-                            tileLocations, // Iterator
-                            1000); // this breaks a list into a lump of 1000s of items per sublist
+            Iterator<List<long[]>> partition = Iterators.partition(tileLocations, // Iterator
+                    1000); // this breaks a list into a lump of 1000s of items per sublist
 
             final TileToKey tileToKey = new TileToKey(coordsPrefix, tileRange.getMimeType());
 
@@ -284,9 +285,7 @@ public class SwiftBlobStore implements BlobStore {
             while (tileLocations.hasNext()) {
                 xyz = tileLocations.next();
 
-                TileObject tile =
-                        TileObject.createQueryTileObject(
-                                layerName, xyz, gridSetId, format, parameters);
+                TileObject tile = TileObject.createQueryTileObject(layerName, xyz, gridSetId, format, parameters);
                 tile.setParametersId(tileRange.getParametersId());
 
                 // Delete each tile object in the range given
@@ -309,11 +308,10 @@ public class SwiftBlobStore implements BlobStore {
         }
 
         return deletionSuccessful;
-    };
+    }
 
     @Override
-    public boolean deleteByGridsetId(final String layerName, final String gridSetId)
-            throws StorageException {
+    public boolean deleteByGridsetId(final String layerName, final String gridSetId) throws StorageException {
         checkNotNull(layerName, "layerName");
         checkNotNull(gridSetId, "gridSetId");
 
@@ -398,10 +396,6 @@ public class SwiftBlobStore implements BlobStore {
         this.objectApi.updateMetadata(layerName, metaData);
     }
 
-    /**
-     * @return {@code true} if the blobstore has a layer named {@code layerName} in use, {@code
-     *     false} otherwise
-     */
     @Override
     public boolean layerExists(String layerName) {
         return this.objectApi.get(layerName) != null;
@@ -422,27 +416,24 @@ public class SwiftBlobStore implements BlobStore {
     }
 
     @Override
-    public boolean deleteByParametersId(String layerName, String parametersId)
-            throws StorageException {
+    public boolean deleteByParametersId(String layerName, String parametersId) throws StorageException {
         checkNotNull(layerName, "layerName");
         checkNotNull(parametersId, "parametersId");
 
-        boolean deletionSuccessful =
-                keyBuilder
-                        // Gets some parameters - probably some iterable
-                        .forParameters(layerName, parametersId)
-                        // Creates a stream from this data
-                        .stream()
-                        // Maps the stream to whether the object has been successfully deleted.
-                        .map(
-                                path -> {
-                                    return this.deleteByPath(path);
-                                })
-                        // Checks if all the entries were true - meaning everything was deleted
-                        // successfully.
-                        .reduce(Boolean::logicalAnd)
-                        // If reduce is not successful then return false.
-                        .orElse(false);
+        boolean deletionSuccessful = keyBuilder
+                // Gets some parameters - probably some iterable
+                .forParameters(layerName, parametersId)
+                // Creates a stream from this data
+                .stream()
+                // Maps the stream to whether the object has been successfully deleted.
+                .map(path -> {
+                    return this.deleteByPath(path);
+                })
+                // Checks if all the entries were true - meaning everything was deleted
+                // successfully.
+                .reduce(Boolean::logicalAnd)
+                // If reduce is not successful then return false.
+                .orElse(false);
 
         // If deletion was successful then tell the listeners.
         if (deletionSuccessful) {
@@ -454,8 +445,7 @@ public class SwiftBlobStore implements BlobStore {
 
     protected boolean deleteByPath(String path) {
 
-        org.jclouds.blobstore.options.ListContainerOptions options =
-                new org.jclouds.blobstore.options.ListContainerOptions();
+        org.jclouds.blobstore.options.ListContainerOptions options = new org.jclouds.blobstore.options.ListContainerOptions();
         options.prefix(path);
         options.recursive();
 

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
@@ -1,0 +1,468 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.io.Payloads.newInputStreamPayload;
+
+import com.google.common.base.Function;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.util.*;
+import javax.annotation.Nullable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.*;
+import org.jclouds.http.HttpResponseException;
+import org.jclouds.io.MutableContentMetadata;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.openstack.swift.v1.SwiftApi;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedSwiftBlobStore;
+import org.jclouds.openstack.swift.v1.domain.SwiftObject;
+import org.jclouds.openstack.swift.v1.features.BulkApi;
+import org.jclouds.openstack.swift.v1.features.ObjectApi;
+import org.jclouds.openstack.swift.v1.options.ListContainerOptions;
+
+public class SwiftBlobStore implements BlobStore {
+
+    static Log log = LogFactory.getLog(SwiftBlobStore.class);
+
+    private final BlobStoreListenerList listeners = new BlobStoreListenerList();
+
+    private String containerName;
+
+    private final TMSKeyBuilder keyBuilder;
+
+    private volatile boolean shutDown;
+
+    /** JClouds Swift API */
+    private SwiftApi swiftApi;
+
+    /** Swift Object API */
+    private ObjectApi objectApi;
+
+    /** Swift Bulk API */
+    private BulkApi bulkApi;
+
+    private RegionScopedBlobStoreContext blobStoreContext;
+
+    private RegionScopedSwiftBlobStore blobStore;
+
+    public SwiftBlobStore(SwiftBlobStoreInfo config, TileLayerDispatcher layers) {
+
+        checkNotNull(config);
+        checkNotNull(layers);
+
+        String prefix = config.getPrefix() == null ? "" : config.getPrefix();
+        this.keyBuilder = new TMSKeyBuilder(prefix, layers);
+        this.containerName = config.getBucket();
+
+        swiftApi = config.buildApi();
+        objectApi = swiftApi.getObjectApi(config.getJcloudsRegion(), containerName);
+        bulkApi = this.swiftApi.getBulkApi(config.getJcloudsRegion());
+
+        blobStoreContext = config.getBlobStore();
+        blobStore =
+                (RegionScopedSwiftBlobStore)
+                        blobStoreContext.getBlobStore(config.getJcloudsRegion());
+    }
+
+    @Override
+    public void destroy() {
+        try {
+            this.shutDown = true;
+            this.swiftApi.close();
+            this.blobStoreContext.close();
+        } catch (IOException e) {
+            log.error("Error closing connection.");
+            log.error(e);
+        }
+    }
+
+    @Override
+    public void addListener(BlobStoreListener listener) {
+        listeners.addListener(listener);
+    }
+
+    @Override
+    public boolean removeListener(BlobStoreListener listener) {
+        return listeners.removeListener(listener);
+    }
+
+    @Override
+    public void put(TileObject obj) throws StorageException {
+        final Resource blob = obj.getBlob();
+        checkNotNull(blob, "Object Blob is null");
+
+        MutableContentMetadata contentMetadata = new BaseMutableContentMetadata();
+
+        // Set content length
+        final String key = keyBuilder.forTile(obj);
+        contentMetadata.setContentLength(blob.getSize());
+
+        // Set content type
+        checkNotNull(obj.getBlobFormat(), "Object Blob Format is null");
+        String blobFormat = obj.getBlobFormat();
+        String mimeType;
+        try {
+            mimeType = MimeType.createFromFormat(blobFormat).getMimeType();
+        } catch (MimeException me) {
+            throw new RuntimeException(me);
+        }
+        contentMetadata.setContentType(mimeType);
+
+        // don't bother for the extra call if there are no listeners
+        final boolean existed;
+        SwiftObject oldObj;
+        if (listeners.isEmpty()) {
+            existed = false;
+            oldObj = null;
+        } else {
+            oldObj = this.objectApi.get(key);
+            existed = oldObj != null;
+        }
+
+        log.trace("Storing " + obj.getLayerName());
+
+        // Upload the payload to object storage
+        try {
+            Payload payload = newInputStreamPayload(blob.getInputStream());
+            payload.setContentMetadata(contentMetadata);
+
+            // Retry logic in case upload fails
+            long failures = 0;
+            boolean retry = true;
+            while (retry && failures < 3) {
+                try {
+                    this.objectApi.put(key, payload);
+                    retry = false;
+                } catch (HttpResponseException e) {
+                    failures += 1;
+                } finally {
+                    payload.close();
+                }
+            }
+
+            if (failures > 0) {
+                log.debug("Some attempts to upload layer " + obj.getLayerName() + " have failed.");
+                log.debug("Failures count: " + failures);
+            }
+        } catch (IOException e) {
+            log.debug("Error getting payload.");
+            log.debug(e.getMessage());
+        }
+
+        // This is important because listeners may be tracking tile existence
+        if (!listeners.isEmpty()) {
+            if (existed) {
+                long oldSize = oldObj.getMetadata().size(); // Assuming this is correct
+                listeners.sendTileUpdated(obj, oldSize);
+            } else {
+                listeners.sendTileStored(obj);
+            }
+        }
+    }
+
+    @Override
+    public boolean get(TileObject obj) throws StorageException {
+        final String key = keyBuilder.forTile(obj);
+        SwiftObject object = this.objectApi.get(key);
+
+        if (object == null) {
+            return false;
+        }
+
+        try (Payload in = object.getPayload()) {
+            byte[] bytes = ByteStreams.toByteArray(in.openStream());
+            obj.setBlobSize(bytes.length);
+            obj.setBlob(new ByteArrayResource(bytes));
+            obj.setCreated(object.getLastModified().getTime());
+        } catch (IOException e) {
+            throw new StorageException("Error getting " + key, e);
+        }
+
+        return true;
+    }
+
+    private class TileToKey implements Function<long[], String> {
+
+        private final String coordsPrefix;
+
+        private final String extension;
+
+        public TileToKey(String coordsPrefix, MimeType mimeType) {
+            this.coordsPrefix = coordsPrefix;
+            this.extension = mimeType.getInternalName();
+        }
+
+        @Override
+        public String apply(long[] loc) {
+            long z = loc[2];
+            long x = loc[0];
+            long y = loc[1];
+            StringBuilder sb = new StringBuilder(coordsPrefix);
+
+            // builds the path to the tile
+            sb.append(z).append('/').append(x).append('/').append(y).append('.').append(extension);
+            return sb.toString();
+        }
+    }
+
+    @Override
+    public boolean delete(final TileRange tileRange) throws StorageException {
+
+        final String coordsPrefix = keyBuilder.coordinatesPrefix(tileRange);
+
+        if (this.objectApi.get(coordsPrefix) == null) {
+            return false;
+        }
+
+        final Iterator<long[]> tileLocations =
+                new AbstractIterator<long[]>() {
+
+                    // TileRange iterator with 1x1 meta tiling factor
+                    private TileRangeIterator trIter =
+                            new TileRangeIterator(
+                                    tileRange,
+                                    new int[] {
+                                        1, 1
+                                    }); // This depends on the tile range which I assume
+
+                    @Override
+                    protected long[] computeNext() {
+                        long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
+                        return gridLoc == null ? endOfData() : gridLoc;
+                    }
+                };
+
+        if (listeners.isEmpty()) {
+
+            // if there are no listeners, don't bother requesting every tile
+            // metadata to notify the listeners
+            Iterator<List<long[]>> partition =
+                    Iterators.partition(
+                            tileLocations, // Iterator
+                            1000); // this breaks a list into a lump of 1000s of items per sublist
+
+            final TileToKey tileToKey = new TileToKey(coordsPrefix, tileRange.getMimeType());
+
+            while (partition.hasNext() && !shutDown) {
+                List<long[]> locations = partition.next();
+                List<String> keys = Lists.transform(locations, tileToKey);
+                this.bulkApi.bulkDelete(keys);
+            }
+
+        } else {
+            long[] xyz;
+            String layerName = tileRange.getLayerName();
+            String gridSetId = tileRange.getGridSetId();
+            String format = tileRange.getMimeType().getFormat();
+            Map<String, String> parameters = tileRange.getParameters();
+
+            while (tileLocations.hasNext()) {
+                xyz = tileLocations.next();
+
+                TileObject tile =
+                        TileObject.createQueryTileObject(
+                                layerName, xyz, gridSetId, format, parameters);
+                tile.setParametersId(tileRange.getParametersId());
+
+                // Delete each tile object in the range given
+                this.delete((TileObject) tile);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean delete(String layerName) throws StorageException {
+
+        checkNotNull(layerName, "layerName");
+
+        boolean deletionSuccessful = this.deleteByPath(layerName);
+
+        // If the layer has been deleted successfully update the listeners
+        if (deletionSuccessful) {
+            listeners.sendLayerDeleted(layerName);
+        }
+
+        return deletionSuccessful;
+    };
+
+    @Override
+    public boolean deleteByGridsetId(final String layerName, final String gridSetId)
+            throws StorageException {
+        checkNotNull(layerName, "layerName");
+        checkNotNull(gridSetId, "gridSetId");
+
+        final String gridsetPrefix = keyBuilder.forGridset(layerName, gridSetId);
+
+        boolean deletedSuccesfully = this.deleteByPath(gridsetPrefix);
+
+        // If the layer has been deleted successfuly update the listeners
+        if (deletedSuccesfully) {
+            listeners.sendGridSubsetDeleted(layerName, gridSetId);
+        }
+
+        // return if the layer has been succesfully deleted
+        return deletedSuccesfully;
+    }
+
+    @Override
+    public boolean delete(TileObject obj) throws StorageException {
+        final String objName = obj.getLayerName();
+
+        checkNotNull(objName, "Object Name");
+
+        // don't bother for the extra call if there are no listeners
+        if (listeners.isEmpty()) {
+            return this.deleteByPath(objName);
+        }
+
+        boolean deleted = this.deleteByPath(objName);
+
+        if (deleted) {
+            listeners.sendTileDeleted(obj);
+        }
+
+        return deleted;
+    }
+
+    @Override
+    public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
+        log.debug("No need to rename layers, SwiftBlobStore uses layer id as key root");
+        if (objectApi.get(oldLayerName) != null) {
+            listeners.sendLayerRenamed(oldLayerName, newLayerName);
+        }
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("clear() should not be called");
+    }
+
+    @Nullable
+    @Override
+    public String getLayerMetadata(String layerName, String key) {
+        SwiftObject layer = this.objectApi.get(layerName);
+
+        if (layer == null) {
+            return null;
+        }
+
+        if (layer.getMetadata() == null) {
+            return null;
+        } else {
+            return layer.getMetadata().get(key);
+        }
+    }
+
+    @Override
+    public void putLayerMetadata(String layerName, String key, String value) {
+        SwiftObject layer = this.objectApi.get(layerName);
+        Map<String, String> metaData;
+
+        if (layer == null) {
+            return;
+        }
+
+        metaData = layer.getMetadata();
+        if (metaData == null) {
+            metaData = new HashMap<>();
+        }
+
+        metaData.put(key, value);
+        this.objectApi.updateMetadata(layerName, metaData);
+    }
+
+    /**
+     * @return {@code true} if the blobstore has a layer named {@code layerName} in use, {@code
+     *     false} otherwise
+     */
+    @Override
+    public boolean layerExists(String layerName) {
+        return this.objectApi.get(layerName) != null;
+    }
+
+    @Override
+    public Map<String, Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        String prefix = keyBuilder.parametersMetadataPrefix(layerName);
+        ListContainerOptions options = new ListContainerOptions();
+        options.prefix(prefix);
+
+        Map<String, Optional<Map<String, String>>> paramMapping = new HashMap<>();
+        for (SwiftObject obj : this.objectApi.list(options)) {
+            paramMapping.put(obj.getName(), Optional.of(obj.getMetadata()));
+        }
+
+        return paramMapping;
+    }
+
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        checkNotNull(layerName, "layerName");
+        checkNotNull(parametersId, "parametersId");
+
+        boolean deletionSuccessful =
+                keyBuilder
+                        // Gets some parameters - probably some iterable
+                        .forParameters(layerName, parametersId)
+                        // Creates a stream from this data
+                        .stream()
+                        // Maps the stream to whether the object has been successfully deleted.
+                        .map(
+                                path -> {
+                                    return this.deleteByPath(path);
+                                })
+                        // Checks if all the entries were true - meaning everything was deleted
+                        // successfully.
+                        .reduce(Boolean::logicalAnd)
+                        // If reduce is not successful then return false.
+                        .orElse(false);
+
+        // If deletion was successful then tell the listeners.
+        if (deletionSuccessful) {
+            listeners.sendParametersDeleted(layerName, parametersId);
+        }
+
+        return deletionSuccessful;
+    }
+
+    protected boolean deleteByPath(String path) {
+
+        org.jclouds.blobstore.options.ListContainerOptions options =
+                new org.jclouds.blobstore.options.ListContainerOptions();
+        options.prefix(path);
+        options.recursive();
+
+        this.blobStore.clearContainer(this.containerName, options);
+
+        // NOTE: this is messy but it seems to work.
+        // there might be a more effecient way of doing this.
+        return this.blobStore.list(this.containerName, options).isEmpty();
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -1,0 +1,125 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Gabriel Roldan, Boundless Spatial Inc, Copyright 2015
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import com.google.common.base.Strings;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+import com.thoughtworks.xstream.converters.basic.BooleanConverter;
+import com.thoughtworks.xstream.converters.basic.IntConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.geowebcache.GeoWebCacheExtensions;
+import org.geowebcache.config.BlobStoreInfo;
+import org.geowebcache.config.Info;
+import org.geowebcache.config.XMLConfigurationProvider;
+
+public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
+
+    private static GeoWebCacheEnvironment gwcEnvironment = null;
+
+    private static SingleValueConverter EnvironmentNullableIntConverter =
+            new IntConverter() {
+
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return super.fromString(str);
+                }
+            };
+
+    private static SingleValueConverter EnvironmentNullableBooleanConverter =
+            new BooleanConverter() {
+
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return super.fromString(str);
+                }
+            };
+
+    private static SingleValueConverter EnvironmentStringConverter =
+            new StringConverter() {
+                @Override
+                public Object fromString(String str) {
+                    str = resolveFromEnv(str);
+                    if (Strings.isNullOrEmpty(str)) {
+                        return null;
+                    }
+                    return str;
+                }
+            };
+
+    private static String resolveFromEnv(String str) {
+        if (gwcEnvironment == null) {
+            gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
+        }
+        if (gwcEnvironment != null
+                && str != null
+                && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            Object result = gwcEnvironment.resolveValue(str);
+            if (result == null) {
+                return null;
+            }
+            return result.toString();
+        }
+        return str;
+    }
+
+    @Override
+    public XStream getConfiguredXStream(XStream xs) {
+        xs.alias("SwiftBlobStore", SwiftBlobStoreInfo.class);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "maxConnections", EnvironmentNullableIntConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "proxyPort", EnvironmentNullableIntConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "useHTTPS", EnvironmentNullableBooleanConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "useGzip", EnvironmentNullableBooleanConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "bucket", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsProvider", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsRegion", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsKeystoneVersion", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsKeystoneScope", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsIdentity", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "jcloudsCredential", EnvironmentStringConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "prefix", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                SwiftBlobStoreInfo.class, "proxyHost", EnvironmentStringConverter);
+        xs.registerLocalConverter(
+                BlobStoreInfo.class, "enabled", EnvironmentNullableBooleanConverter);
+        xs.aliasField("id", SwiftBlobStoreInfo.class, "name");
+        return xs;
+    }
+
+    @Override
+    public boolean canSave(Info i) {
+        return i instanceof SwiftBlobStoreInfo;
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -28,7 +28,8 @@ import org.geowebcache.config.Info;
 import org.geowebcache.config.XMLConfigurationProvider;
 
 /**
- * Reads Swift Blobstore configuration from geowebcache.xml and creates a SwiftBlobStoreInfo object representing this information.
+ * Reads Swift Blobstore configuration from geowebcache.xml and creates a SwiftBlobStoreInfo object
+ * representing this information.
  */
 public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
 
@@ -92,29 +93,16 @@ public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
     public XStream getConfiguredXStream(XStream xs) {
         xs.alias("SwiftBlobStore", SwiftBlobStoreInfo.class);
         xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "maxConnections", EnvironmentNullableIntConverter);
+                SwiftBlobStoreInfo.class, "container", EnvironmentStringConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "provider", EnvironmentStringConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "region", EnvironmentStringConverter);
         xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "proxyPort", EnvironmentNullableIntConverter);
+                SwiftBlobStoreInfo.class, "keystoneVersion", EnvironmentStringConverter);
         xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "useHTTPS", EnvironmentNullableBooleanConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "useGzip", EnvironmentNullableBooleanConverter);
-        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "bucket", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsProvider", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsRegion", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsKeystoneVersion", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsKeystoneScope", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsIdentity", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "jcloudsCredential", EnvironmentStringConverter);
+                SwiftBlobStoreInfo.class, "keystoneScope", EnvironmentStringConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "identity", EnvironmentStringConverter);
+        xs.registerLocalConverter(SwiftBlobStoreInfo.class, "password", EnvironmentStringConverter);
         xs.registerLocalConverter(SwiftBlobStoreInfo.class, "prefix", EnvironmentStringConverter);
-        xs.registerLocalConverter(
-                SwiftBlobStoreInfo.class, "proxyHost", EnvironmentStringConverter);
         xs.registerLocalConverter(
                 BlobStoreInfo.class, "enabled", EnvironmentNullableBooleanConverter);
         xs.aliasField("id", SwiftBlobStoreInfo.class, "name");

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -27,6 +27,9 @@ import org.geowebcache.config.BlobStoreInfo;
 import org.geowebcache.config.Info;
 import org.geowebcache.config.XMLConfigurationProvider;
 
+/**
+ * Reads Swift Blobstore configuration from geowebcache.xml and creates a SwiftBlobStoreInfo object representing this information.
+ */
 public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
 
     private static GeoWebCacheEnvironment gwcEnvironment = null;

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -19,7 +19,6 @@ import com.google.common.base.Strings;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.SingleValueConverter;
 import com.thoughtworks.xstream.converters.basic.BooleanConverter;
-import com.thoughtworks.xstream.converters.basic.IntConverter;
 import com.thoughtworks.xstream.converters.basic.StringConverter;
 import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheExtensions;
@@ -34,19 +33,6 @@ import org.geowebcache.config.XMLConfigurationProvider;
 public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
 
     private static GeoWebCacheEnvironment gwcEnvironment = null;
-
-    private static SingleValueConverter EnvironmentNullableIntConverter =
-            new IntConverter() {
-
-                @Override
-                public Object fromString(String str) {
-                    str = resolveFromEnv(str);
-                    if (Strings.isNullOrEmpty(str)) {
-                        return null;
-                    }
-                    return super.fromString(str);
-                }
-            };
 
     private static SingleValueConverter EnvironmentNullableBooleanConverter =
             new BooleanConverter() {

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
@@ -1,0 +1,298 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Properties;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.BlobStoreInfo;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.locks.LockProvider;
+import org.geowebcache.storage.BlobStore;
+import org.geowebcache.storage.StorageException;
+import org.jclouds.ContextBuilder;
+import org.jclouds.openstack.keystone.config.KeystoneProperties;
+import org.jclouds.openstack.swift.v1.SwiftApi;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.features.ContainerApi;
+
+/** Plain old java object representing the configuration for an Swift blob store. */
+@SuppressWarnings("deprecation")
+public class SwiftBlobStoreInfo extends BlobStoreInfo {
+
+    static Log log = LogFactory.getLog(SwiftBlobStoreInfo.class);
+
+    private static final long serialVersionUID = 9072751143836460389L;
+
+    private String bucket;
+
+    private String prefix;
+
+    private Integer maxConnections;
+
+    private Boolean useHTTPS = true;
+
+    private String jcloudsProvider;
+
+    private String jcloudsRegion;
+
+    private String jcloudsKeystoneVersion;
+
+    private String jcloudsKeystoneScope;
+
+    private String jcloudsKeystoneDomainName;
+
+    private String jcloudsIdentity;
+
+    private String jcloudsCredential;
+
+    private Boolean useGzip;
+
+    private String endpoint;
+
+    public SwiftBlobStoreInfo() {
+        super();
+    }
+
+    public SwiftBlobStoreInfo(String id) {
+        super(id);
+    }
+
+    /** @return the name of the Swift bucket where to store tiles */
+    public String getBucket() {
+        return bucket;
+    }
+
+    /** Sets the name of the Swift bucket where to store tiles */
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    /** @return the Swift endpoint */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /** Sets the Swift endpoint */
+    public void setEndpoint(String host) {
+        this.endpoint = host;
+    }
+
+    @Override
+    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
+            throws StorageException {
+
+        checkNotNull(layers);
+        checkState(getName() != null);
+        checkState(
+                isEnabled(),
+                "Can't call SwiftBlobStoreConfig.createInstance() if blob store is not enabled");
+        return new SwiftBlobStore(this, layers);
+    }
+
+    /**
+     * Returns the base prefix, which is a prefix path to use as the root to store tiles under the
+     * bucket.
+     *
+     * @return optional string for a "base prefix"
+     */
+    @Nullable
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /** @return The maximum number of allowed open HTTP connections. */
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    /** Sets the maximum number of allowed open HTTP connections. */
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    /**
+     * @return whether to use HTTPS (true) or HTTP (false) when talking to Swift (defaults to true)
+     */
+    public Boolean isUseHTTPS() {
+        return useHTTPS;
+    }
+
+    /** @param useHTTPS whether to use HTTPS (true) or HTTP (false) when talking to Swift */
+    public void setUseHTTPS(Boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+
+    /**
+     * Checks if gzip compression is used
+     *
+     * @return if gzip compression is used
+     */
+    public Boolean isUseGzip() {
+        return useGzip;
+    }
+
+    /**
+     * Sets whether gzip compression should be used
+     *
+     * @param use whether gzip compression should be used
+     */
+    public void setUseGzip(Boolean use) {
+        this.useGzip = use;
+    }
+
+    public String getJcloudsProvider() {
+        return jcloudsProvider;
+    }
+
+    public void setJcloudsProvider(String jcloudsProvider) {
+        this.jcloudsProvider = jcloudsProvider;
+    }
+
+    public String getJcloudsRegion() {
+        return jcloudsRegion;
+    }
+
+    public void setJcloudsRegion(String jcloudsRegion) {
+        this.jcloudsRegion = jcloudsRegion;
+    }
+
+    public String getJcloudsKeystoneVersion() {
+        return jcloudsKeystoneVersion;
+    }
+
+    public void setJcloudsKeystoneVersion(String jcloudsKeystoneVersion) {
+        this.jcloudsKeystoneVersion = jcloudsKeystoneVersion;
+    }
+
+    public String getJcloudsKeystoneScope() {
+        return jcloudsKeystoneScope;
+    }
+
+    public void setJcloudsKeystoneScope(String jcloudsKeystoneScope) {
+        this.jcloudsKeystoneScope = jcloudsKeystoneScope;
+    }
+
+    public String getJcloudsKeystoneDomainName() {
+        return jcloudsKeystoneDomainName;
+    }
+
+    public void setJcloudsKeystoneDomainName(String jcloudsKeystoneDomainName) {
+        this.jcloudsKeystoneDomainName = jcloudsKeystoneDomainName;
+    }
+
+    public String getJcloudsIdentity() {
+        return jcloudsIdentity;
+    }
+
+    public void setJcloudsIdentity(String jcloudsIdentity) {
+        this.jcloudsIdentity = jcloudsIdentity;
+    }
+
+    public String getJcloudsCredential() {
+        return jcloudsCredential;
+    }
+
+    public void setJcloudsCredential(String jcloudsCredential) {
+        this.jcloudsCredential = jcloudsCredential;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    /** @return {@link SwiftApi} constructed from this {@link SwiftBlobStoreInfo}. */
+    public SwiftApi buildApi() {
+
+        final Properties overrides = new Properties();
+        overrides.put(KeystoneProperties.KEYSTONE_VERSION, jcloudsKeystoneVersion);
+        overrides.put(KeystoneProperties.SCOPE, jcloudsKeystoneScope);
+        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, jcloudsKeystoneDomainName);
+
+        String provider = jcloudsProvider;
+        String identity = jcloudsIdentity;
+        String credential = jcloudsCredential;
+
+        SwiftApi context =
+                ContextBuilder.newBuilder(provider)
+                        .endpoint(endpoint)
+                        .credentials(identity, credential)
+                        .overrides(overrides)
+                        .buildApi(SwiftApi.class);
+
+        ContainerApi containerApi = context.getContainerApi(jcloudsRegion);
+
+        // Creates bucket if it doesn't already exist
+        if (containerApi.get(bucket) == null) {
+            containerApi.create(bucket);
+        }
+
+        return context;
+    }
+
+    /** @return {@link SwiftApi} constructed from this {@link SwiftBlobStoreInfo}. */
+    public RegionScopedBlobStoreContext getBlobStore() {
+
+        final Properties overrides = new Properties();
+        overrides.put(KeystoneProperties.KEYSTONE_VERSION, jcloudsKeystoneVersion);
+        overrides.put(KeystoneProperties.SCOPE, jcloudsKeystoneScope);
+        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, jcloudsKeystoneDomainName);
+
+        String provider = jcloudsProvider;
+        String identity = jcloudsIdentity;
+        String credential = jcloudsCredential;
+
+        ContextBuilder builder =
+                ContextBuilder.newBuilder(provider)
+                        .endpoint(endpoint)
+                        .credentials(identity, credential)
+                        .overrides(overrides);
+
+        return builder.build(RegionScopedBlobStoreContext.class);
+    }
+
+    @Override
+    public String getLocation() {
+        String bucket = this.getBucket();
+        String prefix = this.getPrefix();
+        if (prefix == null) {
+            return String.format("bucket: %s", bucket);
+        } else {
+            return String.format("bucket: %s prefix: %s", bucket, prefix);
+        }
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
@@ -35,7 +35,10 @@ import org.jclouds.openstack.swift.v1.SwiftApi;
 import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
 import org.jclouds.openstack.swift.v1.features.ContainerApi;
 
-/** Plain old java object representing the configuration for an Swift blob store. */
+/**
+ * Java object representing the configuration for an Swift blob store. Contains methods for building
+ * instance of JClouds API and Blobstore.
+ */
 @SuppressWarnings("deprecation")
 public class SwiftBlobStoreInfo extends BlobStoreInfo {
 
@@ -43,29 +46,23 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
 
     private static final long serialVersionUID = 9072751143836460389L;
 
-    private String bucket;
+    private String container;
 
     private String prefix;
 
-    private Integer maxConnections;
+    private String provider;
 
-    private Boolean useHTTPS = true;
+    private String region;
 
-    private String jcloudsProvider;
+    private String keystoneVersion;
 
-    private String jcloudsRegion;
+    private String keystoneScope;
 
-    private String jcloudsKeystoneVersion;
+    private String keystoneDomainName;
 
-    private String jcloudsKeystoneScope;
+    private String identity;
 
-    private String jcloudsKeystoneDomainName;
-
-    private String jcloudsIdentity;
-
-    private String jcloudsCredential;
-
-    private Boolean useGzip;
+    private String password;
 
     private String endpoint;
 
@@ -78,23 +75,8 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
     }
 
     /** @return the name of the Swift bucket where to store tiles */
-    public String getBucket() {
-        return bucket;
-    }
-
-    /** Sets the name of the Swift bucket where to store tiles */
-    public void setBucket(String bucket) {
-        this.bucket = bucket;
-    }
-
-    /** @return the Swift endpoint */
-    public String getEndpoint() {
-        return endpoint;
-    }
-
-    /** Sets the Swift endpoint */
-    public void setEndpoint(String host) {
-        this.endpoint = host;
+    public String getContainer() {
+        return container;
     }
 
     @Override
@@ -120,104 +102,8 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
         return prefix;
     }
 
-    public void setPrefix(String prefix) {
-        this.prefix = prefix;
-    }
-
-    /** @return The maximum number of allowed open HTTP connections. */
-    public Integer getMaxConnections() {
-        return maxConnections;
-    }
-
-    /** Sets the maximum number of allowed open HTTP connections. */
-    public void setMaxConnections(Integer maxConnections) {
-        this.maxConnections = maxConnections;
-    }
-
-    /**
-     * @return whether to use HTTPS (true) or HTTP (false) when talking to Swift (defaults to true)
-     */
-    public Boolean isUseHTTPS() {
-        return useHTTPS;
-    }
-
-    /** @param useHTTPS whether to use HTTPS (true) or HTTP (false) when talking to Swift */
-    public void setUseHTTPS(Boolean useHTTPS) {
-        this.useHTTPS = useHTTPS;
-    }
-
-    /**
-     * Checks if gzip compression is used
-     *
-     * @return if gzip compression is used
-     */
-    public Boolean isUseGzip() {
-        return useGzip;
-    }
-
-    /**
-     * Sets whether gzip compression should be used
-     *
-     * @param use whether gzip compression should be used
-     */
-    public void setUseGzip(Boolean use) {
-        this.useGzip = use;
-    }
-
-    public String getJcloudsProvider() {
-        return jcloudsProvider;
-    }
-
-    public void setJcloudsProvider(String jcloudsProvider) {
-        this.jcloudsProvider = jcloudsProvider;
-    }
-
-    public String getJcloudsRegion() {
-        return jcloudsRegion;
-    }
-
-    public void setJcloudsRegion(String jcloudsRegion) {
-        this.jcloudsRegion = jcloudsRegion;
-    }
-
-    public String getJcloudsKeystoneVersion() {
-        return jcloudsKeystoneVersion;
-    }
-
-    public void setJcloudsKeystoneVersion(String jcloudsKeystoneVersion) {
-        this.jcloudsKeystoneVersion = jcloudsKeystoneVersion;
-    }
-
-    public String getJcloudsKeystoneScope() {
-        return jcloudsKeystoneScope;
-    }
-
-    public void setJcloudsKeystoneScope(String jcloudsKeystoneScope) {
-        this.jcloudsKeystoneScope = jcloudsKeystoneScope;
-    }
-
-    public String getJcloudsKeystoneDomainName() {
-        return jcloudsKeystoneDomainName;
-    }
-
-    public void setJcloudsKeystoneDomainName(String jcloudsKeystoneDomainName) {
-        this.jcloudsKeystoneDomainName = jcloudsKeystoneDomainName;
-    }
-
-    public String getJcloudsIdentity() {
-        return jcloudsIdentity;
-    }
-
-    public void setJcloudsIdentity(String jcloudsIdentity) {
-        this.jcloudsIdentity = jcloudsIdentity;
-    }
-
-    public String getJcloudsCredential() {
-        return jcloudsCredential;
-    }
-
-    public void setJcloudsCredential(String jcloudsCredential) {
-        this.jcloudsCredential = jcloudsCredential;
+    public String getRegion() {
+        return region;
     }
 
     @Override
@@ -239,13 +125,13 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
     public SwiftApi buildApi() {
 
         final Properties overrides = new Properties();
-        overrides.put(KeystoneProperties.KEYSTONE_VERSION, jcloudsKeystoneVersion);
-        overrides.put(KeystoneProperties.SCOPE, jcloudsKeystoneScope);
-        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, jcloudsKeystoneDomainName);
+        overrides.put(KeystoneProperties.KEYSTONE_VERSION, keystoneVersion);
+        overrides.put(KeystoneProperties.SCOPE, keystoneScope);
+        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, keystoneDomainName);
 
-        String provider = jcloudsProvider;
-        String identity = jcloudsIdentity;
-        String credential = jcloudsCredential;
+        String provider = this.provider;
+        String identity = this.identity;
+        String credential = this.password;
 
         SwiftApi context =
                 ContextBuilder.newBuilder(provider)
@@ -254,11 +140,11 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
                         .overrides(overrides)
                         .buildApi(SwiftApi.class);
 
-        ContainerApi containerApi = context.getContainerApi(jcloudsRegion);
+        ContainerApi containerApi = context.getContainerApi(region);
 
         // Creates bucket if it doesn't already exist
-        if (containerApi.get(bucket) == null) {
-            containerApi.create(bucket);
+        if (containerApi.get(container) == null) {
+            containerApi.create(container);
         }
 
         return context;
@@ -268,13 +154,13 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
     public RegionScopedBlobStoreContext getBlobStore() {
 
         final Properties overrides = new Properties();
-        overrides.put(KeystoneProperties.KEYSTONE_VERSION, jcloudsKeystoneVersion);
-        overrides.put(KeystoneProperties.SCOPE, jcloudsKeystoneScope);
-        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, jcloudsKeystoneDomainName);
+        overrides.put(KeystoneProperties.KEYSTONE_VERSION, keystoneVersion);
+        overrides.put(KeystoneProperties.SCOPE, keystoneScope);
+        overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, keystoneDomainName);
 
-        String provider = jcloudsProvider;
-        String identity = jcloudsIdentity;
-        String credential = jcloudsCredential;
+        String provider = this.provider;
+        String identity = this.identity;
+        String credential = this.password;
 
         ContextBuilder builder =
                 ContextBuilder.newBuilder(provider)
@@ -287,7 +173,7 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
 
     @Override
     public String getLocation() {
-        String bucket = this.getBucket();
+        String bucket = this.getContainer();
         String prefix = this.getPrefix();
         if (prefix == null) {
             return String.format("bucket: %s", bucket);

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
@@ -1,0 +1,238 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Gabriel Roldan, Boundless Spatial Inc, Copyright 2015
+ */
+package org.geowebcache.swift;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Strings;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.TileObject;
+import org.geowebcache.storage.TileRange;
+
+final class TMSKeyBuilder {
+
+    private static final String DELIMITER = "/";
+
+    public static final String LAYER_METADATA_OBJECT_NAME = "metadata.properties";
+    public static final String PARAMETERS_METADATA_OBJECT_PREFIX = "parameters-";
+    public static final String PARAMETERS_METADATA_OBJECT_SUFFIX = ".properties";
+
+    private String prefix;
+
+    private TileLayerDispatcher layers;
+
+    public TMSKeyBuilder(final String prefix, TileLayerDispatcher layers) {
+        this.prefix = prefix;
+        this.layers = layers;
+    }
+
+    public String layerId(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getId();
+    }
+
+    public Set<String> layerGridsets(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getGridSubsets();
+    }
+
+    public Set<String> layerFormats(String layerName) {
+        TileLayer layer;
+        try {
+            layer = layers.getTileLayer(layerName);
+        } catch (GeoWebCacheException e) {
+            throw new RuntimeException(e);
+        }
+        return layer.getMimeTypes()
+                .stream()
+                .map(MimeType::getFileExtension)
+                .collect(Collectors.toSet());
+    }
+
+    public String forTile(TileObject obj) {
+        checkNotNull(obj.getLayerName());
+        checkNotNull(obj.getGridSetId());
+        checkNotNull(obj.getBlobFormat());
+        checkNotNull(obj.getXYZ());
+
+        String layer = layerId(obj.getLayerName());
+        String gridset = obj.getGridSetId();
+        String shortFormat;
+        String parametersId = obj.getParametersId();
+        if (parametersId == null) {
+            Map<String, String> parameters = obj.getParameters();
+            parametersId = ParametersUtils.getId(parameters);
+            if (parametersId == null) {
+                parametersId = "default";
+            } else {
+                obj.setParametersId(parametersId);
+            }
+        }
+        Long x = Long.valueOf(obj.getXYZ()[0]);
+        Long y = Long.valueOf(obj.getXYZ()[1]);
+        Long z = Long.valueOf(obj.getXYZ()[2]);
+        String extension;
+        try {
+            String format = obj.getBlobFormat();
+            MimeType mimeType = MimeType.createFromFormat(format);
+            shortFormat = mimeType.getFileExtension(); // png, png8, png24, etc
+            extension = mimeType.getInternalName(); // png, jpeg, etc
+        } catch (MimeException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Key format, comprised of
+        // {@code <prefix>/<layer name>/<gridset id>/<format id>/<parameters
+        // hash>/<z>/<x>/<y>.<extension>}
+        String key =
+                join(
+                        false,
+                        prefix,
+                        layer,
+                        gridset,
+                        shortFormat,
+                        parametersId,
+                        z,
+                        x,
+                        y + "." + extension);
+        return key;
+    }
+
+    public String forLayer(final String layerName) {
+        String layerId = layerId(layerName);
+        // Layer prefix format, comprised of {@code <prefix>/<layer name>/}
+        return join(true, prefix, layerId);
+    }
+
+    public String forGridset(final String layerName, final String gridsetId) {
+        String layerId = layerId(layerName);
+        // Layer prefix format, comprised of {@code <prefix>/<layer name>/}
+        return join(true, prefix, layerId, gridsetId);
+    }
+
+    public Set<String> forParameters(final String layerName, final String parametersId) {
+        String layerId = layerId(layerName);
+        // Coordinates prefix: {@code <prefix>/<layer name>/<gridset id>/<format id>/<parameters
+        // hash>/}
+        return layerGridsets(layerName)
+                .stream()
+                .flatMap(
+                        gridsetId ->
+                                layerFormats(layerName)
+                                        .stream()
+                                        .map(
+                                                format ->
+                                                        join(
+                                                                true,
+                                                                prefix,
+                                                                layerId,
+                                                                gridsetId,
+                                                                format,
+                                                                parametersId)))
+                .collect(Collectors.toSet());
+    }
+
+    public String layerMetadata(final String layerName) {
+        String layerId = layerId(layerName);
+        return join(false, prefix, layerId, LAYER_METADATA_OBJECT_NAME);
+    }
+
+    public String storeMetadata() {
+        return join(false, prefix, LAYER_METADATA_OBJECT_NAME);
+    }
+
+    public String parametersMetadata(final String layerName, final String parametersId) {
+        String layerId = layerId(layerName);
+        return join(
+                false,
+                prefix,
+                layerId,
+                PARAMETERS_METADATA_OBJECT_PREFIX
+                        + parametersId
+                        + PARAMETERS_METADATA_OBJECT_SUFFIX);
+    }
+
+    public String parametersMetadataPrefix(final String layerName) {
+        String layerId = layerId(layerName);
+        return join(false, prefix, layerId, PARAMETERS_METADATA_OBJECT_PREFIX);
+    }
+
+    /**
+     * @return the key prefix up to the coordinates (i.e. {@code
+     *     "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
+     */
+    public String coordinatesPrefix(TileRange obj) {
+        checkNotNull(obj.getLayerName());
+        checkNotNull(obj.getGridSetId());
+        checkNotNull(obj.getMimeType());
+
+        String layer = layerId(obj.getLayerName());
+        String gridset = obj.getGridSetId();
+        MimeType mimeType = obj.getMimeType();
+
+        String shortFormat;
+        String parametersId = obj.getParametersId();
+        if (parametersId == null) {
+            Map<String, String> parameters = obj.getParameters();
+            parametersId = ParametersUtils.getId(parameters);
+            if (parametersId == null) {
+                parametersId = "default";
+            } else {
+                obj.setParametersId(parametersId);
+            }
+        }
+        shortFormat = mimeType.getFileExtension(); // png, png8, png24, etc
+
+        String key = join(true, prefix, layer, gridset, shortFormat, parametersId);
+        return key;
+    }
+
+    public String pendingDeletes() {
+        return String.format("%s/%s", prefix, "_pending_deletes.properties");
+    }
+
+    private static String join(boolean closing, Object... elements) {
+        StringJoiner joiner = new StringJoiner(DELIMITER);
+        for (Object o : elements) {
+            String s = o == null ? null : o.toString();
+            if (!Strings.isNullOrEmpty(s)) {
+                joiner.add(s);
+            }
+        }
+        if (closing) {
+            joiner.add("");
+        }
+        return joiner.toString();
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
@@ -17,10 +17,12 @@ package org.geowebcache.swift;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.layer.TileLayer;
@@ -30,6 +32,9 @@ import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.TileRange;
 
+/**
+ * Provides methods to retrieve path information for tile objects.
+ */
 final class TMSKeyBuilder {
 
     private static final String DELIMITER = "/";
@@ -190,7 +195,7 @@ final class TMSKeyBuilder {
 
     /**
      * @return the key prefix up to the coordinates (i.e. {@code
-     *     "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
+     * "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
      */
     public String coordinatesPrefix(TileRange obj) {
         checkNotNull(obj.getLayerName());

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
@@ -17,12 +17,10 @@ package org.geowebcache.swift;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.layer.TileLayer;
@@ -32,9 +30,7 @@ import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.TileRange;
 
-/**
- * Provides methods to retrieve path information for tile objects.
- */
+/** Provides methods to retrieve path information for tile objects. */
 final class TMSKeyBuilder {
 
     private static final String DELIMITER = "/";
@@ -195,7 +191,7 @@ final class TMSKeyBuilder {
 
     /**
      * @return the key prefix up to the coordinates (i.e. {@code
-     * "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
+     *     "<prefix>/<layer>/<gridset>/<format>/<parametersId>"})
      */
     public String coordinatesPrefix(TileRange obj) {
         checkNotNull(obj.getLayerName());

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -47,9 +47,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 
-/**
- * Unit testing for the Swift Blobstore class
- */
+/** Unit testing for the Swift Blobstore class */
 public class SwiftBlobStoreTest {
 
     private SwiftBlobStore swiftBlobStore;

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -1,0 +1,715 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.io.ByteSource;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.*;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.io.payloads.ByteSourcePayload;
+import org.jclouds.io.payloads.InputStreamPayload;
+import org.jclouds.openstack.swift.v1.SwiftApi;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedSwiftBlobStore;
+import org.jclouds.openstack.swift.v1.domain.Container;
+import org.jclouds.openstack.swift.v1.domain.ObjectList;
+import org.jclouds.openstack.swift.v1.domain.SwiftObject;
+import org.jclouds.openstack.swift.v1.features.BulkApi;
+import org.jclouds.openstack.swift.v1.features.ObjectApi;
+import org.jclouds.openstack.swift.v1.options.ListContainerOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SwiftBlobStoreTest {
+
+    private SwiftBlobStore swiftBlobStore;
+
+    @Mock private ObjectApi objectApi;
+
+    private TileObject sampleTileObject;
+
+    private TMSKeyBuilder keyBuilder;
+
+    @Mock private SwiftApi swiftApi;
+
+    @Mock private BulkApi bulkApi;
+
+    private BlobStoreListenerList testListeners;
+
+    @Mock private RegionScopedBlobStoreContext blobStoreContext;
+
+    @Mock private RegionScopedSwiftBlobStore blobStore;
+
+    private static final String VALID_TEST_LAYER_NAME = "TestLayer";
+    private static final String INVALID_TEST_LAYER_NAME = "NonExistentLayer";
+
+    @Before
+    public void setUp() throws Exception {
+
+        // Initialises the annotated mocks and spies
+        MockitoAnnotations.initMocks(this);
+
+        // Create tile object for use in swift blob store methods
+        Resource bytes = new ByteArrayResource("1 2 3 4 5 6 test".getBytes());
+        long[] xyz = {1L, 2L, 3L};
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("test param key", "test param value");
+        sampleTileObject =
+                TileObject.createCompleteTileObject(
+                        VALID_TEST_LAYER_NAME, xyz, "EPSG:4326", "image/jpeg", parameters, bytes);
+
+        when(swiftApi.getObjectApi(null, null)).thenReturn(objectApi);
+        when(swiftApi.getBulkApi(null)).thenReturn(bulkApi);
+        when(blobStoreContext.getBlobStore(null)).thenReturn(blobStore);
+
+        when(blobStore.list(any(), any())).thenReturn(mock(PageSet.class));
+
+        // Creating config
+        SwiftBlobStoreInfo config = mock(SwiftBlobStoreInfo.class);
+        when(config.buildApi()).thenReturn(swiftApi);
+        when(config.getBlobStore()).thenReturn(blobStoreContext);
+
+        // Creating spy object for swift blob store, keybuilder and keylisteners
+        swiftBlobStore = spy(new SwiftBlobStore(config, mock(TileLayerDispatcher.class)));
+        keyBuilder = spy(new TMSKeyBuilder("test_prefix", mock(TileLayerDispatcher.class)));
+        testListeners = spy(new BlobStoreListenerList());
+
+        doReturn("sample/key").when(keyBuilder).forTile(sampleTileObject);
+
+        // Setting private class properties to be able to check state in tests
+        ReflectionTestUtils.setField(swiftBlobStore, "keyBuilder", keyBuilder);
+        ReflectionTestUtils.setField(swiftBlobStore, "listeners", testListeners);
+        ReflectionTestUtils.setField(swiftBlobStore, "containerName", "TestContainer");
+    }
+
+    @After
+    public void tearDown() {
+        // Should close the blob store and swift api
+        this.swiftBlobStore.destroy();
+    }
+
+    @Test
+    public void destroy() {
+        this.swiftBlobStore.destroy();
+        try {
+            verify(swiftApi, times(1)).close();
+            verify(blobStoreContext, times(1)).close();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void addListener() {
+
+        // Check if the listeners list is empty before adding any element
+        assertTrue(testListeners.isEmpty());
+
+        // Add a mock listener object
+        BlobStoreListener swiftListener = mock(BlobStoreListener.class);
+        this.swiftBlobStore.addListener(swiftListener);
+
+        // Check if the listener was added to the list successfully
+        ArrayList<BlobStoreListener> blobStoreListenersResult =
+                (ArrayList) testListeners.getListeners();
+        assertTrue(blobStoreListenersResult.contains(swiftListener));
+    }
+
+    @Test
+    public void removeListener() {
+        // Add a listener to the test listeners list and test it exists in the list
+        BlobStoreListener swiftListener = mock(BlobStoreListener.class);
+        this.testListeners.addListener(swiftListener);
+        ArrayList<BlobStoreListener> testListenersList = (ArrayList) testListeners.getListeners();
+        assertTrue(testListenersList.contains(swiftListener));
+
+        // Call the blobstore method to delete the listener
+        this.swiftBlobStore.removeListener(swiftListener);
+
+        // Check if the listener was removed from the list successfully
+        assertTrue(testListeners.isEmpty());
+    }
+
+    @Test
+    public void put() {
+        Resource testResource = mock(Resource.class);
+        String testKey = "test/key";
+        Long contentLen = 3L;
+
+        // Using a mock object here to control methods and test method calls
+        TileObject testTileObject = mock(TileObject.class);
+        when(testTileObject.getBlob()).thenReturn(null);
+        doReturn(testKey).when(this.keyBuilder).forTile(testTileObject);
+
+        // Test when blob is null
+        try {
+            this.swiftBlobStore.put(testTileObject);
+            fail("Null check for grid check id failed");
+        } catch (NullPointerException e) {
+            verify(testTileObject, times(1)).getBlob();
+            assertThat(e.getMessage(), is("Object Blob is null"));
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+
+        // Test when when object.getBlobFormat() is null
+        when(testTileObject.getBlobFormat()).thenReturn(null);
+        when(testTileObject.getBlob()).thenReturn(testResource);
+        try {
+            this.swiftBlobStore.put(testTileObject);
+            fail("Null check for grid check id failed");
+        } catch (NullPointerException e) {
+            verify(testTileObject, times(2)).getBlob();
+            assertThat(e.getMessage(), is("Object Blob Format is null"));
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+
+        // Test when a blob format is an invalid mime type
+        when(testTileObject.getBlobFormat()).thenReturn("invalid mime type");
+        try {
+            this.swiftBlobStore.put(testTileObject);
+            fail("Null check for grid check id failed");
+        } catch (RuntimeException e) {
+            verify(testTileObject, times(3)).getBlob();
+        } catch (StorageException e) {
+            fail("Should be throwing a RuntimeException caused by a MimeException.\n" + e);
+        }
+
+        // Test when blob format is a valid mime type
+        when(testTileObject.getBlobFormat()).thenReturn("image/jpeg");
+        when(testResource.getSize()).thenReturn(contentLen);
+        when(testTileObject.getXYZ()).thenReturn(new long[] {1L, 2L, 3L});
+        try {
+            InputStream testInputStream = mock(InputStream.class);
+            when(testResource.getInputStream()).thenReturn(testInputStream);
+            this.swiftBlobStore.put(testTileObject);
+            verify(testTileObject, times(4)).getBlob();
+            verify(keyBuilder, times(3)).forTile(testTileObject);
+
+            // Test if listeners are empty
+            verify(objectApi, times(0)).get(testKey);
+
+            // Verify put call and arguments
+            verify(objectApi, times(1)).put(testKey, new InputStreamPayload(testInputStream));
+
+            // Test if listeners are not empty
+            BlobStoreListener testListener = mock(BlobStoreListener.class);
+            testListeners.addListener(testListener);
+
+            // When old obj is null
+            when(objectApi.get(testKey)).thenReturn(null);
+            this.swiftBlobStore.put(testTileObject);
+            verify(testTileObject, times(5)).getBlob();
+            verify(this.keyBuilder, times(4)).forTile(testTileObject);
+            verify(this.objectApi, times(1)).get(testKey);
+
+            // When old obj is not null
+            SwiftObject testSwiftObject = mock(SwiftObject.class);
+            when(objectApi.get(testKey)).thenReturn(testSwiftObject);
+
+            this.swiftBlobStore.put(testTileObject);
+            verify(testTileObject, times(6)).getBlob();
+            verify(this.keyBuilder, times(5)).forTile(testTileObject);
+            verify(this.objectApi, times(2)).get(testKey);
+            verify(testSwiftObject, times(1)).getMetadata();
+
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void get() {
+        String thePayloadData = "Test Content";
+        Date lastModified = new Date();
+        ByteSourcePayload testByteSourcePayload =
+                new ByteSourcePayload(
+                        new ByteSource() {
+                            @Override
+                            public InputStream openStream() {
+                                return new ByteArrayInputStream(thePayloadData.getBytes());
+                            }
+                        });
+
+        SwiftObject swiftObject = mock(SwiftObject.class);
+        when(swiftObject.getLastModified()).thenReturn(lastModified);
+        when(swiftObject.getPayload()).thenReturn(testByteSourcePayload);
+
+        try {
+            when(objectApi.get("sample/key")).thenReturn(swiftObject);
+            boolean result = this.swiftBlobStore.get(sampleTileObject);
+
+            verify(keyBuilder, times(1)).forTile(sampleTileObject);
+            verify(objectApi, times(1)).get("sample/key");
+            verify(swiftObject, times(1)).getPayload();
+
+            ByteArrayResource expectedByteArray = new ByteArrayResource(thePayloadData.getBytes());
+            ByteArrayResource actualByteArray = (ByteArrayResource) sampleTileObject.getBlob();
+
+            assertEquals(thePayloadData.length(), sampleTileObject.getBlobSize());
+            assertArrayEquals(expectedByteArray.getContents(), actualByteArray.getContents());
+            assertEquals(lastModified.getTime(), sampleTileObject.getCreated());
+            assertTrue(result);
+
+            when(objectApi.get("sample/key")).thenReturn(null);
+            result = this.swiftBlobStore.get(sampleTileObject);
+            assertFalse(result);
+        } catch (StorageException e) {
+            fail("A storage exception was not expected to be thrown");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void deleteByLayerName() {
+
+        // Test with valid layer name
+        try {
+            // Test when deletion is successful
+            doReturn(true).when(this.swiftBlobStore).deleteByPath(VALID_TEST_LAYER_NAME);
+            boolean result = this.swiftBlobStore.delete(VALID_TEST_LAYER_NAME);
+            verify(this.swiftBlobStore, times(1)).deleteByPath(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(1)).sendLayerDeleted(VALID_TEST_LAYER_NAME);
+            assertTrue(result);
+
+            // Test when deletion is not successful
+            doReturn(false).when(this.swiftBlobStore).deleteByPath(VALID_TEST_LAYER_NAME);
+            result = this.swiftBlobStore.delete(VALID_TEST_LAYER_NAME);
+            verify(this.swiftBlobStore, times(2)).deleteByPath(VALID_TEST_LAYER_NAME);
+            assertFalse(result);
+        } catch (StorageException e) {
+            fail("Storage exception should not be thrown.\n" + e);
+        }
+
+        // Test when layer name is null
+        try {
+            this.swiftBlobStore.delete((String) null);
+            fail("Null check for layer name failed");
+        } catch (NullPointerException e) {
+            verify(this.swiftBlobStore, times(2)).deleteByPath(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(0)).sendLayerDeleted(null);
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+    }
+
+    @Test
+    public void deleteByTileRange() {
+        TileRange testTileRange = mock(TileRange.class);
+        MimeType mimeType = mock(MimeType.class);
+        when(mimeType.getInternalName()).thenReturn("png");
+        when(mimeType.getFormat()).thenReturn("png");
+        when(testTileRange.getMimeType()).thenReturn(mock(MimeType.class));
+
+        // Range bounds format: {{minx, maxx, miny, maxy, zoomLevel}, ...}
+        long[][] rangebounds = {{1L, 2L, 1L, 2L, 1L}, {1L, 2L, 1L, 2L, 2L}, {1L, 2L, 1L, 2L, 3L}};
+        TileRange realTestTileRange =
+                new TileRange(
+                        VALID_TEST_LAYER_NAME,
+                        "test_gridset_id",
+                        1,
+                        2,
+                        rangebounds,
+                        mimeType,
+                        new HashMap<>(),
+                        "test_param_id");
+
+        String testCoordinatesPrefix = "test/coord/prefix";
+        SwiftObject testSwiftObject = mock(SwiftObject.class);
+
+        doReturn(testCoordinatesPrefix).when(this.keyBuilder).coordinatesPrefix(testTileRange);
+        doReturn("layer_id").when(this.keyBuilder).layerId(VALID_TEST_LAYER_NAME);
+
+        try {
+            // Test when object is null from the objectApi
+            when(this.objectApi.get(testCoordinatesPrefix)).thenReturn(null);
+            boolean outcome = this.swiftBlobStore.delete(testTileRange);
+            verify(keyBuilder, times(1)).coordinatesPrefix(testTileRange);
+            verify(objectApi, times(1)).get(testCoordinatesPrefix);
+            assertFalse(outcome);
+
+            // Test when object is valid and listeners are empty
+            when(this.objectApi.get(any())).thenReturn(testSwiftObject);
+            outcome = this.swiftBlobStore.delete(realTestTileRange);
+            verify(keyBuilder, times(1)).coordinatesPrefix(realTestTileRange);
+
+            // Test that keybuilder is outputting the correct path
+            verify(objectApi, times(1)).get("test_prefix/layer_id/test_gridset_id/test_param_id/");
+
+            // Based on the tile range above this should be the resulting keys which should be
+            // called with bulk delete.
+            List<String> expectedKeys =
+                    Arrays.asList(
+                            // Zoom level 1
+                            "test_prefix/layer_id/test_gridset_id/test_param_id/1/1/2.png",
+                            // Zoom level 2
+                            "test_prefix/layer_id/test_gridset_id/test_param_id/2/1/2.png");
+            verify(this.bulkApi, times(1)).bulkDelete(expectedKeys);
+            assertTrue(outcome);
+
+            // Test when object is valid and listeners are not empty
+            BlobStoreListener testListener = mock(BlobStoreListener.class);
+            testListeners.addListener(testListener);
+            outcome = this.swiftBlobStore.delete(realTestTileRange);
+
+            // Verify number of times called
+            verify(this.swiftBlobStore, times(2)).delete((TileObject) any());
+            assertTrue(outcome);
+        } catch (StorageException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void deleteByGridsetId() {
+        String testGridSetID = "TestGridSetID";
+        String testGridsetPrefix = "test/gridset/prefix";
+        doReturn(testGridsetPrefix)
+                .when(this.keyBuilder)
+                .forGridset(VALID_TEST_LAYER_NAME, testGridSetID);
+
+        // Test with a valid layer name and prefix
+        try {
+            // Test with a valid layer name and prefix and deletion unsuccessful
+            doReturn(false).when(this.swiftBlobStore).deleteByPath(testGridsetPrefix);
+            boolean outcome =
+                    this.swiftBlobStore.deleteByGridsetId(VALID_TEST_LAYER_NAME, testGridSetID);
+            verify(this.keyBuilder, times(1)).forGridset(VALID_TEST_LAYER_NAME, testGridSetID);
+            verify(this.swiftBlobStore, times(1)).deleteByPath(testGridsetPrefix);
+            verify(this.testListeners, times(0))
+                    .sendGridSubsetDeleted(VALID_TEST_LAYER_NAME, testGridSetID);
+            assertFalse(outcome);
+
+            // Test with a valid layer name and prefix and deletion successful
+            doReturn(true).when(this.swiftBlobStore).deleteByPath(testGridsetPrefix);
+            outcome = this.swiftBlobStore.deleteByGridsetId(VALID_TEST_LAYER_NAME, testGridSetID);
+            verify(this.keyBuilder, times(2)).forGridset(VALID_TEST_LAYER_NAME, testGridSetID);
+            verify(this.swiftBlobStore, times(2)).deleteByPath(testGridsetPrefix);
+            verify(this.testListeners, times(1))
+                    .sendGridSubsetDeleted(VALID_TEST_LAYER_NAME, testGridSetID);
+            assertTrue(outcome);
+        } catch (StorageException e) {
+            fail("Storage exception should not be thrown.\n" + e);
+        }
+
+        // Test when layer name is null
+        try {
+            this.swiftBlobStore.deleteByGridsetId(null, testGridSetID);
+            fail("Null check for layer name failed");
+        } catch (NullPointerException e) {
+            verify(this.keyBuilder, times(0)).forGridset(null, testGridSetID);
+            verify(this.testListeners, times(0)).sendGridSubsetDeleted(null, testGridSetID);
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+
+        // Test when grid set id is null
+        try {
+            this.swiftBlobStore.deleteByGridsetId(VALID_TEST_LAYER_NAME, null);
+            fail("Null check for grid check id failed");
+        } catch (NullPointerException e) {
+            verify(this.keyBuilder, times(0)).forGridset(VALID_TEST_LAYER_NAME, null);
+            verify(this.testListeners, times(0)).sendGridSubsetDeleted(VALID_TEST_LAYER_NAME, null);
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+    }
+
+    @Test
+    public void deleteByTileObject() {
+
+        TileObject tileObjectWithNullName = mock(TileObject.class);
+        when(tileObjectWithNullName.getLayerName()).thenReturn(null);
+
+        doReturn(true).when(this.swiftBlobStore).deleteByPath(VALID_TEST_LAYER_NAME);
+
+        // Test when layer name is null
+        try {
+            this.swiftBlobStore.delete(tileObjectWithNullName);
+            fail("Null check for grid check id failed");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("Object Name"));
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+
+        try {
+            // Test when listeners are empty
+            boolean result = this.swiftBlobStore.delete(sampleTileObject);
+            verify(this.swiftBlobStore, times(1)).deleteByPath(VALID_TEST_LAYER_NAME);
+            assertTrue(result);
+
+            // Make listeners not empty
+            BlobStoreListener testListener = mock(BlobStoreListener.class);
+            testListeners.addListener(testListener);
+
+            // Test when deletion successful
+            result = this.swiftBlobStore.delete(sampleTileObject);
+            verify(this.swiftBlobStore, times(2)).deleteByPath(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(1)).sendTileDeleted(sampleTileObject);
+            assertTrue(result);
+
+            // Test when deletion unsuccessful
+            when(objectApi.get(VALID_TEST_LAYER_NAME)).thenReturn(mock(SwiftObject.class));
+            doReturn(false).when(this.swiftBlobStore).deleteByPath(VALID_TEST_LAYER_NAME);
+            result = this.swiftBlobStore.delete(sampleTileObject);
+            verify(this.swiftBlobStore, times(3)).deleteByPath(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(1)).sendTileDeleted(sampleTileObject);
+            assertFalse(result);
+        } catch (StorageException e) {
+            fail("Should not throw an exception error.\n" + e);
+        }
+    }
+
+    @Test
+    public void rename() {
+        try {
+            // When old layer is null
+            boolean result = this.swiftBlobStore.rename(VALID_TEST_LAYER_NAME, "NewLayerName");
+            verify(objectApi, times(1)).get(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(0))
+                    .sendLayerRenamed(VALID_TEST_LAYER_NAME, "NewLayerName");
+            assertTrue(result);
+
+            // When old layer is not null
+            when(this.objectApi.get(VALID_TEST_LAYER_NAME)).thenReturn(mock(SwiftObject.class));
+            result = this.swiftBlobStore.rename(VALID_TEST_LAYER_NAME, "NewLayerName");
+            verify(objectApi, times(2)).get(VALID_TEST_LAYER_NAME);
+            verify(this.testListeners, times(1))
+                    .sendLayerRenamed(VALID_TEST_LAYER_NAME, "NewLayerName");
+            assertTrue(result);
+        } catch (StorageException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void clear() {
+        try {
+            this.swiftBlobStore.clear();
+            fail("This method should not work, it should throw a Unsupported Operation Exception");
+        } catch (UnsupportedOperationException e) {
+            assertThat(e.getMessage(), is("clear() should not be called"));
+        }
+    }
+
+    @Test
+    public void getLayerMetadata() {
+        SwiftObject swiftObject = mock(SwiftObject.class);
+        SwiftObject swiftObjectWithoutMetadata = mock(SwiftObject.class);
+
+        when(objectApi.get("")).thenReturn(null);
+        when(objectApi.get(INVALID_TEST_LAYER_NAME)).thenReturn(null);
+        when(objectApi.get(VALID_TEST_LAYER_NAME)).thenReturn(swiftObject);
+        when(objectApi.get("valid layer without metadata")).thenReturn(swiftObjectWithoutMetadata);
+
+        Map<String, String> sampleMetadata = new HashMap<>();
+        sampleMetadata.put("sample_key", "sample_value");
+
+        when(swiftObject.getMetadata()).thenReturn(sampleMetadata);
+        when(swiftObjectWithoutMetadata.getMetadata()).thenReturn(new HashMap<>());
+
+        // Test if layer name is empty
+        String result = this.swiftBlobStore.getLayerMetadata("", "sample_key");
+        assertEquals(null, result);
+
+        // Test if layer name is invalid
+        result = this.swiftBlobStore.getLayerMetadata(INVALID_TEST_LAYER_NAME, "sample_key");
+        assertEquals(null, result);
+
+        // Test if metadata is null
+        result =
+                this.swiftBlobStore.getLayerMetadata(
+                        "valid layer name without metadata", "sample_key");
+        assertEquals(null, result);
+
+        // Test when layer name is valid
+        result = this.swiftBlobStore.getLayerMetadata(VALID_TEST_LAYER_NAME, "sample_key");
+        verify(objectApi, times(1)).get(VALID_TEST_LAYER_NAME);
+        assertEquals("sample_value", result);
+
+        // Test when layer name is valid and key is invalid
+        result = this.swiftBlobStore.getLayerMetadata(VALID_TEST_LAYER_NAME, "");
+        verify(objectApi, times(1)).get("");
+        assertEquals(null, result);
+    }
+
+    @Test
+    public void putLayerMetadata() {
+
+        // Test when layer is null that the method does nothing
+        assertNull(this.objectApi.get(VALID_TEST_LAYER_NAME)); // null before
+        swiftBlobStore.putLayerMetadata(VALID_TEST_LAYER_NAME, "test_key", "test_value");
+        assertNull(this.objectApi.get(VALID_TEST_LAYER_NAME)); // null after therefore no metadata.
+
+        // Test when layer exists but there is no existing metadata
+        SwiftObject layer = mock(SwiftObject.class);
+        when(objectApi.get(VALID_TEST_LAYER_NAME)).thenReturn(layer);
+
+        swiftBlobStore.putLayerMetadata(VALID_TEST_LAYER_NAME, "test_key", "test_value");
+        verify(layer, times(1)).getMetadata();
+
+        Map<String, String> newMetadata = new HashMap<>();
+        newMetadata.put("test_key", "test_value");
+        verify(objectApi, times(1)).updateMetadata(VALID_TEST_LAYER_NAME, newMetadata);
+
+        // Test method when there is existing metadata such that it gets added to
+        Map<String, String> existingMetadata = new HashMap<>();
+        existingMetadata.put("sample_key", "sample_value");
+        when(layer.getMetadata()).thenReturn(existingMetadata);
+
+        swiftBlobStore.putLayerMetadata(VALID_TEST_LAYER_NAME, "test_key", "test_value");
+        verify(layer, times(2)).getMetadata();
+
+        Map<String, String> updatedMetadata = new HashMap<>();
+        updatedMetadata.put("test_key", "test_value");
+        updatedMetadata.put("sample_key", "sample_value");
+        verify(objectApi, times(1)).updateMetadata(VALID_TEST_LAYER_NAME, updatedMetadata);
+    }
+
+    @Test
+    public void layerExists() {
+        SwiftObject swiftObject = mock(SwiftObject.class);
+
+        // Test when layer does exist
+        when(objectApi.get(VALID_TEST_LAYER_NAME)).thenReturn(swiftObject);
+        assertTrue(swiftBlobStore.layerExists(VALID_TEST_LAYER_NAME));
+
+        // Test when layer doesn't exist
+        when(objectApi.get("layer which doesn't exist")).thenReturn(null);
+        assertFalse(swiftBlobStore.layerExists("layer which doesn't exist"));
+    }
+
+    @Test
+    public void getParametersMapping() {
+
+        // Setting up mock things
+        String prefixPath = "sample/prefix/path";
+        String testObjectName = "test object";
+
+        SwiftObject swiftObject = mock(SwiftObject.class);
+        when(swiftObject.getName()).thenReturn(testObjectName);
+        List<SwiftObject> swiftObjects = new ArrayList<>();
+        swiftObjects.add(swiftObject);
+
+        ObjectList swiftObjectList = ObjectList.create(swiftObjects, mock(Container.class));
+        ListContainerOptions options = new ListContainerOptions();
+        options.prefix(prefixPath);
+        when(this.objectApi.list(options)).thenReturn(swiftObjectList);
+        doReturn(prefixPath).when(this.keyBuilder).parametersMetadataPrefix(VALID_TEST_LAYER_NAME);
+
+        // Testing that the parameter mapping is correct when there is a valid layer but no
+        // metadata.
+        Map<String, Optional<Map<String, String>>> testResult =
+                swiftBlobStore.getParametersMapping(VALID_TEST_LAYER_NAME);
+        verify(keyBuilder, times(1)).parametersMetadataPrefix(VALID_TEST_LAYER_NAME);
+        verify(objectApi, times(1)).list(options);
+
+        Map<String, Optional<Map<String, String>>> expectedResult = new HashMap<>();
+        expectedResult.put(testObjectName, Optional.ofNullable(new HashMap<>()));
+        assertEquals(expectedResult, testResult);
+
+        // Testing that the parameter mapping is correct when there is a valid layer and valid
+        // metadata.
+        Map<String, String> objectMetadata = new HashMap<>();
+        objectMetadata.put("test_key", "test_value");
+        when(swiftObject.getMetadata()).thenReturn(objectMetadata);
+
+        testResult = swiftBlobStore.getParametersMapping(VALID_TEST_LAYER_NAME);
+
+        // Check if the correct methods were called
+        verify(keyBuilder, times(2)).parametersMetadataPrefix(VALID_TEST_LAYER_NAME);
+        verify(objectApi, times(2)).list(options);
+
+        // Check if the return value is as expected
+        Map<String, Optional<Map<String, String>>> expectedResultWithMetadata = new HashMap<>();
+        expectedResultWithMetadata.put(testObjectName, Optional.of(objectMetadata));
+        assertEquals(expectedResultWithMetadata, testResult);
+    }
+
+    @Test
+    public void deleteByParametersId() {
+        String testParametersId = "testParamId";
+
+        // Test when layer name is null
+        try {
+            this.swiftBlobStore.deleteByParametersId(null, testParametersId);
+            fail("Null check for layer name failed");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("layerName"));
+        } catch (StorageException e) {
+            fail(e.toString());
+        }
+
+        // Test when parameters id is null
+        try {
+            this.swiftBlobStore.deleteByParametersId(VALID_TEST_LAYER_NAME, null);
+            fail("Null check for parameters id failed");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("parametersId"));
+        } catch (StorageException e) {
+            fail(e.toString());
+        }
+
+        Set<String> dummyParamsPrefixes = new HashSet<>(Arrays.asList("prefix/one", "prefix/two"));
+        doReturn(dummyParamsPrefixes)
+                .when(this.keyBuilder)
+                .forParameters(VALID_TEST_LAYER_NAME, testParametersId);
+
+        try {
+            // Test outcome when all deletions are successful
+            doReturn(true).when(this.swiftBlobStore).deleteByPath("prefix/one");
+            doReturn(true).when(this.swiftBlobStore).deleteByPath("prefix/two");
+            boolean outcome =
+                    this.swiftBlobStore.deleteByParametersId(
+                            VALID_TEST_LAYER_NAME, testParametersId);
+            verify(this.swiftBlobStore, times(1)).deleteByPath("prefix/one");
+            verify(this.swiftBlobStore, times(1)).deleteByPath("prefix/two");
+            verify(this.testListeners, times(1))
+                    .sendParametersDeleted(VALID_TEST_LAYER_NAME, testParametersId);
+            assertTrue(outcome);
+
+            // Test outcome when one of the deletion fails
+            doReturn(false).when(this.swiftBlobStore).deleteByPath("prefix/one");
+            outcome =
+                    this.swiftBlobStore.deleteByParametersId(
+                            VALID_TEST_LAYER_NAME, testParametersId);
+            verify(this.swiftBlobStore, times(2)).deleteByPath("prefix/one");
+            verify(this.swiftBlobStore, times(2)).deleteByPath("prefix/two");
+            verify(this.testListeners, times(1))
+                    .sendParametersDeleted(VALID_TEST_LAYER_NAME, testParametersId);
+            assertFalse(outcome);
+        } catch (StorageException e) {
+            fail(e.toString());
+        }
+    }
+}

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -47,6 +47,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+/**
+ * Unit testing for the Swift Blobstore class
+ */
 public class SwiftBlobStoreTest {
 
     private SwiftBlobStore swiftBlobStore;

--- a/geowebcache/swiftblob/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/geowebcache/swiftblob/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>gwc-sqlite</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-swift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-servlet.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-servlet.xml
@@ -22,7 +22,7 @@
   <import resource="geowebcache-wmsservice-context.xml"/>
   <import resource="geowebcache-s3storage-context.xml"/>
   <import resource="geowebcache-sqlite-context.xml"/>
-
+  <import resource="geowebcache-swiftblob-context.xml"/>
   <import resource="geowebcache-diskquota-context.xml"/>
   <import resource="geowebcache-arcgiscache-context.xml"/>
   <import resource="geowebcache-distributed.xml"/>

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-swiftblob-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-swiftblob-context.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+  <description>
+   Bean configuration file for the gwc-swift module
+  </description>
+
+  <bean id="SwiftBlobStoreConfigProvider" class="org.geowebcache.swift.SwiftBlobStoreConfigProvider" depends-on="geoWebCacheEnvironment">
+    <description>
+      Contributes XStream configuration settings to org.geowebcache.config.XMLConfiguration to encode SwiftBlobStoreConfig instances
+    </description>
+  </bean>
+</beans>


### PR DESCRIPTION
Extension to GWC which adds native support for Swift. This allows OpenStack Cloud deployments to easily use GeoWebCache without the support from external libraries such as S3Proxy. This has been implemented using the open source multi-cloud toolkit jclouds (https://jclouds.apache.org/).

**Additions:**
- Swift Blobstore package containing blobstore class and supporting config provider classes
- Additions to configuration and pom files for swift
- Unit tests covering blobstore class
