### PR TITLE
Checkstyle maven 3.1.1

### DIFF
--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheStorageInfo.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheStorageInfo.java
@@ -54,8 +54,6 @@ public class CacheStorageInfo {
     /**
      * The storage format defined in the config file, defaults to {@link #EXPLODED_FORMAT_CODE
      * exploded format}
-     *
-     * @return
      */
     public String getStorageFormat() {
         return storageFormat;

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/SpatialReference.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/SpatialReference.java
@@ -124,20 +124,12 @@ public class SpatialReference {
         return WKID;
     }
 
-    /**
-     * New in ArcGIS 10.1+
-     *
-     * @return
-     */
+    /** New in ArcGIS 10.1+ */
     public int getLatestWKID() {
         return LatestWKID;
     }
 
-    /**
-     * Seems to be in ArcGIS 9.2 format only?
-     *
-     * @return
-     */
+    /** Seems to be in ArcGIS 9.2 format only? */
     public double getLeftLongitude() {
         return LeftLongitude;
     }

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/TileCacheInfo.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/TileCacheInfo.java
@@ -85,11 +85,7 @@ public class TileCacheInfo {
         return DPI;
     }
 
-    /**
-     * New in ArcGIS 10.1+
-     *
-     * @return
-     */
+    /** New in ArcGIS 10.1+ */
     public int getPreciseDPI() {
         return PreciseDPI;
     }

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
@@ -33,14 +33,7 @@ import org.springframework.util.Assert;
  */
 class GridSetBuilder {
 
-    /**
-     * Creates a {@link GridSet} out of a ArcGIS tiling scheme
-     *
-     * @param layerName
-     * @param info
-     * @param layerBounds
-     * @return
-     */
+    /** Creates a {@link GridSet} out of a ArcGIS tiling scheme */
     public GridSet buildGridset(
             final String layerName, final CacheInfo info, final BoundingBox layerBounds) {
 

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
@@ -102,9 +102,6 @@ class DeleteManager implements Closeable {
 
     /**
      * Executes the provided iterator of callables on the delete executor, returning their results
-     *
-     * @param callables
-     * @return
      */
     public void executeParallel(List<Callable> callables) throws StorageException {
         List<Future> futures = new ArrayList<>();

--- a/geowebcache/checkstyle.xml
+++ b/geowebcache/checkstyle.xml
@@ -13,11 +13,7 @@
   <module name="TreeWalker">
     <module name="JavadocMethod">
       <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowMissingJavadoc" value="true"/>
-      <property name="allowMissingPropertyJavadoc" value="true"/>
-      <property name="suppressLoadErrors" value="true"/>
     </module>
   </module>
   <module name="RegexpHeader">

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -101,12 +101,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
 
     private SecurityDispatcher securityDispatcher;
 
-    /**
-     * Should be invoked through Spring
-     *
-     * @param tileLayerDispatcher
-     * @param gridSetBroker
-     */
+    /** Should be invoked through Spring */
     public GeoWebCacheDispatcher(
             TileLayerDispatcher tileLayerDispatcher,
             GridSetBroker gridSetBroker,
@@ -141,8 +136,6 @@ public class GeoWebCacheDispatcher extends AbstractController {
     /**
      * GeoServer and other solutions that embedded this dispatcher will prepend a path, this is used
      * to remove it.
-     *
-     * @param servletPrefix
      */
     public void setServletPrefix(String servletPrefix) {
         if (!servletPrefix.startsWith("/")) {
@@ -167,8 +160,6 @@ public class GeoWebCacheDispatcher extends AbstractController {
      *
      * <p>The application context is scanned for objects extending Service, thereby making it easy
      * to add new services.
-     *
-     * @return
      */
     private Map<String, Service> loadServices() {
         log.info("Loading GWC Service extensions...");
@@ -361,7 +352,6 @@ public class GeoWebCacheDispatcher extends AbstractController {
     /**
      * Essentially this slices away the prefix, leaving type and request
      *
-     * @param servletPath
      * @return {type, service}ervletPrefix
      */
     private String[] parseRequest(String servletPath) throws GeoWebCacheException {
@@ -379,13 +369,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
         return retStrs;
     }
 
-    /**
-     * This is the main method for handling service requests. See comments in the code.
-     *
-     * @param request
-     * @param response
-     * @throws Exception
-     */
+    /** This is the main method for handling service requests. See comments in the code. */
     private void handleServiceRequest(
             String serviceStr, HttpServletRequest request, HttpServletResponse response)
             throws Exception {
@@ -441,7 +425,6 @@ public class GeoWebCacheDispatcher extends AbstractController {
      * Helper function for looking up the service that should handle the request.
      *
      * @param serviceStr name of the service
-     * @return
      */
     private Service findService(String serviceStr) throws GeoWebCacheException {
         if (this.services == null) {
@@ -462,12 +445,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
         return service;
     }
 
-    /**
-     * Create a minimalistic frontpage
-     *
-     * @param request
-     * @param response
-     */
+    /** Create a minimalistic frontpage */
     private void handleFrontPage(HttpServletRequest request, HttpServletResponse response) {
 
         String baseUrl = null;
@@ -727,11 +705,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
         return securityDispatcher;
     }
 
-    /**
-     * Set the security dispatcher to use to test service requests.
-     *
-     * @param secDispatcher
-     */
+    /** Set the security dispatcher to use to test service requests. */
     public void setSecurityDispatcher(SecurityDispatcher secDispatcher) {
         this.securityDispatcher = secDispatcher;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheEnvironment.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheEnvironment.java
@@ -136,9 +136,6 @@ public class GeoWebCacheEnvironment {
      *
      * <p>The method first looks for System variables which take precedence on local ones, then into
      * internal props injected through the applicationContext.
-     *
-     * @param value
-     * @return
      */
     public Object resolveValue(Object value) {
         if (value != null) {

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheExtensions.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheExtensions.java
@@ -198,8 +198,6 @@ public class GeoWebCacheExtensions implements ApplicationContextAware, Applicati
      * Return a list of configurations in priority order.
      *
      * @param extensionPoint The extension point of the configuration, may affect priority.
-     * @param context
-     * @return
      */
     public static <T extends BaseConfiguration> List<T> configurations(
             Class<T> extensionPoint, ApplicationContext context) {
@@ -217,18 +215,12 @@ public class GeoWebCacheExtensions implements ApplicationContextAware, Applicati
      * Return a list of configurations in priority order.
      *
      * @param extensionPoint The extension point of the configuration, may affect priority.
-     * @return
      */
     public static <T extends BaseConfiguration> List<T> configurations(Class<T> extensionPoint) {
         return configurations(extensionPoint, context);
     }
 
-    /**
-     * Reinitialize all reinitializable beans in the context.
-     *
-     * @param context
-     * @throws GeoWebCacheException
-     */
+    /** Reinitialize all reinitializable beans in the context. */
     public static void reinitialize(ApplicationContext context) {
         List<ReinitializingBean> extensions = extensions(ReinitializingBean.class, context);
         for (ReinitializingBean bean : extensions) {
@@ -266,12 +258,7 @@ public class GeoWebCacheExtensions implements ApplicationContextAware, Applicati
         }
     }
 
-    /**
-     * Returns a specific bean given its name
-     *
-     * @param name
-     * @return
-     */
+    /** Returns a specific bean given its name */
     public static final Object bean(String name) {
         return bean(name, context);
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/BaseConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/BaseConfiguration.java
@@ -38,21 +38,12 @@ public interface BaseConfiguration
      */
     String getLocation();
 
-    /**
-     * Priority for sorting against other configurations of the specified type.
-     *
-     * @param clazz
-     * @return
-     */
+    /** Priority for sorting against other configurations of the specified type. */
     default int getPriority(Class<? extends BaseConfiguration> clazz) {
         return BASE_PRIORITY;
     }
 
-    /**
-     * Priority for sorting against other priority extensions.
-     *
-     * @return
-     */
+    /** Priority for sorting against other priority extensions. */
     @Override
     default int getPriority() {
         return getPriority(BaseConfiguration.class);

--- a/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreConfiguration.java
@@ -118,17 +118,11 @@ public interface BlobStoreConfiguration extends BaseConfiguration {
      */
     boolean containsBlobStore(String name);
 
-    /**
-     * Adds a {@link BlobStoreConfigurationListener} to this configuration.
-     *
-     * @param listener
-     */
+    /** Adds a {@link BlobStoreConfigurationListener} to this configuration. */
     void addBlobStoreListener(BlobStoreConfigurationListener listener);
 
     /**
      * Removes a {@link BlobStoreConfigurationListener} from this configuration, if it is present.
-     *
-     * @param listener
      */
     void removeBlobStoreListener(BlobStoreConfigurationListener listener);
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/BlobStoreInfo.java
@@ -145,8 +145,6 @@ public abstract class BlobStoreInfo implements Serializable, Cloneable, Info {
      *
      * <p>May only be called if {@link #isEnabled() == true}.
      *
-     * @param layers
-     * @param lockProvider
      * @return A BlobStore implementation.
      * @throws StorageException if the blob store can't be created with this configuration settings
      * @throws IllegalStateException if {@link #isEnabled() isEnabled() == false} or {@link #getId()

--- a/geowebcache/core/src/main/java/org/geowebcache/config/ConfigurationResourceProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/ConfigurationResourceProvider.java
@@ -25,28 +25,13 @@ import java.io.OutputStream;
  */
 public interface ConfigurationResourceProvider {
 
-    /**
-     * Create inputstream
-     *
-     * @return
-     * @throws IOException
-     * @throws ConfigurationException
-     */
+    /** Create inputstream */
     public InputStream in() throws IOException;
 
-    /**
-     * Create outputstream
-     *
-     * @throws IOException
-     * @throws ConfigurationException
-     */
+    /** Create outputstream */
     public OutputStream out() throws IOException;
 
-    /**
-     * Make a backup
-     *
-     * @throws IOException
-     */
+    /** Make a backup */
     public void backup() throws IOException;
 
     /** @return identifier for this resource */

--- a/geowebcache/core/src/main/java/org/geowebcache/config/DefaultingConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/DefaultingConfiguration.java
@@ -23,8 +23,6 @@ public interface DefaultingConfiguration extends BaseConfiguration {
      * TileLayerConfiguration objects lacking their own defaults can delegate to this. Should set
      * values in the default geowebcache.xml to the TileLayer configuration, and fall back on
      * implemented default values if missing.
-     *
-     * @param layer
      */
     void setDefaultValues(TileLayer layer);
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/FileBlobStoreInfo.java
@@ -97,11 +97,7 @@ public class FileBlobStoreInfo extends BlobStoreInfo {
         this.fileSystemBlockSize = fileSystemBlockSize;
     }
 
-    /**
-     * Returns the path generator for this blob store, by default, it's
-     *
-     * @return
-     */
+    /** Returns the path generator for this blob store, by default, it's */
     public PathGeneratorType getPathGeneratorType() {
         return pathGeneratorType;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
@@ -222,7 +222,6 @@ public class GeoWebCacheConfiguration {
      * Returns the chosen lock provider
      *
      * @see ServerConfiguration#getLockProvider()
-     * @return
      */
     public LockProvider getLockProvider() {
         if (lockProviderInstance == null) {

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GridSetConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GridSetConfiguration.java
@@ -27,8 +27,6 @@ public interface GridSetConfiguration extends BaseConfiguration {
     /**
      * Get a GridSet by name
      *
-     * @param name
-     * @return
      * @throw NoSuchElementException if the named gridset is not available.
      */
     Optional<GridSet> getGridSet(final String name);
@@ -55,7 +53,6 @@ public interface GridSetConfiguration extends BaseConfiguration {
     /**
      * Removes an existing gridset from the configuration
      *
-     * @param gridSetName
      * @throws NoSuchElementException If there is no existing gridset by that name.
      * @throws UnsupportedOperationException if removing this gridset is not supported
      */

--- a/geowebcache/core/src/main/java/org/geowebcache/config/ListenerCollection.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/ListenerCollection.java
@@ -31,22 +31,14 @@ public class ListenerCollection<Listener> {
 
     List<Listener> listeners = new LinkedList<>();
 
-    /**
-     * Add a listener
-     *
-     * @param listener
-     */
+    /** Add a listener */
     public synchronized void add(Listener listener) {
         if (!listeners.contains(listener)) {
             listeners.add(listener);
         }
     }
 
-    /**
-     * Remove a listener
-     *
-     * @param listener
-     */
+    /** Remove a listener */
     public synchronized void remove(Listener listener) {
         listeners.remove(listener);
     }
@@ -61,10 +53,6 @@ public class ListenerCollection<Listener> {
      * execute. If more than one exception is thrown, the last will be the one propagated, with the
      * others added as suppressed exceptions. If an Error is thrown, it will be propagated
      * immediately.
-     *
-     * @param method
-     * @throws GeoWebCacheException
-     * @throws IOException
      */
     public synchronized void safeForEach(HandlerMethod<Listener> method)
             throws GeoWebCacheException, IOException {

--- a/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
@@ -34,11 +34,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     ServiceInformation getServiceInformation();
 
-    /**
-     * Used to set the service information for this configuration.
-     *
-     * @param serviceInfo
-     */
+    /** Used to set the service information for this configuration. */
     void setServiceInformation(ServiceInformation serviceInfo) throws IOException;
 
     /**
@@ -50,11 +46,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     Boolean isRuntimeStatsEnabled();
 
-    /**
-     * Set if runtime statistics is enabled for this configuration, True or False.
-     *
-     * @param isEnabled
-     */
+    /** Set if runtime statistics is enabled for this configuration, True or False. */
     void setRuntimeStatsEnabled(Boolean isEnabled) throws IOException;
 
     /**
@@ -64,11 +56,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     LockProvider getLockProvider();
 
-    /**
-     * Set the lock provider for this configuration.
-     *
-     * @param lockProvider
-     */
+    /** Set the lock provider for this configuration. */
     void setLockProvider(LockProvider lockProvider) throws IOException;
 
     /**
@@ -78,11 +66,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     Boolean isFullWMS();
 
-    /**
-     * Used to set fullWMS is parameter for this configuration if present.
-     *
-     * @param isFullWMS
-     */
+    /** Used to set fullWMS is parameter for this configuration if present. */
     void setFullWMS(Boolean isFullWMS) throws IOException;
 
     /**
@@ -110,10 +94,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     Integer getBackendTimeout();
 
-    /**
-     * @param backendTimeout
-     * @throws IOException
-     */
+    /** */
     void setBackendTimeout(Integer backendTimeout) throws IOException;
 
     /**
@@ -124,16 +105,9 @@ public interface ServerConfiguration extends BaseConfiguration {
      */
     Boolean isCacheBypassAllowed();
 
-    /**
-     * @param cacheBypassAllowed
-     * @throws IOException
-     */
+    /** */
     void setCacheBypassAllowed(Boolean cacheBypassAllowed) throws IOException;
 
-    /**
-     * The version number should match the XSD namespace and the version of GWC
-     *
-     * @return
-     */
+    /** The version number should match the XSD namespace and the version of GWC */
     String getVersion();
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/TileLayerConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/TileLayerConfiguration.java
@@ -119,10 +119,6 @@ public interface TileLayerConfiguration extends BaseConfiguration {
      */
     boolean canSave(TileLayer tl);
 
-    /**
-     * Set the GridSetBroker
-     *
-     * @param broker
-     */
+    /** Set the GridSetBroker */
     void setGridSetBroker(GridSetBroker broker);
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -131,7 +131,6 @@ public class XMLConfiguration
      * Base Constructor with custom ConfiguratioNResourceProvider
      *
      * @param appCtx use to lookup {@link XMLConfigurationProvider} extensions, may be {@code null}
-     * @param inFac
      */
     public XMLConfiguration(
             final ApplicationContextProvider appCtx, final ConfigurationResourceProvider inFac) {
@@ -143,9 +142,6 @@ public class XMLConfiguration
      * File System based Constructor
      *
      * @param appCtx use to lookup {@link XMLConfigurationProvider} extensions, may be {@code null}
-     * @param configFileDirectory
-     * @param storageDirFinder
-     * @throws ConfigurationException
      */
     public XMLConfiguration(
             final ApplicationContextProvider appCtx,
@@ -167,8 +163,6 @@ public class XMLConfiguration
      * storageDirFinder}
      *
      * @param appCtx use to lookup {@link XMLConfigurationProvider} extenions, may be {@code null}
-     * @param storageDirFinder
-     * @throws ConfigurationException
      */
     public XMLConfiguration(
             final ApplicationContextProvider appCtx, final DefaultStorageFinder storageDirFinder)
@@ -182,10 +176,6 @@ public class XMLConfiguration
 
     /**
      * Constructor that will accept an absolute or relative path for finding {@code geowebcache.xml}
-     *
-     * @param appCtx
-     * @param configFileDirectory
-     * @throws ConfigurationException
      */
     public XMLConfiguration(
             final ApplicationContextProvider appCtx, final String configFileDirectory)
@@ -193,19 +183,12 @@ public class XMLConfiguration
         this(appCtx, configFileDirectory, null);
     }
 
-    /**
-     * Path to template to use when there is no config file.
-     *
-     * @param template
-     */
+    /** Path to template to use when there is no config file. */
     public void setTemplate(String template) {
         resourceProvider.setTemplate(template);
     }
 
-    /**
-     * @return The root path where configuration is stored
-     * @throws ConfigurationException
-     */
+    /** @return The root path where configuration is stored */
     public String getConfigLocation() throws ConfigurationException {
         try {
             return resourceProvider.getLocation();
@@ -223,10 +206,7 @@ public class XMLConfiguration
         }
     }
 
-    /**
-     * @see ServerConfiguration#setRuntimeStatsEnabled(Boolean)
-     * @param isEnabled
-     */
+    /** @see ServerConfiguration#setRuntimeStatsEnabled(Boolean) */
     public void setRuntimeStatsEnabled(Boolean isEnabled) throws IOException {
         getGwcConfig().setRuntimeStats(isEnabled);
         save();
@@ -237,20 +217,13 @@ public class XMLConfiguration
         return getGwcConfig().getServiceInformation();
     }
 
-    /**
-     * @see ServerConfiguration#setServiceInformation(ServiceInformation);
-     * @param serviceInfo
-     */
+    /** @see ServerConfiguration#setServiceInformation(ServiceInformation); */
     public void setServiceInformation(ServiceInformation serviceInfo) throws IOException {
         getGwcConfig().setServiceInformation(serviceInfo);
         save();
     }
 
-    /**
-     * TileLayerConfiguration objects lacking their own defaults can delegate to this
-     *
-     * @param layer
-     */
+    /** TileLayerConfiguration objects lacking their own defaults can delegate to this */
     @Override
     public void setDefaultValues(TileLayer layer) {
         // Additional values that can have defaults set
@@ -545,7 +518,6 @@ public class XMLConfiguration
 
     /**
      * @param tl the layer to add to this configuration
-     * @return
      * @throws IllegalArgumentException if a layer named the same than {@code tl} already exists
      * @see TileLayerConfiguration#addLayer(org.geowebcache.layer.TileLayer)
      */
@@ -579,7 +551,6 @@ public class XMLConfiguration
      * Method responsible for modifying an existing layer.
      *
      * @param tl the new layer to overwrite the existing layer
-     * @throws NoSuchElementException
      * @see TileLayerConfiguration#modifyLayer(org.geowebcache.layer.TileLayer)
      */
     public synchronized void modifyLayer(TileLayer tl) throws NoSuchElementException {
@@ -647,10 +618,7 @@ public class XMLConfiguration
         }
     }
 
-    /**
-     * @param gridSet
-     * @throws GeoWebCacheException
-     */
+    /** */
     private synchronized void addOrReplaceGridSet(final XMLGridSet gridSet)
             throws IllegalArgumentException {
         final String gridsetName = gridSet.getName();
@@ -991,10 +959,7 @@ public class XMLConfiguration
         return null;
     }
 
-    /**
-     * @see ServerConfiguration#setFullWMS(Boolean)
-     * @param isFullWMS
-     */
+    /** @see ServerConfiguration#setFullWMS(Boolean) */
     @Override
     public void setFullWMS(Boolean isFullWMS) throws IOException {
         getGwcConfig().setFullWMS(isFullWMS);
@@ -1296,10 +1261,7 @@ public class XMLConfiguration
         return getGwcConfig().getLockProvider();
     }
 
-    /**
-     * @see ServerConfiguration#setLockProvider(LockProvider)
-     * @param lockProvider
-     */
+    /** @see ServerConfiguration#setLockProvider(LockProvider) */
     @Override
     public void setLockProvider(LockProvider lockProvider) throws IOException {
         getGwcConfig().setLockProvider(lockProvider);

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfigurationProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfigurationProvider.java
@@ -39,7 +39,6 @@ public interface XMLConfigurationProvider {
      * Returns true if XStream has been configured to persist the given Info object.
      *
      * @param i The info object
-     * @return
      */
     boolean canSave(Info i);
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLFileResourceProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLFileResourceProvider.java
@@ -122,8 +122,6 @@ public class XMLFileResourceProvider implements ConfigurationResourceProvider {
      * storageDirFinder}
      *
      * @param appCtx use to lookup {@link XMLConfigurationProvider} extenions, may be {@code null}
-     * @param storageDirFinder
-     * @throws ConfigurationException
      */
     public XMLFileResourceProvider(
             final String configFileName,
@@ -142,8 +140,6 @@ public class XMLFileResourceProvider implements ConfigurationResourceProvider {
      * storageDirFinder}
      *
      * @param appCtx use to lookup {@link XMLConfigurationProvider} extenions, may be {@code null}
-     * @param storageDirFinder
-     * @throws ConfigurationException
      */
     public XMLFileResourceProvider(
             final String configFileName,

--- a/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/conveyor/ConveyorTile.java
@@ -147,11 +147,7 @@ public class ConveyorTile extends Conveyor implements TileResponseReceiver {
         return tileLayer;
     }
 
-    /**
-     * The time that the stored tile resource was created
-     *
-     * @return
-     */
+    /** The time that the stored tile resource was created */
     public long getTSCreated() {
         return stObj.getCreated();
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/CaseNormalizer.java
@@ -61,7 +61,6 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
          *
          * @param input string to normalize
          * @param loc locale to use for case changes
-         * @return
          */
         public abstract String apply(String input, Locale loc);
     }
@@ -91,18 +90,13 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
     /**
      * Apply normalisation to given string. Guaranteed to be idempotent.
      *
-     * @param input
      * @return The normalised string.
      */
     public String apply(String input) {
         return getCase().apply(input, getLocale());
     }
 
-    /**
-     * Get the case
-     *
-     * @return
-     */
+    /** Get the case */
     public Case getCase() {
         if (kase == null) {
             return Case.NONE;
@@ -111,20 +105,12 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
         }
     }
 
-    /**
-     * Set the case
-     *
-     * @param kase
-     */
+    /** Set the case */
     public void setCase(Case kase) {
         this.kase = kase;
     }
 
-    /**
-     * Get the locale. If unset, the default locale will be returned.
-     *
-     * @return
-     */
+    /** Get the locale. If unset, the default locale will be returned. */
     public Locale getLocale() {
         if (locale == null) {
             return Locale.getDefault();
@@ -133,11 +119,7 @@ public class CaseNormalizer implements Function<String, String>, Serializable, C
         }
     }
 
-    /**
-     * Get the locale. If unset, returns {@code null}.
-     *
-     * @return
-     */
+    /** Get the locale. If unset, returns {@code null}. */
     public @Nullable Locale getConfiguredLocale() {
         return locale;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -37,10 +37,7 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         // Empty for XStream
     }
 
-    /**
-     * @param key
-     * @param defaultValue
-     */
+    /** */
     public ParameterFilter(String key, @Nullable String defaultValue) {
         Preconditions.checkNotNull(key);
         Preconditions.checkArgument(!key.isEmpty(), "Parameter key must not be empty.");
@@ -53,20 +50,12 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         this(key, "");
     }
 
-    /**
-     * Get the key of the parameter to filter.
-     *
-     * @return
-     */
+    /** Get the key of the parameter to filter. */
     public String getKey() {
         return key;
     }
 
-    /**
-     * Get the default value to use if the parameter is not specified.
-     *
-     * @return
-     */
+    /** Get the default value to use if the parameter is not specified. */
     public String getDefaultValue() {
         if (defaultValue == null) return "";
         return defaultValue;
@@ -141,13 +130,7 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         return this;
     }
 
-    /**
-     * Is the given value exactly a value that could be produced by the filter.
-     *
-     * @param value
-     * @return
-     * @throws ParameterException
-     */
+    /** Is the given value exactly a value that could be produced by the filter. */
     public boolean isFilteredValue(final String value) {
         if (Objects.equal(value, this.getDefaultValue())) {
             return true;

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParametersUtils.java
@@ -35,9 +35,6 @@ public class ParametersUtils {
      * This should be treated as an opaque Identifier and should not be parsed, it is used to to
      * maintain compatibility with old caches. For any other uses, {@link #getKvp(Map)} is preferred
      * as it uses safe escaping of values.
-     *
-     * @param parameters
-     * @return
      */
     public static String getLegacyParametersKvp(Map<String, String> parameters) {
         StringBuilder sb = new StringBuilder();
@@ -84,12 +81,7 @@ public class ParametersUtils {
         return (t1, t2) -> derivation.apply(t1).compareTo(derivation.apply(t2));
     }
 
-    /**
-     * Turns the parameter list into a sorted KVP string
-     *
-     * @param parameters
-     * @return
-     */
+    /** Turns the parameter list into a sorted KVP string */
     public static String getKvp(Map<String, String> parameters) {
         return parameters
                 .entrySet()
@@ -104,9 +96,6 @@ public class ParametersUtils {
      *
      * <p>This should only be used for parsing strings created by {@link #getKvp(Map)} not for
      * parsing raw query strings
-     *
-     * @param kvp
-     * @return
      */
     public static Map<String, String> getMap(String kvp) {
         return Arrays.stream(kvp.split("&"))
@@ -115,12 +104,7 @@ public class ParametersUtils {
                 .collect(Collectors.toMap(p -> decUTF8(p[0]), p -> decUTF8(p[1])));
     }
 
-    /**
-     * Returns the parameters identifier for the given parameters map
-     *
-     * @param parameters
-     * @return
-     */
+    /** Returns the parameters identifier for the given parameters map */
     public static String getId(Map<String, String> parameters) {
         if (parameters == null || parameters.size() == 0) {
             return null;

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/RegexParameterFilter.java
@@ -40,12 +40,7 @@ public class RegexParameterFilter extends CaseNormalizingParameterFilter {
         pat = compile(regex, getNormalize().getCase());
     }
 
-    /**
-     * Get a {@link Matcher} for this filter's regexp against the given string.
-     *
-     * @param value
-     * @return
-     */
+    /** Get a {@link Matcher} for this filter's regexp against the given string. */
     public synchronized Matcher getMatcher(String value) {
         return pat.matcher(value);
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/request/RasterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/request/RasterFilter.java
@@ -222,13 +222,7 @@ public abstract class RasterFilter extends RequestFilter {
         }
     }
 
-    /**
-     * Performs a lookup against an internal raster.
-     *
-     * @param grid
-     * @param idx
-     * @return
-     */
+    /** Performs a lookup against an internal raster. */
     private boolean lookup(GridSubset grid, long[] idx) {
         BufferedImage mat = matrices.get(grid.getName())[(int) idx[2]];
 
@@ -244,10 +238,6 @@ public abstract class RasterFilter extends RequestFilter {
     /**
      * Performs a lookup against an internal raster. The sampling is actually done against 4 pixels,
      * idx should already have been modified to use one level higher than strictly necessary.
-     *
-     * @param grid
-     * @param idx
-     * @return
      */
     private boolean lookupQuad(GridSubset grid, long[] idx) {
         BufferedImage mat = matrices.get(grid.getName())[(int) idx[2]];
@@ -373,7 +363,6 @@ public abstract class RasterFilter extends RequestFilter {
      * This function will load the matrix from the appropriate source.
      *
      * @param layer Access to the layer, to make the object simpler
-     * @param gridSetId
      * @param z (zoom level)
      * @param replace Whether to update if a matrix exists
      */
@@ -405,14 +394,7 @@ public abstract class RasterFilter extends RequestFilter {
         }
     }
 
-    /**
-     * Helper function for calculating width and height
-     *
-     * @param grid
-     * @param z
-     * @return
-     * @throws GeoWebCacheException
-     */
+    /** Helper function for calculating width and height */
     protected int[] calculateWidthHeight(GridSubset grid, int z) throws GeoWebCacheException {
         long[] bounds = grid.getCoverage(z);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/request/RequestFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/request/RequestFilter.java
@@ -26,18 +26,11 @@ public abstract class RequestFilter implements Serializable {
 
     private String name;
 
-    /**
-     * Apply the filter to the
-     *
-     * @param convTile
-     * @throws RequestFilterException
-     */
+    /** Apply the filter to the */
     public abstract void apply(ConveyorTile convTile) throws RequestFilterException;
 
     /**
      * The name of the filter, as chosen by the user. It should be unique, but this is not enforced.
-     *
-     * @return
      */
     public String getName() {
         return name;

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/request/WMSRasterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/request/WMSRasterFilter.java
@@ -169,15 +169,7 @@ public class WMSRasterFilter extends RasterFilter {
         return img;
     }
 
-    /**
-     * Generates the URL used to create the lookup raster
-     *
-     * @param layer
-     * @param gridSubset
-     * @param z
-     * @param widthHeight
-     * @return
-     */
+    /** Generates the URL used to create the lookup raster */
     protected Map<String, String> wmsParams(
             WMSLayer layer, GridSubset gridSubset, int z, int[] widthHeight)
             throws GeoWebCacheException {

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityDispatcher.java
@@ -41,7 +41,6 @@ public class SecurityDispatcher implements ApplicationContextAware {
     /**
      * Apply security filters to a conveyor.
      *
-     * @param tile
      * @throws SecurityException if any of the filter throw it
      */
     public void checkSecurity(final ConveyorTile tile)
@@ -64,9 +63,6 @@ public class SecurityDispatcher implements ApplicationContextAware {
     /**
      * Apply all filters to a bounding box within a layer
      *
-     * @param layer
-     * @param extent
-     * @param srs
      * @throws SecurityException if any of the filter throw it
      */
     public void checkSecurity(TileLayer layer, @Nullable BoundingBox extent, @Nullable SRS srs)

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityFilter.java
@@ -26,9 +26,6 @@ public interface SecurityFilter {
      * Check that the the specified extent is allowed for the specified layer and throw an exception
      * if not.
      *
-     * @param layer
-     * @param extent
-     * @param srs
      * @throws SecurityException if the request is not allowed.
      */
     public void checkSecurity(TileLayer layer, @Nullable BoundingBox extent, @Nullable SRS srs)

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
@@ -128,11 +128,7 @@ public class BoundingBox implements Serializable {
         return coords[3] - coords[1];
     }
 
-    /**
-     * Sets from an array of strings
-     *
-     * @param BBOX
-     */
+    /** Sets from an array of strings */
     public void setFromStringArray(String[] BBOX) {
         setFromStringArray(BBOX, 0);
     }
@@ -151,11 +147,7 @@ public class BoundingBox implements Serializable {
         }
     }
 
-    /**
-     * Parses the BBOX parameters from a comma separted value list
-     *
-     * @param BBOX
-     */
+    /** Parses the BBOX parameters from a comma separted value list */
     public void setFromBBOXString(String BBOX, int recWatch) {
         String[] tokens = BBOX.split(DELIMITER);
         setFromStringArray(tokens, recWatch + 1);
@@ -228,7 +220,6 @@ public class BoundingBox implements Serializable {
     /**
      * Comparing whether the differences between the bounding boxes can be ignored.
      *
-     * @param obj
      * @return whether the boxes are equal
      */
     @Override
@@ -250,7 +241,6 @@ public class BoundingBox implements Serializable {
     /**
      * Check whether this bbox contains the bbox
      *
-     * @param other
      * @return whether other is contained by this
      */
     public boolean contains(BoundingBox other) {

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSet.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSet.java
@@ -331,9 +331,6 @@ public class GridSet implements Info {
      * idea)
      *
      * <p>Used for WMTS GetCapabilities
-     *
-     * @param gridIndex
-     * @return
      */
     public double[] getOrderedTopLeftCorner(int gridIndex) {
         // First we will find the x,y pair, then we'll flip it if necessary
@@ -526,7 +523,6 @@ public class GridSet implements Info {
      * except if both the grids of {@code another} are a superset of the grids of this gridset (i.e.
      * they are all the same but {@code another} just has more zoom levels}.
      *
-     * @param another
      * @return {@code true} if
      */
     public boolean shouldTruncateIfChanged(final GridSet another) {

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetBroker.java
@@ -136,9 +136,6 @@ public class GridSetBroker
      *
      * <p>This method doesn't check whether there's any layer referencing the gridset nor removes it
      * from the {@link XMLConfiguration}.
-     *
-     * @param gridSetName
-     * @return
      */
     public synchronized GridSet remove(final String gridSetName) {
         return getGridSet(gridSetName)

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetFactory.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSetFactory.java
@@ -49,17 +49,6 @@ public class GridSetFactory {
     /**
      * Note that you should provide EITHER resolutions or scales. Providing both will cause a
      * precondition violation exception.
-     *
-     * @param name
-     * @param srs
-     * @param extent
-     * @param resolutions
-     * @param scaleDenoms
-     * @param tileWidth
-     * @param tileHeight
-     * @param pixelSize
-     * @param yCoordinateFirst
-     * @return
      */
     public static GridSet createGridSet(
             final String name,

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSubset.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSubset.java
@@ -189,11 +189,7 @@ public class GridSubset {
         return ret;
     }
 
-    /**
-     * Convert pixel size to dots per inch
-     *
-     * @return
-     */
+    /** Convert pixel size to dots per inch */
     public double getDotsPerInch() {
         return (0.0254 / this.gridSet.getPixelSize());
     }
@@ -391,8 +387,6 @@ public class GridSubset {
     /**
      * WMTS is indexed from top left hand corner. We will still return {minx,miny,maxx,maxy}, but
      * note that the y positions have been reversed
-     *
-     * @return
      */
     // TODO: this is specific to WMTS, move it somewhere on the wmts module
     // TODO: Does this need to be public?
@@ -443,11 +437,7 @@ public class GridSubset {
         return maxCachedZoom;
     }
 
-    /**
-     * Whether the Grid Subset equals or exceeds the extent of the Grid Set
-     *
-     * @return
-     */
+    /** Whether the Grid Subset equals or exceeds the extent of the Grid Set */
     public boolean fullGridSetCoverage() {
         return fullGridSetCoverage;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridUtil.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridUtil.java
@@ -19,11 +19,6 @@ import java.util.List;
 public class GridUtil {
 
     /**
-     * @param reqBounds
-     * @param crsMatchingGridSubsets
-     * @param expectedTileWidth
-     * @param expectedTileHeight
-     * @param matchingTileIndexTarget
      * @return null if none matches, the gridset with a tile index closest to the requested bounds
      *     and dimensions otherwise
      */

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/SRS.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/SRS.java
@@ -78,9 +78,6 @@ public class SRS implements Comparable<SRS>, Serializable {
      * looked up that has an alias defined for the given code, and if found the alias is returned.
      * If no SRS is registered nor an alias is found, a new SRS for this code is registered and
      * returned.
-     *
-     * @param epsgCode
-     * @return
      */
     public static SRS getSRS(final int epsgCode) {
         final Integer code = Integer.valueOf(epsgCode);

--- a/geowebcache/core/src/main/java/org/geowebcache/io/ByteArrayResource.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/ByteArrayResource.java
@@ -141,11 +141,7 @@ public class ByteArrayResource implements Resource, Serializable {
         return new SeekableInputStream(this);
     }
 
-    /**
-     * Get the contents of the resource.
-     *
-     * @return
-     */
+    /** Get the contents of the resource. */
     public byte[] getContents() {
         if (data == null || length == 0) {
             return null;

--- a/geowebcache/core/src/main/java/org/geowebcache/io/Resource.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/Resource.java
@@ -22,11 +22,7 @@ import java.nio.channels.WritableByteChannel;
 
 public interface Resource {
 
-    /**
-     * The size of the resource in bytes.
-     *
-     * @return
-     */
+    /** The size of the resource in bytes. */
     public long getSize();
 
     /**
@@ -34,7 +30,6 @@ public interface Resource {
      *
      * @param channel the channel to write too
      * @return The number of bytes written
-     * @throws IOException
      */
     public long transferTo(WritableByteChannel channel) throws IOException;
 
@@ -43,31 +38,19 @@ public interface Resource {
      *
      * @param channel the channel to read from
      * @return The number of bytes read
-     * @throws IOException
      */
     public long transferFrom(ReadableByteChannel channel) throws IOException;
 
-    /**
-     * An InputStream backed by the resource.
-     *
-     * @return
-     * @throws IOException
-     */
+    /** An InputStream backed by the resource. */
     public InputStream getInputStream() throws IOException;
 
-    /**
-     * An OutputStream backed by the resource. Writes are appended to the resource.
-     *
-     * @return
-     * @throws IOException
-     */
+    /** An OutputStream backed by the resource. Writes are appended to the resource. */
     public OutputStream getOutputStream() throws IOException;
 
     /**
      * The time the resource was last modified.
      *
      * @see java.lang.System#currentTimeMillis
-     * @return
      */
     public long getLastModified();
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/io/XMLBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/XMLBuilder.java
@@ -60,8 +60,6 @@ public class XMLBuilder {
     /**
      * Append the given string without escaping
      *
-     * @param s
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder appendUnescaped(@Nullable String s) throws IOException {
@@ -73,7 +71,6 @@ public class XMLBuilder {
      * Start an XML Element on a new line indented for its depth
      *
      * @param name name of the element
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder indentElement(String name) throws IOException {
@@ -84,7 +81,6 @@ public class XMLBuilder {
      * Start an XML Element
      *
      * @param name name of the element
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder startElement(String name, boolean indent) throws IOException {
@@ -110,7 +106,6 @@ public class XMLBuilder {
      * Start an XML Element
      *
      * @param name name of the element
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder startElement(String name) throws IOException {
@@ -120,7 +115,6 @@ public class XMLBuilder {
     /**
      * End an XML element
      *
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder endElement() throws IOException {
@@ -131,7 +125,6 @@ public class XMLBuilder {
      *
      * @param name if not null and assertions are enabled, will check that the element being closed
      *     has this name.
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder endElement(@Nullable String name) throws IOException {
@@ -157,7 +150,6 @@ public class XMLBuilder {
     /**
      * Append an element that contains only text.
      *
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder simpleElement(String name, @Nullable String text, boolean indent)
@@ -168,8 +160,6 @@ public class XMLBuilder {
     /**
      * Add text to the body of the element.
      *
-     * @param str
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder text(@Nullable String str) throws IOException {
@@ -184,8 +174,6 @@ public class XMLBuilder {
     /**
      * Append the string, escaping special characters.
      *
-     * @param str
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder appendEscaped(@Nullable String str) throws IOException {
@@ -208,8 +196,6 @@ public class XMLBuilder {
     /**
      * Add an entity to the text.
      *
-     * @param name
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder entity(String name) throws IOException {
@@ -223,9 +209,6 @@ public class XMLBuilder {
     /**
      * Add an attribute to the current element. Must be called before any text is added.
      *
-     * @param name
-     * @param value
-     * @return
      * @throws IOException thrown if the underlying Appendable throws IOException
      */
     public XMLBuilder attribute(String name, String value) throws IOException {
@@ -240,16 +223,7 @@ public class XMLBuilder {
         return this;
     }
 
-    /**
-     * Add minx, miny, maxx, and maxy attributes
-     *
-     * @param minx
-     * @param miny
-     * @param maxx
-     * @param maxy
-     * @return
-     * @throws IOException
-     */
+    /** Add minx, miny, maxx, and maxy attributes */
     public <T> XMLBuilder bboxAttributes(T minx, T miny, T maxx, T maxy) throws IOException {
         return attribute("minx", minx.toString())
                 .attribute("miny", miny.toString())
@@ -257,17 +231,7 @@ public class XMLBuilder {
                 .attribute("maxy", maxy.toString());
     }
 
-    /**
-     * Add a BoundingBox element
-     *
-     * @param srs
-     * @param minx
-     * @param miny
-     * @param maxx
-     * @param maxy
-     * @return
-     * @throws IOException
-     */
+    /** Add a BoundingBox element */
     public <T> XMLBuilder boundingBox(@Nullable String srs, T minx, T miny, T maxx, T maxy)
             throws IOException {
         indentElement("BoundingBox");
@@ -277,30 +241,14 @@ public class XMLBuilder {
         return this;
     }
 
-    /**
-     * Add a LatLonBoundingBox element
-     *
-     * @param minx
-     * @param miny
-     * @param maxx
-     * @param maxy
-     * @return
-     * @throws IOException
-     */
+    /** Add a LatLonBoundingBox element */
     public <T> XMLBuilder latLonBoundingBox(T minx, T miny, T maxx, T maxy) throws IOException {
         return indentElement("LatLonBoundingBox")
                 .bboxAttributes(minx, miny, maxx, maxy)
                 .endElement();
     }
 
-    /**
-     * Append an XML header
-     *
-     * @param version
-     * @param charset
-     * @return
-     * @throws IOException
-     */
+    /** Append an XML header */
     public XMLBuilder header(String version, @Nullable String charset) throws IOException {
         Preconditions.checkNotNull(version);
         appendUnescaped("<?xml version=\"").appendEscaped(version).appendUnescaped("\"");
@@ -310,14 +258,7 @@ public class XMLBuilder {
         appendUnescaped("?>\n");
         return this;
     }
-    /**
-     * Append an XML header
-     *
-     * @param version
-     * @param charset
-     * @return
-     * @throws IOException
-     */
+    /** Append an XML header */
     public XMLBuilder header(String version, @Nullable Charset charset) throws IOException {
         String charsetName = charset.name();
         return header(version, charsetName);

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/AbstractTileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/AbstractTileLayer.java
@@ -131,12 +131,7 @@ public abstract class AbstractTileLayer extends TileLayer {
         listeners.addListener(listener);
     }
 
-    /**
-     * Removes a layer listener from this layer's set of listeners
-     *
-     * @param listener
-     * @return
-     */
+    /** Removes a layer listener from this layer's set of listeners */
     @Override
     public boolean removeLayerListener(TileLayerListener listener) {
         return listeners == null ? false : listeners.removeListener(listener);
@@ -164,11 +159,7 @@ public abstract class AbstractTileLayer extends TileLayer {
         this.blobStoreId = blobStoreId;
     }
 
-    /**
-     * Then name of the layer
-     *
-     * @return
-     */
+    /** Then name of the layer */
     @Override
     public String getName() {
         return this.name;
@@ -204,11 +195,7 @@ public abstract class AbstractTileLayer extends TileLayer {
         this.transientLayer = transientLayer;
     }
 
-    /**
-     * Layer meta information
-     *
-     * @return
-     */
+    /** Layer meta information */
     @Override
     public LayerMetaInformation getMetaInformation() {
         return this.metaInformation;
@@ -219,11 +206,7 @@ public abstract class AbstractTileLayer extends TileLayer {
         return metadataURLs == null ? null : new ArrayList<MetadataURL>(metadataURLs);
     }
 
-    /**
-     * Retrieves a list of Grids for this layer
-     *
-     * @return
-     */
+    /** Retrieves a list of Grids for this layer */
     @Override
     public Set<String> getGridSubsets() {
         return Collections.unmodifiableSet(this.subSets.keySet());
@@ -363,11 +346,7 @@ public abstract class AbstractTileLayer extends TileLayer {
         return sources;
     }
 
-    /**
-     * Whether to use ETags for this layer
-     *
-     * @return
-     */
+    /** Whether to use ETags for this layer */
     @Override
     public boolean useETags() {
         return useETags == null ? false : useETags.booleanValue();

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/MetaTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/MetaTile.java
@@ -123,14 +123,6 @@ public class MetaTile implements TileResponseReceiver {
      * <p>The response format is what the tiles are actually saved as. The primary example is to use
      * image/png or image/tiff for backend requests, and then save the resulting tiles to JPEG to
      * avoid loss of quality.
-     *
-     * @param gridSubset
-     * @param responseFormat
-     * @param formatModifier
-     * @param tileGridPosition
-     * @param metaX
-     * @param metaY
-     * @param gutter
      */
     public MetaTile(
             GridSubset gridSubset,
@@ -286,7 +278,6 @@ public class MetaTile implements TileResponseReceiver {
      *
      * @param tileWidth width of each tile
      * @param tileHeight height of each tile
-     * @return
      */
     private Rectangle[] createTiles(int tileHeight, int tileWidth) {
         int tileCount = metaX * metaY;
@@ -353,7 +344,6 @@ public class MetaTile implements TileResponseReceiver {
      * @param tileIdx the index of the tile relative to the internal array
      * @param target the resource
      * @return true if no error was encountered
-     * @throws IOException
      */
     public boolean writeTileToStream(final int tileIdx, Resource target) throws IOException {
         if (tiles == null) {
@@ -412,10 +402,6 @@ public class MetaTile implements TileResponseReceiver {
      * To get the BBOX you need to add one tilewidth to the top and right.
      *
      * <p>It also updates metaX and metaY to the actual metatiling factors
-     *
-     * @param coverage
-     * @param tileIdx
-     * @return
      */
     private long[] calculateMetaTileGridBounds(long[] coverage, long[] tileIdx) {
         long[] metaGridCov = new long[5];
@@ -452,21 +438,13 @@ public class MetaTile implements TileResponseReceiver {
         return tilesGridPos;
     }
 
-    /**
-     * The bottom left grid position and zoomlevel for this metatile, used for locking.
-     *
-     * @return
-     */
+    /** The bottom left grid position and zoomlevel for this metatile, used for locking. */
     public long[] getMetaGridPos() {
         long[] gridPos = {metaGridCov[0], metaGridCov[1], metaGridCov[4]};
         return gridPos;
     }
 
-    /**
-     * The bounds for the metatile
-     *
-     * @return
-     */
+    /** The bounds for the metatile */
     public long[] getMetaTileGridBounds() {
         return metaGridCov;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -80,19 +80,10 @@ public abstract class TileLayer implements Info {
      */
     public abstract void addLayerListener(TileLayerListener listener);
 
-    /**
-     * Removes a layer listener from this layer's set of listeners
-     *
-     * @param listener
-     * @return
-     */
+    /** Removes a layer listener from this layer's set of listeners */
     public abstract boolean removeLayerListener(TileLayerListener listener);
 
-    /**
-     * The unique identifier for the layer.
-     *
-     * @return
-     */
+    /** The unique identifier for the layer. */
     public abstract String getId();
 
     /**
@@ -104,11 +95,7 @@ public abstract class TileLayer implements Info {
 
     public abstract void setBlobStoreId(@Nullable String blobStoreId);
 
-    /**
-     * Then name of the layer
-     *
-     * @return
-     */
+    /** Then name of the layer */
     public abstract String getName();
 
     /** @return {@code true} if the layer is enabled, {@code false} otherwise */
@@ -129,11 +116,7 @@ public abstract class TileLayer implements Info {
     /** @param transientLayer whether to set this layer as transient */
     public abstract void setTransientLayer(boolean transientLayer);
 
-    /**
-     * Layer meta information
-     *
-     * @return
-     */
+    /** Layer meta information */
     public abstract LayerMetaInformation getMetaInformation();
 
     /**
@@ -156,42 +139,20 @@ public abstract class TileLayer implements Info {
     /** @return possibly empty list of update sources for this layer */
     public abstract List<UpdateSourceDefinition> getUpdateSources();
 
-    /**
-     * Whether to use ETags for this layer
-     *
-     * @return
-     */
+    /** Whether to use ETags for this layer */
     public abstract boolean useETags();
 
     /**
      * The normal way of getting a single tile from the layer. Under the hood, this may result in
      * several tiles being requested and stored before returning.
-     *
-     * @param tile
-     * @return
-     * @throws GeoWebCacheException
-     * @throws IOException
-     * @throws OutsideCoverageException
      */
     public abstract ConveyorTile getTile(ConveyorTile tile)
             throws GeoWebCacheException, IOException, OutsideCoverageException;
 
-    /**
-     * Makes a non-metatiled request to backend, bypassing the cache before and after
-     *
-     * @param tile
-     * @return
-     * @throws GeoWebCacheException
-     * @throws IOException
-     */
+    /** Makes a non-metatiled request to backend, bypassing the cache before and after */
     public abstract ConveyorTile getNoncachedTile(ConveyorTile tile) throws GeoWebCacheException;
 
-    /**
-     * @param tile
-     * @param tryCache
-     * @throws GeoWebCacheException
-     * @throws IOException
-     */
+    /** */
     public abstract void seedTile(ConveyorTile tile, boolean tryCache)
             throws GeoWebCacheException, IOException;
 
@@ -199,10 +160,6 @@ public abstract class TileLayer implements Info {
      * This is a more direct way of requesting a tile without invoking metatiling, and should not be
      * used in general. The method was exposed to let the KML service traverse the tree ahead of the
      * client, to avoid linking to empty tiles.
-     *
-     * @param tile
-     * @return
-     * @throws GeoWebCacheException
      */
     public abstract ConveyorTile doNonMetatilingRequest(ConveyorTile tile)
             throws GeoWebCacheException;
@@ -309,13 +266,7 @@ public abstract class TileLayer implements Info {
         return matches.isEmpty() ? matches : Collections.unmodifiableList(matches);
     }
 
-    /**
-     * Whether the layer supports the given format string
-     *
-     * @param strFormat
-     * @return
-     * @throws GeoWebCacheException
-     */
+    /** Whether the layer supports the given format string */
     public boolean supportsFormat(String strFormat) throws GeoWebCacheException {
         if (strFormat == null) {
             return true; // what the heck?!
@@ -332,18 +283,7 @@ public abstract class TileLayer implements Info {
                 "Format " + strFormat + " is not supported by " + this.getName());
     }
 
-    /**
-     * GetFeatureInfo template, throws exception, subclasses must override if supported.
-     *
-     * @param convTile
-     * @param bbox
-     * @param height
-     * @param width
-     * @param x
-     * @param y
-     * @return
-     * @throws GeoWebCacheException
-     */
+    /** GetFeatureInfo template, throws exception, subclasses must override if supported. */
     public Resource getFeatureInfo(
             ConveyorTile convTile, BoundingBox bbox, int height, int width, int x, int y)
             throws GeoWebCacheException {
@@ -351,10 +291,7 @@ public abstract class TileLayer implements Info {
                 "GetFeatureInfo is not supported by this layer (" + getName() + ")");
     }
 
-    /**
-     * @param gridSetId
-     * @return the resolutions (units/pixel) for the layer
-     */
+    /** @return the resolutions (units/pixel) for the layer */
     public double[] getResolutions(String gridSetId) throws GeoWebCacheException {
         return getGridSubset(gridSetId).getResolutions();
     }
@@ -382,11 +319,7 @@ public abstract class TileLayer implements Info {
         return null;
     }
 
-    /**
-     * The default MIME type is the first one in the configuration
-     *
-     * @return
-     */
+    /** The default MIME type is the first one in the configuration */
     public MimeType getDefaultMimeType() {
         return getMimeTypes().get(0);
     }
@@ -394,34 +327,18 @@ public abstract class TileLayer implements Info {
     /**
      * Converts the given bounding box into the closest location on the grid supported by the
      * reference system.
-     *
-     * @param gridSetId
-     * @param tileBounds
-     * @return
-     * @throws GeoWebCacheException
-     * @throws GeoWebCacheException
-     * @throws GridMismatchException
      */
     public long[] indexFromBounds(String gridSetId, BoundingBox tileBounds)
             throws GridMismatchException {
         return getGridSubset(gridSetId).closestIndex(tileBounds);
     }
 
-    /**
-     * @param gridSetId
-     * @param gridLoc
-     * @return
-     * @throws GeoWebCacheException
-     */
+    /** */
     public BoundingBox boundsFromIndex(String gridSetId, long[] gridLoc) {
         return getGridSubset(gridSetId).boundsFromIndex(gridLoc);
     }
 
-    /**
-     * Uses the HTTP 1.1 spec to set expiration headers
-     *
-     * @param response
-     */
+    /** Uses the HTTP 1.1 spec to set expiration headers */
     public void setExpirationHeader(HttpServletResponse response, int zoomLevel) {
         int expireValue = getExpireClients(zoomLevel);
 
@@ -448,12 +365,7 @@ public abstract class TileLayer implements Info {
         }
     }
 
-    /**
-     * Loops over all the request filters and applies them successively.
-     *
-     * @param convTile
-     * @throws RequestFilterException
-     */
+    /** Loops over all the request filters and applies them successively. */
     public void applyRequestFilters(ConveyorTile convTile) throws RequestFilterException {
         List<RequestFilter> requestFilters = getRequestFilters();
         if (requestFilters == null) return;
@@ -576,13 +488,7 @@ public abstract class TileLayer implements Info {
         return buffer;
     }
 
-    /**
-     * Loops over the gridPositions, generates cache keys and saves to cache
-     *
-     * @param metaTile
-     * @param tileProto
-     * @param requestTime
-     */
+    /** Loops over the gridPositions, generates cache keys and saves to cache */
     protected void saveTiles(MetaTile metaTile, ConveyorTile tileProto, long requestTime)
             throws GeoWebCacheException {
 

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
@@ -194,7 +194,6 @@ public class TileLayerDispatcher
      *
      * @param oldName The name of the existing layer
      * @param newName The name to rename the layer to
-     * @throws IllegalArgumentException
      */
     public synchronized void rename(final String oldName, final String newName)
             throws NoSuchElementException, IllegalArgumentException {
@@ -206,7 +205,6 @@ public class TileLayerDispatcher
      * Replaces the given layer and returns the Layer's configuration, saving the configuration.
      *
      * @param tl The layer to modify
-     * @throws IllegalArgumentException
      */
     public synchronized void modify(final TileLayer tl) throws IllegalArgumentException {
         TileLayerConfiguration config = getConfiguration(tl);

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/updatesource/GeoRSSFeedDefinition.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/updatesource/GeoRSSFeedDefinition.java
@@ -39,8 +39,6 @@ public class GeoRSSFeedDefinition extends UpdateSourceDefinition {
     /**
      * The maximum zoom level which to create a backing tile mask for to track the tiles affected by
      * the feed geometries; defaults to {@code 10}
-     *
-     * @return
      */
     public int getMaxMaskLevel() {
         return maxMaskLevel == null ? 10 : maxMaskLevel.intValue();
@@ -65,8 +63,6 @@ public class GeoRSSFeedDefinition extends UpdateSourceDefinition {
     /**
      * Number of threads to spawn to seed based on the results of the GeoRSS feed; default to {@code
      * 1} if not set
-     *
-     * @return
      */
     public int getSeedingThreads() {
         return seedingThreads == null ? 1 : seedingThreads.intValue();
@@ -76,8 +72,6 @@ public class GeoRSSFeedDefinition extends UpdateSourceDefinition {
      * The URL to the feed. I think we should use templating for parameters, so in the initial
      * implementation we search the string for {lastEntryId} and replace any occurrences with the
      * actual last entry id.
-     *
-     * @return
      */
     public String getFeedUrl() {
         return feedUrl;
@@ -86,8 +80,6 @@ public class GeoRSSFeedDefinition extends UpdateSourceDefinition {
     /**
      * The format for which to truncate / reseed. If you omit this parameter all supported formats
      * will be truncated / reseeded.
-     *
-     * @return
      */
     public String getFormat() {
         return format;

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -88,16 +88,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
         return client;
     }
 
-    /**
-     * Loops over the different backends, tries the request
-     *
-     * @param tileRespRecv
-     * @param layer
-     * @param wmsParams
-     * @param expectedMimeType
-     * @param target
-     * @throws GeoWebCacheException
-     */
+    /** Loops over the different backends, tries the request */
     @Override
     protected void makeRequest(
             TileResponseReceiver tileRespRecv,
@@ -158,18 +149,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
         }
     }
 
-    /**
-     * Executes the actual HTTP request, checks the response headers (status and MIME) and
-     *
-     * @param tileRespRecv
-     * @param wmsBackendUrl
-     * @param wmsParams
-     * @param requestMimeType
-     * @param backendTimeout
-     * @param target
-     * @param httpRequestMode
-     * @throws GeoWebCacheException
-     */
+    /** Executes the actual HTTP request, checks the response headers (status and MIME) and */
     private void connectAndCheckHeaders(
             TileResponseReceiver tileRespRecv,
             URL wmsBackendUrl,
@@ -305,7 +285,6 @@ public class WMSHttpHelper extends WMSSourceHelper {
      * @param httpRequestMode the method used to perform requests (can be null, in such case {@link
      *     org.geowebcache.layer.wms.WMSLayer.HttpRequestMode#Get} will be used
      * @return executed method (that has to be closed after reading the response!)
-     * @throws IOException
      */
     public HttpMethodBase executeRequest(
             final URL url,

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
@@ -128,18 +128,6 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
 
     /**
      * Note XStream uses reflection, this is only used for testing and loading from getCapabilities
-     *
-     * @param layerName
-     * @param wmsURL
-     * @param wmsStyles
-     * @param wmsLayers
-     * @param mimeFormats
-     * @param subSets
-     * @param parameterFilters<
-     * @param metaWidthHeight
-     * @param vendorParams
-     * @param queryable
-     * @param wmsQueryLayers
      */
     public WMSLayer(
             String layerName,
@@ -259,7 +247,6 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
      *
      * @param tile The tile request
      * @return The resulting tile request
-     * @throws OutsideCoverageException
      */
     public ConveyorTile getTile(ConveyorTile tile)
             throws GeoWebCacheException, IOException, OutsideCoverageException {
@@ -321,7 +308,6 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
      *
      * @param tile the Tile with all the information
      * @param tryCache whether to try the cache, or seed
-     * @throws GeoWebCacheException
      */
     private ConveyorTile getMetatilingReponse(ConveyorTile tile, boolean tryCache)
             throws GeoWebCacheException {
@@ -435,7 +421,6 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
      *
      * @param tile the Tile with all the information
      * @param tryCache whether to try the cache, or seed
-     * @throws GeoWebCacheException
      */
     private ConveyorTile getNonMetatilingReponse(ConveyorTile tile, boolean tryCache)
             throws GeoWebCacheException {

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSMetaTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSMetaTile.java
@@ -26,18 +26,7 @@ public class WMSMetaTile extends MetaTile {
 
     protected Map<String, String> fullParameters;
 
-    /**
-     * Used for requests by clients
-     *
-     * @param layer
-     * @param gridSubset
-     * @param responseFormat
-     * @param formatModifier
-     * @param tileGridPosition
-     * @param metaX
-     * @param metaY
-     * @param fullParameters
-     */
+    /** Used for requests by clients */
     protected WMSMetaTile(
             WMSLayer layer,
             GridSubset gridSubset,

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
@@ -134,29 +134,17 @@ public abstract class WMSSourceHelper {
         return target;
     }
 
-    /**
-     * The levels of concurrent requests this source helper is allowing
-     *
-     * @return
-     */
+    /** The levels of concurrent requests this source helper is allowing */
     public int getConcurrency() {
         return concurrency;
     }
 
-    /**
-     * Sets the maximum amount of concurrent requests this source helper will issue
-     *
-     * @param concurrency
-     */
+    /** Sets the maximum amount of concurrent requests this source helper will issue */
     public void setConcurrency(int concurrency) {
         this.concurrency = concurrency;
     }
 
-    /**
-     * Sets the backend timeout for HTTP calls
-     *
-     * @param backendTimeout
-     */
+    /** Sets the backend timeout for HTTP calls */
     public void setBackendTimeout(int backendTimeout) {
         this.backendTimetout = backendTimeout;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/locks/LockProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/locks/LockProvider.java
@@ -23,11 +23,7 @@ import org.geowebcache.GeoWebCacheException;
  */
 public interface LockProvider {
 
-    /**
-     * Acquires a exclusive lock on the specified key
-     *
-     * @param lockKey
-     */
+    /** Acquires a exclusive lock on the specified key */
     public Lock getLock(String lockKey) throws GeoWebCacheException;
 
     public interface Lock {

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -63,12 +63,7 @@ public class ImageMime extends MimeType {
     public static final ImageMime jpeg =
             new ImageMime("image/jpeg", "jpeg", "jpeg", "image/jpeg", true, false, false) {
 
-                /**
-                 * Shave off the alpha band, JPEG cannot write it out
-                 *
-                 * @param ri
-                 * @return
-                 */
+                /** Shave off the alpha band, JPEG cannot write it out */
                 @Override
                 public RenderedImage preprocess(RenderedImage ri) {
                     if (ri.getColorModel().hasAlpha()) {
@@ -99,12 +94,7 @@ public class ImageMime extends MimeType {
     public static final ImageMime png8 =
             new ImageMime("image/png", "png8", "png", "image/png8", true, false, true) {
 
-                /**
-                 * Quantize if the source did not do so already
-                 *
-                 * @param canvas
-                 * @return
-                 */
+                /** Quantize if the source did not do so already */
                 @Override
                 public RenderedImage preprocess(RenderedImage canvas) {
                     if (!(canvas.getColorModel() instanceof IndexColorModel)) {
@@ -263,12 +253,7 @@ public class ImageMime extends MimeType {
         return writer;
     }
 
-    /**
-     * Preprocesses the image to optimize it for the write about to happen
-     *
-     * @param tile
-     * @return
-     */
+    /** Preprocesses the image to optimize it for the write about to happen */
     public RenderedImage preprocess(RenderedImage tile) {
         return tile;
     }
@@ -296,9 +281,6 @@ public class ImageMime extends MimeType {
          * without any actual transparency use). This code is duplicated in GeoServer
          * JpegPngRenderedImageMapOutputFormat. Unfortunately gwc-core does not depend on GeoTools,
          * so we don't have an easy place to share it. On the bright side, it's small.
-         *
-         * @param renderedImage
-         * @return
          */
         boolean isBestFormatJpeg(RenderedImage renderedImage) {
             int numBands = renderedImage.getSampleModel().getNumBands();

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
@@ -45,21 +45,12 @@ public class MimeType {
         this.supportsTiling = supportsTiling;
     }
 
-    /**
-     * The MIME identifier string for this format.
-     *
-     * @return
-     */
+    /** The MIME identifier string for this format. */
     public String getMimeType() {
         return mimeType;
     }
 
-    /**
-     * The MIME identifier string for this format.
-     *
-     * @return
-     * @throws IOException
-     */
+    /** The MIME identifier string for this format. */
     public String getMimeType(Resource resource) throws IOException {
         return mimeType;
     }
@@ -76,11 +67,7 @@ public class MimeType {
         return mimeType;
     }
 
-    /**
-     * The conventional file extension most commonly used with this format.
-     *
-     * @return
-     */
+    /** The conventional file extension most commonly used with this format. */
     public String getFileExtension() {
         return fileExtension;
     }
@@ -112,12 +99,7 @@ public class MimeType {
         return false;
     }
 
-    /**
-     * Get the MIME type object for a given MIME type string
-     *
-     * @param formatStr
-     * @return
-     */
+    /** Get the MIME type object for a given MIME type string */
     public static MimeType createFromFormat(String formatStr) throws MimeException {
         MimeType mimeType = null;
         if (formatStr == null) {
@@ -145,12 +127,7 @@ public class MimeType {
         throw new MimeException("Unsupported format request: " + formatStr);
     }
 
-    /**
-     * Get the MIME type object for a given file extension
-     *
-     * @param fileExtension
-     * @return
-     */
+    /** Get the MIME type object for a given file extension */
     public static MimeType createFromExtension(String fileExtension) throws MimeException {
         MimeType mimeType = null;
 

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/MassTruncateRequest.java
@@ -33,7 +33,6 @@ public interface MassTruncateRequest {
      * @param sb The storage broker managing the cache
      * @param breeder The tile breeder storing information about the affected layers
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean doTruncate(StorageBroker sb, TileBreeder breeder)
             throws StorageException, GeoWebCacheException;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedRequest.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedRequest.java
@@ -73,7 +73,6 @@ public class SeedRequest {
      * @param zoomStart the zoom start level for this seed request
      * @param zoomStop the zoom stop level for this seed request
      * @param mimeFormat the MIME format requested
-     * @param type
      */
     public SeedRequest(
             String layerName,
@@ -114,11 +113,7 @@ public class SeedRequest {
         return this.bounds;
     }
 
-    /**
-     * Whether any request filters should be updated after this seed request completes.
-     *
-     * @return
-     */
+    /** Whether any request filters should be updated after this seed request completes. */
     public boolean getFilterUpdate() {
         if (filterUpdate != null) {
             return filterUpdate;
@@ -145,11 +140,7 @@ public class SeedRequest {
         return this.format;
     }
 
-    /**
-     * Used to handle 1.1.x-style seed requests
-     *
-     * @return
-     */
+    /** Used to handle 1.1.x-style seed requests */
     public SRS getSRS() {
         return this.srs;
     }
@@ -221,8 +212,6 @@ public class SeedRequest {
     /**
      * Number of retries to build a tile before giving up on it. -1 disables also the wait and total
      * failures counters.
-     *
-     * @return
      */
     public int getTileFailureRetryCount() {
         return tileFailureRetryCount;
@@ -232,11 +221,7 @@ public class SeedRequest {
         this.tileFailureRetryCount = tileFailureRetryCount;
     }
 
-    /**
-     * Time to wait between tile computation failures, in milliseconds
-     *
-     * @return
-     */
+    /** Time to wait between tile computation failures, in milliseconds */
     public long getTileFailureRetryWaitTime() {
         return tileFailureRetryWaitTime;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
@@ -57,15 +57,7 @@ class SeedTask extends GWCTask {
 
     @VisibleForTesting Sleeper sleeper = Thread::sleep;
 
-    /**
-     * Constructs a SeedTask
-     *
-     * @param sb
-     * @param trIter
-     * @param tl
-     * @param reseed
-     * @param doFilterUpdate
-     */
+    /** Constructs a SeedTask */
     public SeedTask(
             StorageBroker sb,
             TileRangeIterator trIter,
@@ -253,7 +245,6 @@ class SeedTask extends GWCTask {
     /**
      * helper for counting the number of tiles
      *
-     * @param tr
      * @return -1 if too many
      */
     private long tileCount(TileRange tr) {
@@ -283,13 +274,7 @@ class SeedTask extends GWCTask {
         return count;
     }
 
-    /**
-     * Helper method to update the members tracking thread progress.
-     *
-     * @param layer
-     * @param tilesCount
-     * @param start_time
-     */
+    /** Helper method to update the members tracking thread progress. */
     private void updateStatusInfo(TileLayer layer, long tilesCount, long start_time) {
 
         // working on tile

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TileBreeder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TileBreeder.java
@@ -196,13 +196,7 @@ public class TileBreeder implements ApplicationContextAware {
         return defaultVal;
     }
 
-    /**
-     * Create and dispatch tasks to fulfil a seed request
-     *
-     * @param layerName
-     * @param sr
-     * @throws GeoWebCacheException
-     */
+    /** Create and dispatch tasks to fulfil a seed request */
     // TODO: The SeedRequest specifies a layer name. Would it make sense to use that instead of
     // including one as a separate parameter?
     public void seed(final String layerName, final SeedRequest sr) throws GeoWebCacheException {
@@ -226,7 +220,6 @@ public class TileBreeder implements ApplicationContextAware {
      * @param threadCount The number of threads to use, forced to 1 if type is TRUNCATE
      * @param filterUpdate // TODO: What does this do?
      * @return Array of tasks. Will have length threadCount or 1.
-     * @throws GeoWebCacheException
      */
     public GWCTask[] createTasks(
             TileRange tr, GWCTask.TYPE type, int threadCount, boolean filterUpdate)
@@ -265,7 +258,6 @@ public class TileBreeder implements ApplicationContextAware {
      * @param totalFailuresBeforeAborting Total number of failures, across all threads, before
      *     aborting seeding
      * @return Array of tasks. Will have length threadCount or 1.
-     * @throws GeoWebCacheException
      */
     public GWCTask[] createTasks(
             TileRange tr,
@@ -307,11 +299,7 @@ public class TileBreeder implements ApplicationContextAware {
         return tasks;
     }
 
-    /**
-     * Dispatches tasks
-     *
-     * @param tasks
-     */
+    /** Dispatches tasks */
     public void dispatchTasks(GWCTask[] tasks) {
         lock.writeLock().lock();
         try {
@@ -332,14 +320,7 @@ public class TileBreeder implements ApplicationContextAware {
         }
     }
 
-    /**
-     * Find the tile range for a Seed Request.
-     *
-     * @param req
-     * @param tl
-     * @return
-     * @throws GeoWebCacheException
-     */
+    /** Find the tile range for a Seed Request. */
     public static TileRange createTileRange(SeedRequest req, TileLayer tl)
             throws GeoWebCacheException {
         int zoomStart = req.getZoomStart().intValue();
@@ -408,9 +389,6 @@ public class TileBreeder implements ApplicationContextAware {
      * @param type the type, SEED or RESEED
      * @param trIter a collection of tile ranges
      * @param tl the layer
-     * @param doFilterUpdate
-     * @return
-     * @throws IllegalArgumentException
      */
     private GWCTask createSeedTask(
             TYPE type, TileRangeIterator trIter, TileLayer tl, boolean doFilterUpdate)
@@ -452,7 +430,6 @@ public class TileBreeder implements ApplicationContextAware {
      *     where {@code taskStatus} is one of: {@code 0 = PENDING, 1 = RUNNING, 2 = DONE, -1 =
      *     ABORTED}
      * @param layerName the name of the layer. null for all layers.
-     * @return
      */
     public long[][] getStatusList(final String layerName) {
         List<long[]> list = new ArrayList<long[]>(currentPool.size());
@@ -535,8 +512,6 @@ public class TileBreeder implements ApplicationContextAware {
     /**
      * Find a layer by name.
      *
-     * @param layerName
-     * @return
      * @throws GeoWebCacheException if the layer is not found
      */
     public TileLayer findTileLayer(String layerName) throws GeoWebCacheException {
@@ -551,31 +526,19 @@ public class TileBreeder implements ApplicationContextAware {
         return layer;
     }
 
-    /**
-     * Get all tasks that are running
-     *
-     * @return
-     */
+    /** Get all tasks that are running */
     public Iterator<GWCTask> getRunningTasks() {
         drain();
         return filterTasks(STATE.RUNNING);
     }
 
-    /**
-     * Get all tasks that are running or waiting to run.
-     *
-     * @return
-     */
+    /** Get all tasks that are running or waiting to run. */
     public Iterator<GWCTask> getRunningAndPendingTasks() {
         drain();
         return filterTasks(STATE.READY, STATE.UNSET, STATE.RUNNING);
     }
 
-    /**
-     * Get all tasks that are waiting to run.
-     *
-     * @return
-     */
+    /** Get all tasks that are waiting to run. */
     public Iterator<GWCTask> getPendingTasks() {
         drain();
         return filterTasks(STATE.READY, STATE.UNSET);
@@ -585,7 +548,6 @@ public class TileBreeder implements ApplicationContextAware {
      * Return all current tasks that are in the specified states
      *
      * @param filter the states to filter for
-     * @return
      */
     private Iterator<GWCTask> filterTasks(STATE... filter) {
         Set<STATE> states = new HashSet<STATE>(Arrays.asList(filter));
@@ -605,12 +567,7 @@ public class TileBreeder implements ApplicationContextAware {
         return runningTasks.iterator();
     }
 
-    /**
-     * Terminate a running or pending task
-     *
-     * @param id
-     * @return
-     */
+    /** Terminate a running or pending task */
     public boolean terminateGWCTask(final long id) {
         SubmittedTask submittedTask = this.currentPool.remove(Long.valueOf(id));
         if (submittedTask == null) {
@@ -621,11 +578,7 @@ public class TileBreeder implements ApplicationContextAware {
         return true;
     }
 
-    /**
-     * Get an iterator over the layers.
-     *
-     * @return
-     */
+    /** Get an iterator over the layers. */
     public Iterable<TileLayer> getLayers() {
         return this.layerDispatcher.getLayerList();
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/service/Service.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/service/Service.java
@@ -37,11 +37,7 @@ public abstract class Service {
         this.pathName = pathName;
     }
 
-    /**
-     * Whether this service can handle the given request
-     *
-     * @return
-     */
+    /** Whether this service can handle the given request */
     public boolean handlesRequest(HttpServletRequest request) {
         return request.getPathInfo().equalsIgnoreCase(pathName);
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStore.java
@@ -48,10 +48,7 @@ public interface BlobStore {
     /**
      * Delete the cache for the named gridset and layer
      *
-     * @param layerName
-     * @param gridSetId
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean deleteByGridsetId(final String layerName, final String gridSetId)
             throws StorageException;
@@ -59,10 +56,8 @@ public interface BlobStore {
     /**
      * Delete the cache for the named layer and parameters.
      *
-     * @param layerName
      * @param parameters Complete filtered parameters to generate the ID
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public default boolean deleteByParameters(
             final String layerName, final Map<String, String> parameters) throws StorageException {
@@ -72,10 +67,7 @@ public interface BlobStore {
     /**
      * Delete the cache for the named layer and parameters id.
      *
-     * @param layerName
-     * @param parametersId
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean deleteByParametersId(final String layerName, String parametersId)
             throws StorageException;
@@ -84,9 +76,7 @@ public interface BlobStore {
      * Delete the cached blob associated with the specified TileObject. The passed in object itself
      * will not be modified.
      *
-     * @param obj
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean delete(TileObject obj) throws StorageException;
 
@@ -95,32 +85,20 @@ public interface BlobStore {
      *
      * @param obj the range of tiles.
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean delete(TileRange obj) throws StorageException;
 
     /**
      * Retrieves a tile from the storage, filling its metadata too
      *
-     * @param obj
      * @return {@literal true} if successful, {@literal false} otherwise
-     * @throws StorageException
      */
     public boolean get(TileObject obj) throws StorageException;
 
-    /**
-     * Store blob. Calls getBlob() on passed object, does not modify the object.
-     *
-     * @param obj
-     * @throws StorageException
-     */
+    /** Store blob. Calls getBlob() on passed object, does not modify the object. */
     public void put(TileObject obj) throws StorageException;
 
-    /**
-     * Wipes the entire storage. Should only be invoked during testing.
-     *
-     * @throws StorageException
-     */
+    /** Wipes the entire storage. Should only be invoked during testing. */
     public void clear() throws StorageException;
 
     /** Destroy method for Spring */
@@ -129,7 +107,6 @@ public interface BlobStore {
     /**
      * Add an event listener
      *
-     * @param listener
      * @see BlobStoreListener
      */
     public void addListener(BlobStoreListener listener);
@@ -137,18 +114,12 @@ public interface BlobStore {
     /**
      * Remove an event listener
      *
-     * @param listener
      * @return {@literal true} if successful, {@literal false} otherwise
      * @see BlobStoreListener
      */
     public boolean removeListener(BlobStoreListener listener);
 
-    /**
-     * Get the cached parameter maps for a layer
-     *
-     * @param layerName
-     * @return
-     */
+    /** Get the cached parameter maps for a layer */
     public default Set<Map<String, String>> getParameters(String layerName)
             throws StorageException {
         return getParametersMapping(layerName)
@@ -165,9 +136,6 @@ public interface BlobStore {
      * <p>Stores that predate 1.12 should implement this to provide any parameters for which maps
      * are not available. Stores not using {@link ParametersUtils#getId(Map)} or which have more
      * efficient ways to provide it should also implement it.
-     *
-     * @param layerName
-     * @return
      */
     public default Set<String> getParameterIds(String layerName) throws StorageException {
         return getParametersMapping(layerName).keySet();
@@ -211,12 +179,7 @@ public interface BlobStore {
      */
     Map<String, Optional<Map<String, String>>> getParametersMapping(String layerName);
 
-    /**
-     * If the given layer is cached, remove
-     *
-     * @param layer
-     * @throws StorageException
-     */
+    /** If the given layer is cached, remove */
     public default boolean purgeOrphans(TileLayer layer) throws StorageException {
         // TODO maybe do purging based on gridset and format
         try {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
@@ -45,12 +45,7 @@ public class BlobStoreAggregator {
     private ServiceInformation serviceInformation;
     private TileLayerDispatcher layers;
 
-    /**
-     * Used to delegate calls to {@link BlobStoreConfiguration} objects
-     *
-     * @param configs
-     * @param layers
-     */
+    /** Used to delegate calls to {@link BlobStoreConfiguration} objects */
     public BlobStoreAggregator(List<BlobStoreConfiguration> configs, TileLayerDispatcher layers) {
         this.configs = configs == null ? new ArrayList<BlobStoreConfiguration>() : configs;
         this.layers = layers;
@@ -276,7 +271,6 @@ public class BlobStoreAggregator {
      *
      * @param oldName The name of the existing blob store
      * @param newName The name to rename the blob store to
-     * @throws IllegalArgumentException
      */
     public synchronized void renameBlobStore(final String oldName, final String newName)
             throws NoSuchElementException, IllegalArgumentException {
@@ -297,7 +291,6 @@ public class BlobStoreAggregator {
      * configuration.
      *
      * @param bs The blob store to modify
-     * @throws IllegalArgumentException
      */
     public synchronized void modifyBlobStore(final BlobStoreInfo bs)
             throws IllegalArgumentException {
@@ -312,7 +305,6 @@ public class BlobStoreAggregator {
      *
      * @param bs BlobStoreInfo for this configuration
      * @return The BlobStoreConfiguration for BlobStoreInfo
-     * @throws IllegalArgumentException
      */
     public BlobStoreConfiguration getConfiguration(BlobStoreInfo bs)
             throws IllegalArgumentException {
@@ -323,10 +315,6 @@ public class BlobStoreAggregator {
     /**
      * Returns the BlobStoreConfiguration for the given Blob Store Name, if found in list of blob
      * store configurations.
-     *
-     * @param blobStoreName
-     * @return
-     * @throws IllegalArgumentException
      */
     public BlobStoreConfiguration getConfiguration(final String blobStoreName)
             throws IllegalArgumentException {
@@ -364,11 +352,7 @@ public class BlobStoreAggregator {
         }
     }
 
-    /**
-     * Get a list of all the configurations that are being aggregated.
-     *
-     * @return
-     */
+    /** Get a list of all the configurations that are being aggregated. */
     protected List<BlobStoreConfiguration> getConfigs() {
         return configs;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
@@ -107,11 +107,7 @@ public class CompositeBlobStore implements BlobStore, BlobStoreConfigurationList
                                     .map(StoreSuitabilityCheck::valueOf)
                                     .orElse(StoreSuitabilityCheck.EXISTING));
 
-    /**
-     * Specifies how new blob stores should check the existing content of their persistence.
-     *
-     * @return
-     */
+    /** Specifies how new blob stores should check the existing content of their persistence. */
     public static StoreSuitabilityCheck getStoreSuitabilityCheck() {
         return storeSuitability.get();
     }
@@ -126,7 +122,6 @@ public class CompositeBlobStore implements BlobStore, BlobStoreConfigurationList
      *     blob store when no {@link BlobStoreInfo#isDefault() default blob store} is given
      * @param blobStoreAggregator the configuration as read from {@code geowebcache.xml} containing
      *     the configured {@link BlobStoreAggregator#getBlobStores() blob stores}
-     * @param serverConfiguration
      * @throws ConfigurationException if there's a configuration error like a store confing having
      *     no id, or two store configs having the same id, or more than one store config being
      *     marked as the default one, or the default store is not {@link BlobStoreInfo#isEnabled()
@@ -611,8 +606,6 @@ public class CompositeBlobStore implements BlobStore, BlobStoreConfigurationList
      *
      * @param stores The blobStores map to update
      * @param config The new default blob store
-     * @throws StorageException
-     * @throws ConfigurationException
      */
     private void loadBlobStoreOverwritingDefault(
             Map<String, LiveStore> stores, BlobStoreInfo config)
@@ -641,7 +634,6 @@ public class CompositeBlobStore implements BlobStore, BlobStoreConfigurationList
      * @param location Location of the storage for heuman readable error messages
      * @param exists The storage is already a GWC cache
      * @param empty The storage is empty
-     * @throws UnsuitableStorageException
      */
     public static void checkSuitability(String location, final boolean exists, boolean empty)
             throws UnsuitableStorageException {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
@@ -102,11 +102,7 @@ public class MetastoreRemover {
         }
     }
 
-    /**
-     * Drop all the tiles to prevent a future migration
-     *
-     * @param template
-     */
+    /** Drop all the tiles to prevent a future migration */
     private void removeTiles(JdbcTemplate template) {
         template.execute("delete from tiles");
     }
@@ -181,9 +177,6 @@ public class MetastoreRemover {
                     /**
                      * Parses the param list stored in the db to a parameter list (since this is
                      * coming from the database the assumption is that the contents are sane)
-                     *
-                     * @param paramsKvp
-                     * @return
                      */
                     private Map<String, String> toMap(String paramsKvp) {
                         // TODO: wondering, shall we URL decode the values??

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/RasterMask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/RasterMask.java
@@ -37,8 +37,6 @@ public class RasterMask implements TileRangeMask {
     /**
      * Creates a RasterMask from the given parameters with default {@code noDataValue == 0}
      *
-     * @param byLevelMasks
-     * @param fullCoverage
      * @see #RasterMask(BufferedImage[], long[][], long[][], int)
      */
     public RasterMask(
@@ -58,7 +56,6 @@ public class RasterMask implements TileRangeMask {
      * its bitmasked image, which represents the whole tile range for the layer at a specific zoom
      * level.
      *
-     * @param byLevelMasks
      * @param fullCoverage the full grid subsets coverage, needed to compute downsampled pixel
      *     locations
      * @param coveredBounds by level bounds enclosing the area that has pixels set in the masks

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/StorageBroker.java
@@ -32,29 +32,13 @@ public interface StorageBroker {
      * Completely deletes the cache for a layer/gridset combination; differs from truncate that the
      * layer doesn't need to have a gridSubset associated for the given gridset at runtime (in order
      * to handle the deletion of a layer's gridsubset)
-     *
-     * @param layerName
-     * @param gridSetId
-     * @throws StorageException
      */
     boolean deleteByGridSetId(String layerName, String gridSetId) throws StorageException;
 
-    /**
-     * Completely deletes the cache for a layer/parameters combination
-     *
-     * @param layerName
-     * @param parametersId
-     * @throws StorageException
-     */
+    /** Completely deletes the cache for a layer/parameters combination */
     boolean deleteByParametersId(String layerName, String parametersId) throws StorageException;
 
-    /**
-     * Completely deletes the cache for a layer/parameters combination
-     *
-     * @param layerName
-     * @param parameters
-     * @throws StorageException
-     */
+    /** Completely deletes the cache for a layer/parameters combination */
     boolean deleteByParameters(String layerName, Map<String, String> parameters)
             throws StorageException;
 
@@ -67,59 +51,31 @@ public interface StorageBroker {
      *
      * @param tileObj TileOpject to set the Resource of
      * @return true if successful, false otherwise
-     * @throws StorageException
      */
     boolean get(TileObject tileObj) throws StorageException;
 
-    /**
-     * Puts the given TileObject into storage
-     *
-     * @param tileObj
-     * @return
-     * @throws StorageException
-     */
+    /** Puts the given TileObject into storage */
     boolean put(TileObject tileObj) throws StorageException;
 
     /** Destroy method for Spring */
     void destroy();
 
-    /**
-     * Get an entry from the layer's metadata map
-     *
-     * @param layerName
-     * @param key
-     * @return
-     */
+    /** Get an entry from the layer's metadata map */
     String getLayerMetadata(String layerName, String key);
 
-    /**
-     * Add/set an entry in the layer's metadata map
-     *
-     * @param layerName
-     * @param key
-     * @return
-     */
+    /** Add/set an entry in the layer's metadata map */
     void putLayerMetadata(String layerName, String key, String value);
 
     boolean getTransient(TileObject tile);
 
     void putTransient(TileObject tile);
 
-    /**
-     * Get the set of parameter IDs cached for the given layer
-     *
-     * @param layerName
-     * @param key
-     * @return
-     */
+    /** Get the set of parameter IDs cached for the given layer */
     Set<String> getCachedParameterIds(String layerName) throws StorageException;
 
     /**
      * Get the set of map cached for the given layer, for those parameterizations that have reverse
      * mappings (Created by GWC 1.12 or later)
-     *
-     * @param layerName
-     * @return
      */
     Set<Map<String, String>> getCachedParameters(String layerName) throws StorageException;
 
@@ -127,10 +83,6 @@ public interface StorageBroker {
      * Purge parameter caches from the layer if they are unreachable by its current parameter
      * filters. The store may purge gridsets and formats as well. These additional purges may be
      * guaranteed in future.
-     *
-     * @param layer
-     * @return
-     * @throws StorageException
      */
     boolean purgeOrphans(final TileLayer layer) throws StorageException;
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileObject.java
@@ -106,19 +106,13 @@ public class TileObject extends StorageObject implements Serializable {
         return this.gridSetId;
     }
 
-    /**
-     * May be null until this object has been handled by the BlobStore
-     *
-     * @return
-     */
+    /** May be null until this object has been handled by the BlobStore */
     public String getParametersId() {
         return this.parameters_id;
     }
 
     /**
      * The BlobStore is responsible for setting this based on the value of {@link #getParameters()}
-     *
-     * @param parameters_id
      */
     public void setParametersId(String parameters_id) {
         this.parameters_id = parameters_id;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileRange.java
@@ -152,7 +152,6 @@ public class TileRange {
     /**
      * Returns the range bounds for the given level, as a <code>minx,miny,maxx,maxy</code> array
      *
-     * @param zoomLevel
      * @return The bounds
      * @throws IllegalArgumentException if the given z level is not between zoomstart and zoomStop
      */

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TileRangeIterator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TileRangeIterator.java
@@ -35,9 +35,6 @@ public class TileRangeIterator {
     /**
      * Note that the bounds of the tile range must already be expanded to the meta tile factors for
      * this to work.
-     *
-     * @param tr
-     * @param metaTilingFactors
      */
     public TileRangeIterator(TileRange tr, int[] metaTilingFactors) {
         this.tr = tr;
@@ -51,11 +48,7 @@ public class TileRangeIterator {
         }
     }
 
-    /**
-     * Returns the underlying tile range
-     *
-     * @return
-     */
+    /** Returns the underlying tile range */
     public TileRange getTileRange() {
         return tr;
     }
@@ -126,14 +119,7 @@ public class TileRangeIterator {
         return null;
     }
 
-    /**
-     * Calculates the number of tiles covered by the meta tile for this grid location.
-     *
-     * @param x
-     * @param y
-     * @param levelBounds
-     * @return
-     */
+    /** Calculates the number of tiles covered by the meta tile for this grid location. */
     private int tilesForLocation(long x, long y, long[] levelBounds) {
         long boundsMaxX = levelBounds[2];
         long boundsMaxY = levelBounds[3];
@@ -148,9 +134,6 @@ public class TileRangeIterator {
     /**
      * Checks whether this grid location, or any on the same meta tile, should be included according
      * to the DiscontinuousTileRange
-     *
-     * @param gridLoc
-     * @return
      */
     private boolean checkGridLocation(long[] gridLoc) {
         if (dtr == null) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/TransientCache.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/TransientCache.java
@@ -74,20 +74,12 @@ public class TransientCache {
         this.expireDelay = expireDelay;
     }
 
-    /**
-     * Count of cached resources. May include expired resources not yet cleared.
-     *
-     * @return
-     */
+    /** Count of cached resources. May include expired resources not yet cleared. */
     public int size() {
         return cache.size();
     }
 
-    /**
-     * The currently used storage. May include expired resources not yet cleared.
-     *
-     * @return
-     */
+    /** The currently used storage. May include expired resources not yet cleared. */
     public long storageSize() {
         return currentStorage;
     }
@@ -113,7 +105,6 @@ public class TransientCache {
     /**
      * Retrieve a resource
      *
-     * @param key
      * @return The resource cached under the given key, or null if no resource is cached.
      */
     public Resource get(String key) {
@@ -131,11 +122,7 @@ public class TransientCache {
         return null;
     }
 
-    /**
-     * A timestamp in milliseconds
-     *
-     * @return
-     */
+    /** A timestamp in milliseconds */
     protected long currentTime() {
         return ticker.read() / 1000;
     }
@@ -180,11 +167,7 @@ public class TransientCache {
         }
     }
 
-    /**
-     * Set a time source for computing expiry.
-     *
-     * @param ticker
-     */
+    /** Set a time source for computing expiry. */
     public void setTicker(Ticker ticker) {
         Preconditions.checkNotNull(ticker);
         this.ticker = ticker;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathFilter.java
@@ -37,7 +37,6 @@ public class DefaultFilePathFilter implements FilenameFilter {
      * Create a filter for stored tiles that are within a particular range.
      *
      * @param trObj the range to find
-     * @throws StorageException
      */
     public DefaultFilePathFilter(TileRange trObj) throws StorageException {
         this.tr = trObj;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -281,7 +281,6 @@ public class FileBlobStore implements BlobStore {
     }
 
     /**
-     * @throws StorageException
      * @see org.geowebcache.storage.BlobStore#deleteByGridsetId(java.lang.String, java.lang.String)
      */
     public boolean deleteByGridsetId(final String layerName, final String gridSetId)
@@ -594,9 +593,6 @@ public class FileBlobStore implements BlobStore {
     /**
      * This method will recursively create the missing directories and call the listeners
      * directoryCreated method for each created directory.
-     *
-     * @param path
-     * @return
      */
     private boolean mkdirs(File path, TileObject stObj) {
         /* If the terminal directory already exists, answer false */

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FilePathUtils.java
@@ -33,10 +33,6 @@ public class FilePathUtils {
     /**
      * Silly way to pad numbers with leading zeros, since I don't know a fast way of doing this in
      * Java.
-     *
-     * @param number
-     * @param order
-     * @return
      */
     public static void zeroPadder(long number, int order, StringBuilder padding) {
         int numberOrder = 1;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/TileFileVisitor.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/TileFileVisitor.java
@@ -22,27 +22,12 @@ import java.io.File;
  */
 public interface TileFileVisitor {
 
-    /**
-     * Invoked before visitng a directory
-     *
-     * @param dir
-     */
+    /** Invoked before visitng a directory */
     default void preVisitDirectory(File dir) {};
 
-    /**
-     * Invoked on a specific tile file
-     *
-     * @param tile
-     * @param x
-     * @param y
-     * @param z
-     */
+    /** Invoked on a specific tile file */
     public void visitFile(File tile, long x, long y, int z);
 
-    /**
-     * Invoked on a directory post file visit
-     *
-     * @param dir
-     */
+    /** Invoked on a directory post file visit */
     default void postVisitDirectory(File dir) {};
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/XYZFilePathFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/XYZFilePathFilter.java
@@ -39,7 +39,6 @@ public class XYZFilePathFilter implements FilenameFilter {
      * Create a filter for stored tiles that are within a particular range.
      *
      * @param trObj the range to find
-     * @throws StorageException
      */
     public XYZFilePathFilter(TileRange trObj, XYZFilePathGenerator generator)
             throws StorageException {
@@ -112,13 +111,7 @@ public class XYZFilePathFilter implements FilenameFilter {
         return dirName.substring(prefix.length() + 1);
     }
 
-    /**
-     * Can only check the zoom levels
-     *
-     * @param parent
-     * @param fileName
-     * @return
-     */
+    /** Can only check the zoom levels */
     private boolean acceptIntermediateDir(File parent, String fileName) {
         try {
             if (acceptGridsetDir(parent.getName())) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/XYZFilePathGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/XYZFilePathGenerator.java
@@ -113,14 +113,6 @@ public class XYZFilePathGenerator implements FilePathGenerator {
      * This method abstract going from internal tile grid (TMS) to storage tile grid (could be
      * slippy). One method is all it needs only because the TMS vs Slippy conventions have
      * symmetrical map, e.g., the same extact operation goes both directions
-     *
-     * @param layerName
-     * @param gridSetId
-     * @param x
-     * @param y
-     * @param z
-     * @return
-     * @throws GeoWebCacheException
      */
     protected long getY(String layerName, String gridSetId, long x, long y, int z)
             throws GeoWebCacheException {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheConfiguration.java
@@ -72,11 +72,7 @@ public class CacheConfiguration implements Serializable {
         return hardMemoryLimit;
     }
 
-    /**
-     * Sets the cache memory limit
-     *
-     * @param hardMemoryLimit
-     */
+    /** Sets the cache memory limit */
     public void setHardMemoryLimit(long hardMemoryLimit) {
         this.hardMemoryLimit = hardMemoryLimit;
     }
@@ -86,11 +82,7 @@ public class CacheConfiguration implements Serializable {
         return policy;
     }
 
-    /**
-     * Sets the Cache eviction policy
-     *
-     * @param policy
-     */
+    /** Sets the Cache eviction policy */
     public void setPolicy(EvictionPolicy policy) {
         this.policy = policy;
     }
@@ -100,11 +92,7 @@ public class CacheConfiguration implements Serializable {
         return concurrencyLevel;
     }
 
-    /**
-     * Sets the cache concurrency level
-     *
-     * @param concurrencyLevel
-     */
+    /** Sets the cache concurrency level */
     public void setConcurrencyLevel(int concurrencyLevel) {
         this.concurrencyLevel = concurrencyLevel;
     }
@@ -114,11 +102,7 @@ public class CacheConfiguration implements Serializable {
         return evictionTime;
     }
 
-    /**
-     * Sets the cache eviction time
-     *
-     * @param evictionTime
-     */
+    /** Sets the cache eviction time */
     public void setEvictionTime(long evictionTime) {
         this.evictionTime = evictionTime;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheProvider.java
@@ -31,25 +31,13 @@ public interface CacheProvider {
     /** Returns the {@link TileObject} for the selected id */
     public TileObject getTileObj(TileObject obj);
 
-    /**
-     * Insert a {@link TileObject} in cache.
-     *
-     * @param obj
-     */
+    /** Insert a {@link TileObject} in cache. */
     public void putTileObj(TileObject obj);
 
-    /**
-     * Removes a {@link TileObject} from cache.
-     *
-     * @param obj
-     */
+    /** Removes a {@link TileObject} from cache. */
     public void removeTileObj(TileObject obj);
 
-    /**
-     * Removes all the {@link TileObject}s for the related layer from cache.
-     *
-     * @param layername
-     */
+    /** Removes all the {@link TileObject}s for the related layer from cache. */
     public void removeLayer(String layername);
 
     /** Removes all the cached {@link TileObject}s */
@@ -61,31 +49,18 @@ public interface CacheProvider {
     /** Returns a {@link CacheStatistics} object containing the current cache statistics. */
     public CacheStatistics getStatistics();
 
-    /**
-     * Sets the CacheConfiguration to use
-     *
-     * @param configuration
-     */
+    /** Sets the CacheConfiguration to use */
     void configure(CacheConfiguration configuration);
 
-    /**
-     * Add a new Layer that should not be cached
-     *
-     * @param layername
-     */
+    /** Add a new Layer that should not be cached */
     public void addUncachedLayer(String layername);
 
-    /**
-     * Remove a Layer so that it can be cached again
-     *
-     * @param layername
-     */
+    /** Remove a Layer so that it can be cached again */
     public void removeUncachedLayer(String layername);
 
     /**
      * Checks if the Layer must be cached or not
      *
-     * @param layername
      * @return true if the Layer should not be cached
      */
     public boolean containsUncachedLayer(String layername);

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheStatistics.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/CacheStatistics.java
@@ -74,11 +74,7 @@ public class CacheStatistics implements Serializable {
         return hitCount;
     }
 
-    /**
-     * Setter for cache hit count
-     *
-     * @param hitCount
-     */
+    /** Setter for cache hit count */
     public void setHitCount(long hitCount) {
         this.hitCount = hitCount;
     }
@@ -88,11 +84,7 @@ public class CacheStatistics implements Serializable {
         return missCount;
     }
 
-    /**
-     * Setter for cache miss count
-     *
-     * @param missCount
-     */
+    /** Setter for cache miss count */
     public void setMissCount(long missCount) {
         this.missCount = missCount;
     }
@@ -102,11 +94,7 @@ public class CacheStatistics implements Serializable {
         return evictionCount;
     }
 
-    /**
-     * Setter for cache eviction count
-     *
-     * @param evictionCount
-     */
+    /** Setter for cache eviction count */
     public void setEvictionCount(long evictionCount) {
         this.evictionCount = evictionCount;
     }
@@ -116,11 +104,7 @@ public class CacheStatistics implements Serializable {
         return totalCount;
     }
 
-    /**
-     * Setter for cache total count
-     *
-     * @param totalCount
-     */
+    /** Setter for cache total count */
     public void setTotalCount(long totalCount) {
         this.totalCount = totalCount;
     }
@@ -130,11 +114,7 @@ public class CacheStatistics implements Serializable {
         return hitRate;
     }
 
-    /**
-     * Setter for cache hit rate
-     *
-     * @param hitRate
-     */
+    /** Setter for cache hit rate */
     public void setHitRate(double hitRate) {
         this.hitRate = hitRate;
     }
@@ -144,11 +124,7 @@ public class CacheStatistics implements Serializable {
         return missRate;
     }
 
-    /**
-     * Setter for cache miss rate
-     *
-     * @param missRate
-     */
+    /** Setter for cache miss rate */
     public void setMissRate(double missRate) {
         this.missRate = missRate;
     }
@@ -158,11 +134,7 @@ public class CacheStatistics implements Serializable {
         return currentMemoryOccupation;
     }
 
-    /**
-     * Setter for cache memory occupation
-     *
-     * @param currentMemoryOccupation
-     */
+    /** Setter for cache memory occupation */
     public void setCurrentMemoryOccupation(double currentMemoryOccupation) {
         this.currentMemoryOccupation = currentMemoryOccupation;
     }
@@ -172,11 +144,7 @@ public class CacheStatistics implements Serializable {
         return totalSize;
     }
 
-    /**
-     * Setter for cache total size
-     *
-     * @param totalSize
-     */
+    /** Setter for cache total size */
     public void setTotalSize(long totalSize) {
         this.totalSize = totalSize;
     }
@@ -186,11 +154,7 @@ public class CacheStatistics implements Serializable {
         return actualSize;
     }
 
-    /**
-     * Setter for cache actual size
-     *
-     * @param actualSize
-     */
+    /** Setter for cache actual size */
     public void setActualSize(long actualSize) {
         this.actualSize = actualSize;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
@@ -423,11 +423,7 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
         }
     }
 
-    /**
-     * Setter for the store to wrap
-     *
-     * @param store
-     */
+    /** Setter for the store to wrap */
     public void setStore(BlobStore store) {
         blobStoreStateLock.lock();
         try {
@@ -456,11 +452,7 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
         }
     }
 
-    /**
-     * Setter for the cacheProvider to use
-     *
-     * @param cache
-     */
+    /** Setter for the cacheProvider to use */
     public void setCacheProvider(CacheProvider cache) {
         blobStoreStateLock.lock();
         try {
@@ -481,9 +473,7 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
      * * This method is used for converting a {@link TileObject} {@link Resource} into a {@link
      * ByteArrayResource}.
      *
-     * @param obj
      * @return a TileObject with resource stored in a Byte Array
-     * @throws StorageException
      */
     private TileObject getByteResourceTile(TileObject obj) throws StorageException {
         // Get TileObject resource
@@ -527,8 +517,6 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
     /**
      * Setter for the Cache Provider name, note that this cannot be used in combination with the
      * setCacheProvider method in the application Context initialization
-     *
-     * @param cacheBeanName
      */
     public void setCacheBeanName(String cacheBeanName) {
         blobStoreStateLock.lock();
@@ -783,10 +771,7 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
         /**
          * Executes an operation defined by the Enum.
          *
-         * @param store
-         * @param objs
          * @return operation result
-         * @throws StorageException
          */
         public abstract boolean executeOperation(BlobStore store, Object... objs)
                 throws StorageException;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/guava/GuavaCacheProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/guava/GuavaCacheProvider.java
@@ -133,11 +133,7 @@ public class GuavaCacheProvider implements CacheProvider {
         configure(config);
     }
 
-    /**
-     * This method is used for creating a new cache object, from the defined configuration.
-     *
-     * @param configuration
-     */
+    /** This method is used for creating a new cache object, from the defined configuration. */
     private void initCache(CacheConfiguration configuration) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Building new Cache");
@@ -514,7 +510,6 @@ public class GuavaCacheProvider implements CacheProvider {
     /**
      * * Static method for generating the {@link TileObject} cache key to use for caching.
      *
-     * @param obj
      * @return {@link TileObject} key
      */
     public static String generateTileKey(TileObject obj) {
@@ -652,12 +647,7 @@ public class GuavaCacheProvider implements CacheProvider {
             readLock = lock.readLock();
         }
 
-        /**
-         * Insertion of a {@link TileObject} key in the map for the associated Layer.
-         *
-         * @param layer
-         * @param id
-         */
+        /** Insertion of a {@link TileObject} key in the map for the associated Layer. */
         // not sure why locking is used on top of concurrent structures to start with... just
         // ignoring to move on, but imho all locks should be removed and concurrent structure
         // be used as intended (e.g., putIfAbsent and the like
@@ -708,12 +698,7 @@ public class GuavaCacheProvider implements CacheProvider {
             }
         }
 
-        /**
-         * Removal of a {@link TileObject} key in the map for the associated Layer.
-         *
-         * @param layer
-         * @param id
-         */
+        /** Removal of a {@link TileObject} key in the map for the associated Layer. */
         public void removeTile(String layer, String id) {
             // ReadLock is used because we are only accessing the map
             readLock.lock();
@@ -750,7 +735,6 @@ public class GuavaCacheProvider implements CacheProvider {
         /**
          * Removes a layer {@link Set} and returns it to the cache.
          *
-         * @param layer
          * @return the keys associated to the Layer
          */
         public Set<String> removeLayer(String layer) {

--- a/geowebcache/core/src/main/java/org/geowebcache/util/ByteUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ByteUtils.java
@@ -35,7 +35,6 @@ public class ByteUtils {
     /**
      * Combines four bytes (most significant bit first) into a 32 bit unsigned integer.
      *
-     * @param bytes
      * @param index of most significant byte
      * @return long with the 32 bit unsigned integer
      */

--- a/geowebcache/core/src/main/java/org/geowebcache/util/ExceptionUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ExceptionUtils.java
@@ -24,10 +24,6 @@ public class ExceptionUtils {
     /**
      * Returns true if the provided throwable is of the specified class, or if any of those is
      * suppresses is.
-     *
-     * @param e
-     * @param klazz
-     * @return
      */
     public static <T extends Throwable> boolean isOrSuppresses(T e, Class<? extends T> klazz) {
         return Streams.concat(Stream.of(e), Arrays.stream(e.getSuppressed()))

--- a/geowebcache/core/src/main/java/org/geowebcache/util/FileUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/FileUtils.java
@@ -65,7 +65,6 @@ public class FileUtils {
      *
      * <p>
      *
-     * @param path
      * @param filter used to implement the visitor pattern. The accept method may contain any
      *     desired logic, it will be called for all files and directories inside {@code path},
      *     recursively
@@ -175,12 +174,7 @@ public class FileUtils {
         }
     }
 
-    /**
-     * Prints the provided file tree structure onto the returned string
-     *
-     * @param dir
-     * @return
-     */
+    /** Prints the provided file tree structure onto the returned string */
     public static String printFileTree(File dir) {
         StringBuilder sb = new StringBuilder();
         sb.append(dir.getPath()).append("\n");

--- a/geowebcache/core/src/main/java/org/geowebcache/util/HttpClientBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/HttpClientBuilder.java
@@ -57,11 +57,6 @@ public class HttpClientBuilder {
      *
      * @param url The server url, or null if no authentication is required or if the client is going
      *     to be used against a single server only
-     * @param backendTimeout
-     * @param httpUsername
-     * @param httpPassword
-     * @param proxyUrl
-     * @param concurrency
      */
     public HttpClientBuilder(
             URL url,
@@ -125,8 +120,6 @@ public class HttpClientBuilder {
     /**
      * parses a proxyUrl parameter and configures (if possible) the builder to set a proxy when
      * generating a httpClient and (if possible) proxy authentication.
-     *
-     * @param proxyUrl
      */
     public void setProxy(URL proxyUrl) {
         this.proxyUrl = proxyUrl;
@@ -182,8 +175,6 @@ public class HttpClientBuilder {
     /**
      * returns true if this builder was configured to pass HTTP credentials to the generated
      * HttpClient.
-     *
-     * @return
      */
     public boolean isDoAuthentication() {
         return doAuthentication;

--- a/geowebcache/core/src/main/java/org/geowebcache/util/ResponseUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ResponseUtils.java
@@ -72,9 +72,6 @@ public final class ResponseUtils {
      * @param tileLayerDispatcher tiles dispatcher
      * @param defaultStorageFinder storage finder
      * @param runtimeStats runtime statistics
-     * @throws GeoWebCacheException
-     * @throws RequestFilterException
-     * @throws IOException
      */
     public static void writeTile(
             SecurityDispatcher secDispatcher,

--- a/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
@@ -50,8 +50,6 @@ public class ServletUtils {
     /**
      * Case insensitive lookup
      *
-     * @param map
-     * @param key
      * @return all matchings string
      */
     public static String[] stringsFromMap(Map<String, String[]> map, String encoding, String key) {
@@ -72,13 +70,7 @@ public class ServletUtils {
         return null;
     }
 
-    /**
-     * Case insensitive lookup
-     *
-     * @param map
-     * @param key
-     * @return
-     */
+    /** Case insensitive lookup */
     public static String stringFromMap(Map<String, String[]> map, String encoding, String key) {
         String[] strArray = stringsFromMap(map, encoding, key);
         if (strArray != null) {
@@ -87,13 +79,7 @@ public class ServletUtils {
         return null;
     }
 
-    /**
-     * Case insensitive lookup for a couple of strings, drops everything else
-     *
-     * @param map
-     * @param keys
-     * @return
-     */
+    /** Case insensitive lookup for a couple of strings, drops everything else */
     public static String[][] selectedStringArraysFromMap(
             Map<String, String[]> map, String encoding, String[] keys) {
         String[][] retAr = new String[keys.length][];
@@ -117,8 +103,6 @@ public class ServletUtils {
     /**
      * Case insensitive lookup for a couple of strings, drops everything else
      *
-     * @param map
-     * @param keys
      * @return map subset containing (URL decoded) values for {@code keys}, with keys normalized to
      *     upper case
      */
@@ -142,7 +126,6 @@ public class ServletUtils {
     /**
      * Extracts the cache control header
      *
-     * @param cacheControlHeader
      * @return Long representing expiration time in seconds
      */
     // public static Long extractHeaderMaxAge(URLConnection backendCon) {
@@ -171,7 +154,6 @@ public class ServletUtils {
      * @param bufferHint hint for the total buffer, -1 = 10240
      * @param tmpBufferSize how many bytes to read at a time, -1 = 1024
      * @return a compacted buffer with all the data
-     * @throws IOException
      */
     public static byte[] readStream(InputStream is, int bufferHint, int tmpBufferSize)
             throws IOException {
@@ -228,9 +210,6 @@ public class ServletUtils {
      * Makes HTTP Expire header value
      *
      * <p>Has to be synchronized due to the shared Calendar objects
-     *
-     * @param seconds
-     * @return
      */
     public static String makeExpiresHeader(int seconds) {
         return formatTimestamp(System.currentTimeMillis() + seconds * 1000L);
@@ -251,12 +230,7 @@ public class ServletUtils {
         return ret;
     }
 
-    /**
-     * Returns the expiration time in milliseconds from now
-     *
-     * @param expiresHeader
-     * @return
-     */
+    /** Returns the expiration time in milliseconds from now */
     public static long parseExpiresHeader(String expiresHeader) {
         if (expiresHeader == null) {
             return -1;
@@ -293,12 +267,7 @@ public class ServletUtils {
         return str.toString();
     }
 
-    /**
-     * Converts a byte to a hex String
-     *
-     * @param aByte
-     * @return
-     */
+    /** Converts a byte to a hex String */
     public static String hexOfByte(byte aByte) {
         char[] str = new char[2];
 
@@ -415,12 +384,7 @@ public class ServletUtils {
         return ret;
     }
 
-    /**
-     * Replaces occurrences of &gt; and &lt; with HTML equivalents
-     *
-     * @param str
-     * @return
-     */
+    /** Replaces occurrences of &gt; and &lt; with HTML equivalents */
     public static String disableHTMLTags(String str) {
         if (str == null) {
             return "null";
@@ -467,12 +431,7 @@ public class ServletUtils {
         }
     }
 
-    /**
-     * Generate the context path of the request, less the specified trailing path
-     *
-     * @param req
-     * @param trailingPath
-     */
+    /** Generate the context path of the request, less the specified trailing path */
     public static String getServletContextPath(
             HttpServletRequest req, String trailingPath, String servletPrefix) {
         String reqUrl = req.getRequestURL().toString();
@@ -486,12 +445,7 @@ public class ServletUtils {
         return context;
     }
 
-    /**
-     * Generate the context path of the request, try the specified trailing path
-     *
-     * @param req
-     * @param trailingPaths
-     */
+    /** Generate the context path of the request, try the specified trailing path */
     public static String getServletContextPath(
             HttpServletRequest req, String[] trailingPaths, String servletPrefix) {
         String context = "";

--- a/geowebcache/core/src/main/java/org/geowebcache/util/Sleeper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/Sleeper.java
@@ -21,10 +21,6 @@ package org.geowebcache.util;
  */
 @FunctionalInterface
 public interface Sleeper {
-    /**
-     * @see Thread#sleep(long)
-     * @param millis
-     * @throws InterruptedException
-     */
+    /** @see Thread#sleep(long) */
     public void sleep(long millis) throws InterruptedException;
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/MockExtensionRule.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/MockExtensionRule.java
@@ -54,8 +54,6 @@ public class MockExtensionRule extends ExternalResource {
      * If true this rule will modify the static context used by GeoWebCacheExtensions by default.
      * Otherwise only the context produced by this rule will be affected. Only one rule affecting
      * the static context can be active at one time.
-     *
-     * @param staticContext
      */
     public MockExtensionRule(boolean staticContext) {
         super();
@@ -90,13 +88,7 @@ public class MockExtensionRule extends ExternalResource {
                         new ContextInvocationHandler());
     }
 
-    /**
-     * Register a mock extension bean
-     *
-     * @param name
-     * @param bean
-     * @param classes
-     */
+    /** Register a mock extension bean */
     public void addBean(String name, Object bean, Class<?>... classes) {
         for (Class<?> clazz : classes) {
             Collection<String> c = types.getOrDefault(clazz, new ArrayList<>());
@@ -122,11 +114,7 @@ public class MockExtensionRule extends ExternalResource {
         }
     }
 
-    /**
-     * Get the mock ApplicationContext that contains the mock extension beans
-     *
-     * @return
-     */
+    /** Get the mock ApplicationContext that contains the mock extension beans */
     public ApplicationContext getMockContext() {
         if (Objects.isNull(mockContext)) {
             throw new IllegalStateException("Mock context only available while rule is active");

--- a/geowebcache/core/src/test/java/org/geowebcache/TestHelpers.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/TestHelpers.java
@@ -118,12 +118,7 @@ public class TestHelpers {
         return req;
     }
 
-    /**
-     * Matcher for an {@link HttpServletResponse} that checks its status.
-     *
-     * @param expected
-     * @return
-     */
+    /** Matcher for an {@link HttpServletResponse} that checks its status. */
     public static Matcher<HttpServletResponse> hasStatus(HttpStatus expected) {
         return new BaseMatcher<HttpServletResponse>() {
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/BlobStoreConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/BlobStoreConfigurationTest.java
@@ -576,7 +576,6 @@ public abstract class BlobStoreConfigurationTest
      * Set up the configuration for a modify test with an info named "test".
      *
      * @return an info named "test" with a different value
-     * @throws Exception
      */
     protected BlobStoreInfo prepForModify() throws Exception {
         BlobStoreInfo goodInfo = this.getGoodInfo("test", 1);
@@ -670,7 +669,6 @@ public abstract class BlobStoreConfigurationTest
      * Set up the configuration for a rename test with an info named "test".
      *
      * @return an info named "test2"
-     * @throws Exception
      */
     protected BlobStoreInfo prepForRename() throws Exception {
         BlobStoreInfo goodInfo = this.getGoodInfo("test", 1);
@@ -785,7 +783,6 @@ public abstract class BlobStoreConfigurationTest
      * Set up the configuration for a remove test with an info named "test".
      *
      * @return the info that was added
-     * @throws Exception
      */
     protected BlobStoreInfo prepForRemove() throws Exception {
         BlobStoreInfo goodInfo = this.getGoodInfo("test", 1);

--- a/geowebcache/core/src/test/java/org/geowebcache/config/ConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/ConfigurationTest.java
@@ -294,13 +294,7 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
         assertThat(retrieved, isPresent(not(infoEquals(2))));
     }
 
-    /**
-     * Modify an existing info object.
-     *
-     * @param info
-     * @param rand
-     * @throws Exception
-     */
+    /** Modify an existing info object. */
     protected abstract void doModifyInfo(I info, int rand) throws Exception;
 
     @Test
@@ -474,7 +468,6 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
      *
      * @param id ID for the GridSet
      * @param rand GridSets created with different values should not be equal to one another.
-     * @return
      */
     protected abstract I getGoodInfo(String id, int rand) throws Exception;
 
@@ -484,49 +477,30 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
      *
      * @param id ID for the GridSet
      * @param rand GridSets created with different values should not be equal to one another.
-     * @return
      */
     protected abstract I getBadInfo(String id, int rand) throws Exception;
 
     /**
      * Get an ID for a pre-existing GridSet. Throw AssumptionViolatedException if this this
      * configuration does not have existing GridSets.
-     *
-     * @return
      */
     protected abstract String getExistingInfo();
 
-    /**
-     * Create a GridSetConfiguration to test.
-     *
-     * @return
-     * @throws Exception
-     */
+    /** Create a GridSetConfiguration to test. */
     protected abstract C getConfig() throws Exception;
     /**
      * Create a second config from the same persistence source or throw AssumptionViolatedException
      * if this is a non-persistent configuration.
-     *
-     * @return
-     * @throws Exception
      */
     protected abstract C getSecondConfig() throws Exception;
 
     /**
      * Check that two GridSets created by calls to getGoodGridSet, which may have been persisted and
      * depersisted, are equal if and only if they had the same rand value.
-     *
-     * @param expected
-     * @return
      */
     protected abstract Matcher<I> infoEquals(final I expected);
 
-    /**
-     * Check that an info has the specified test value.
-     *
-     * @param rand
-     * @return
-     */
+    /** Check that an info has the specified test value. */
     protected abstract Matcher<I> infoEquals(final int rand);
 
     protected abstract void addInfo(C config, I info) throws Exception;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationRoundTripTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationRoundTripTest.java
@@ -34,8 +34,6 @@ public class GWCConfigIntegrationRoundTripTest {
      * Tests {@link XMLConfiguration} persistence by initializing a configuration, constructing a
      * new configuration from the resulting geowebcache.xml, and validating some basic assumptions
      * about the new config.
-     *
-     * @throws Exception
      */
     @Test
     public void testXMLConfiguration() throws Exception {

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationConstructorsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationConstructorsTest.java
@@ -93,10 +93,7 @@ public class XMLConfigurationConstructorsTest {
         FileUtils.copyURLToFile(source, configFile);
     }
 
-    /**
-     * @param dir
-     * @return
-     */
+    /** */
     protected File configFile(File dir) {
         return new File(dir, XMLConfiguration.DEFAULT_CONFIGURATION_FILE_NAME);
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/BoundingBoxTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/BoundingBoxTest.java
@@ -15,8 +15,6 @@ public class BoundingBoxTest extends TestCase {
      * strings.
      *
      * <p>Ff not you should figure out where it is used.
-     *
-     * @throws Exception
      */
     public void testBBOX() throws Exception {
         BoundingBox bbox = new BoundingBox(-180.0, -90.0, 180.0, 90.0);
@@ -54,11 +52,7 @@ public class BoundingBoxTest extends TestCase {
         assertTrue(Arrays.equals(new double[] {5, 5, 10, 10}, intersection.getCoords()));
     }
 
-    /**
-     * Two bboxes don't intersect, BoundingBox.intersection()'s result should be the empty bbox
-     *
-     * @throws Exception
-     */
+    /** Two bboxes don't intersect, BoundingBox.intersection()'s result should be the empty bbox */
     public void testIntersectionNonIntersecting() throws Exception {
         BoundingBox bb1 = new BoundingBox(0, 0, 10, 10);
         BoundingBox bb2 = new BoundingBox(11, 11, 20, 20);

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridSubSetTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridSubSetTest.java
@@ -34,11 +34,7 @@ public class GridSubSetTest {
         assertNotNull(result);
     }
 
-    /**
-     * Creation of a PNG test Layer with a non-zero zoomStart parameter for the test.
-     *
-     * @return
-     */
+    /** Creation of a PNG test Layer with a non-zero zoomStart parameter for the test. */
     private static WMSLayer createWMSLayer() {
         // Subsets table
         Hashtable<String, GridSubset> grids = new Hashtable<String, GridSubset>();

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/HttpClientTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/HttpClientTest.java
@@ -36,8 +36,6 @@ public class HttpClientTest extends TestCase {
      *
      * <p>Core i7 , Java 1.6 values: 1 000 000 in 559 ms 1 00 000 in 267 ms 10 000 in 186 ms 1 000
      * in 134 ms
-     *
-     * @throws Exception
      */
     public void testHttpClientConstruction() throws Exception {
         if (RUN_PERFORMANCE_TEST) {

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
@@ -73,8 +73,6 @@ public class SeedTaskTest extends TestCase {
     /**
      * For a metatiled seed request over a given zoom level, make sure the correct wms calls are
      * issued
-     *
-     * @throws Exception
      */
     @SuppressWarnings("serial")
     public void testSeedWMSRequests() throws Exception {
@@ -158,8 +156,6 @@ public class SeedTaskTest extends TestCase {
     /**
      * For a metatiled seed request over a given zoom level, make sure the correct wms calls are
      * issued
-     *
-     * @throws Exception
      */
     public void testSeedRetries() throws Exception {
         WMSLayer tl = createWMSLayer("image/png");
@@ -258,8 +254,6 @@ public class SeedTaskTest extends TestCase {
     /**
      * Make sure when seeding a given zoom level, the correct tiles are sent to the {@link
      * StorageBroker}
-     *
-     * @throws Exception
      */
     @SuppressWarnings("serial")
     public void testSeedStoredTiles() throws Exception {

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
@@ -61,11 +61,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
     @Before
     public abstract void createTestUnit() throws Exception;
 
-    /**
-     * Override and add tear down assertions after calling super
-     *
-     * @throws Exception
-     */
+    /** Override and add tear down assertions after calling super */
     @After
     public void destroyTestUnit() throws Exception {
         // Might be null if an Assumption failed during createTestUnit

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/SuitabilityCheckRule.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/SuitabilityCheckRule.java
@@ -31,33 +31,19 @@ public class SuitabilityCheckRule extends PropertyRule {
         super(props, CompositeBlobStore.GEOWEBCACHE_BLOBSTORE_SUITABILITY_CHECK);
     }
 
-    /**
-     * Create a rule to override the system property
-     *
-     * @param name
-     * @return
-     */
+    /** Create a rule to override the system property */
     public static SuitabilityCheckRule system() {
         return new SuitabilityCheckRule(System.getProperties());
     }
 
-    /**
-     * Create a rule to override the system property
-     *
-     * @param name
-     * @return
-     */
+    /** Create a rule to override the system property */
     public static SuitabilityCheckRule system(CompositeBlobStore.StoreSuitabilityCheck value) {
         SuitabilityCheckRule rule = new SuitabilityCheckRule(System.getProperties());
         rule.initial = value;
         return rule;
     }
 
-    /**
-     * Set the StoreSuitabilityCheck property
-     *
-     * @param value
-     */
+    /** Set the StoreSuitabilityCheck property */
     public void setValue(CompositeBlobStore.StoreSuitabilityCheck value) {
         setValue(value.name());
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
@@ -264,7 +264,6 @@ public class MemoryBlobStoreTest {
      * * Private method for creating a {@link FileBlobStore}
      *
      * @return a new FileBlobStore
-     * @throws Exception
      */
     private BlobStore setup() throws Exception {
         File fh = new File(StorageBrokerTest.findTempDir() + File.separator + TEST_BLOB_DIR_NAME);

--- a/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/FileMatchers.java
@@ -38,11 +38,7 @@ public class FileMatchers {
         throw new IllegalStateException();
     };
 
-    /**
-     * Matcher for a file that exists
-     *
-     * @return
-     */
+    /** Matcher for a file that exists */
     public static Matcher<File> exists() {
         return new BaseMatcher<File>() {
 
@@ -73,11 +69,7 @@ public class FileMatchers {
         };
     }
 
-    /**
-     * Matcher for a regular (non-directory) file
-     *
-     * @return
-     */
+    /** Matcher for a regular (non-directory) file */
     public static Matcher<File> file() {
         return new BaseMatcher<File>() {
 
@@ -113,11 +105,7 @@ public class FileMatchers {
         };
     }
 
-    /**
-     * Matcher for a directory
-     *
-     * @return
-     */
+    /** Matcher for a directory */
     public static Matcher<File> directory() {
         return new BaseMatcher<File>() {
 
@@ -153,11 +141,7 @@ public class FileMatchers {
         };
     }
 
-    /**
-     * Matcher for a directory's contents
-     *
-     * @return
-     */
+    /** Matcher for a directory's contents */
     public static Matcher<File> directoryContaining(Matcher<Iterable<File>> filesMatcher) {
         return new BaseMatcher<File>() {
 
@@ -201,12 +185,7 @@ public class FileMatchers {
         return directoryContaining(Matchers.emptyIterableOf(File.class));
     }
 
-    /**
-     * Matcher for last modified time
-     *
-     * @param timeMatcher
-     * @return
-     */
+    /** Matcher for last modified time */
     public static Matcher<File> lastModified(final Matcher<Long> timeMatcher) {
         return new BaseMatcher<File>() {
 
@@ -244,12 +223,7 @@ public class FileMatchers {
         };
     }
 
-    /**
-     * Matcher for file with a particular name
-     *
-     * @param timeMatcher
-     * @return
-     */
+    /** Matcher for file with a particular name */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static Matcher<File> named(String name) {
         return both(instanceOf(File.class)).and((Matcher) hasProperty("name", equalTo(name)));
@@ -258,10 +232,6 @@ public class FileMatchers {
     /**
      * Executes the given {@link Callable} and then returns a matcher for values of {@link
      * System#currentTimeMillis()} during the execution.
-     *
-     * @param stuffToDo
-     * @return
-     * @throws Exception
      */
     public static Matcher<Long> whileRunning(Callable<Void> stuffToDo) throws Exception {
         final long start = System.currentTimeMillis();

--- a/geowebcache/core/src/test/java/org/geowebcache/util/LogTestWrapper.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/LogTestWrapper.java
@@ -35,22 +35,14 @@ public abstract class LogTestWrapper extends SetSingletonRule<Log> implements Lo
 
     private Optional<Level> level;
 
-    /**
-     * Create a wrapper that overrides the log level
-     *
-     * @param level
-     */
+    /** Create a wrapper that overrides the log level */
     public LogTestWrapper(Level level) {
         super();
         setNewValue(() -> this);
         this.level = Optional.of(level);
     }
 
-    /**
-     * Create a wrapper
-     *
-     * @param level
-     */
+    /** Create a wrapper */
     public LogTestWrapper() {
         super();
         setNewValue(() -> this);
@@ -143,32 +135,17 @@ public abstract class LogTestWrapper extends SetSingletonRule<Log> implements Lo
 
     List<LogEntry> entries = new LinkedList<>();
 
-    /**
-     * Get the entries that have been logged by the wrapper
-     *
-     * @return
-     */
+    /** Get the entries that have been logged by the wrapper */
     public List<LogEntry> getEntries() {
         return entries;
     }
 
-    /**
-     * Add an entry to the log
-     *
-     * @param level
-     * @param message
-     * @param thrown
-     */
+    /** Add an entry to the log */
     protected void log(Level level, Object message, Throwable thrown) {
         entries.add(new LogEntry(level, message, thrown));
     }
 
-    /**
-     * Add an entry to the log
-     *
-     * @param level
-     * @param message
-     */
+    /** Add an entry to the log */
     protected void log(Level level, Object message) {
         entries.add(new LogEntry(level, message));
     }
@@ -245,45 +222,24 @@ public abstract class LogTestWrapper extends SetSingletonRule<Log> implements Lo
         getOldValue().fatal(message, t);
     }
 
-    /**
-     * Matcher for the level of an entry
-     *
-     * @param level
-     * @return
-     */
+    /** Matcher for the level of an entry */
     public static Matcher<LogEntry> level(Level level) {
         return Matchers.describedAs(
                 "Log entry at level %0", hasProperty("level", is(level)), level);
     }
 
-    /**
-     * Matcher for the message of an entry
-     *
-     * @param match
-     * @return
-     */
+    /** Matcher for the message of an entry */
     public static Matcher<LogEntry> message(Matcher<String> match) {
         return Matchers.describedAs(
                 "Log entry with message %0", hasProperty("message", match), match);
     }
 
-    /**
-     * Matcher for the exception causing the log entry
-     *
-     * @param match
-     * @return
-     */
+    /** Matcher for the exception causing the log entry */
     public static Matcher<LogEntry> thrown(Matcher<Throwable> match) {
         return Matchers.describedAs("Log entry with cause", hasProperty("thrown", match), match);
     }
 
-    /**
-     * Create a log wrapper using the given injector methods
-     *
-     * @param get
-     * @param set
-     * @return
-     */
+    /** Create a log wrapper using the given injector methods */
     public static LogTestWrapper wrap(Supplier<Log> get, Consumer<Log> set) {
         return new LogTestWrapper() {
 
@@ -299,14 +255,7 @@ public abstract class LogTestWrapper extends SetSingletonRule<Log> implements Lo
         };
     }
 
-    /**
-     * Create a log wrapper using the given injector methods and level
-     *
-     * @param get
-     * @param set
-     * @param level
-     * @return
-     */
+    /** Create a log wrapper using the given injector methods and level */
     public static LogTestWrapper wrap(Supplier<Log> get, Consumer<Log> set, Level level) {
         return new LogTestWrapper(level) {
 

--- a/geowebcache/core/src/test/java/org/geowebcache/util/PropertyRule.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/PropertyRule.java
@@ -13,42 +13,24 @@ public class PropertyRule extends SetSingletonRule<String> {
 
     final String name;
 
-    /**
-     * Create a rule to override a system property
-     *
-     * @param name
-     * @return
-     */
+    /** Create a rule to override a system property */
     public static PropertyRule system(String name) {
         return new PropertyRule(System.getProperties(), name);
     }
 
-    /**
-     * Create a rule to override a property in the given Properties
-     *
-     * @param name
-     * @return
-     */
+    /** Create a rule to override a property in the given Properties */
     public PropertyRule(Properties props, String name) {
         super();
         this.props = props;
         this.name = name;
     }
 
-    /**
-     * Set the original value of the property
-     *
-     * @return
-     */
+    /** Set the original value of the property */
     public String getOldValue() {
         return oldValue;
     }
 
-    /**
-     * Set the value of the property
-     *
-     * @return
-     */
+    /** Set the value of the property */
     public void setValue(String value) {
         if (Objects.nonNull(value)) {
             props.setProperty(name, value);
@@ -57,20 +39,12 @@ public class PropertyRule extends SetSingletonRule<String> {
         }
     }
 
-    /**
-     * Get the name of the property
-     *
-     * @return
-     */
+    /** Get the name of the property */
     public String getName() {
         return name;
     }
 
-    /**
-     * Set the current value of the property
-     *
-     * @return
-     */
+    /** Set the current value of the property */
     @Override
     public String getValue() {
         return props.getProperty(name);

--- a/geowebcache/core/src/test/java/org/geowebcache/util/SetSingletonRule.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/SetSingletonRule.java
@@ -40,7 +40,6 @@ public abstract class SetSingletonRule<T> extends ExternalResource {
      * @param set Setter for the singleton value
      * @param newValue Supplier for value to set the value to on start. Do not set on test start if
      *     null.
-     * @return
      */
     public static <T> SetSingletonRule<T> create(
             Supplier<T> get, Consumer<T> set, @Nullable Supplier<T> newValue) {
@@ -61,7 +60,6 @@ public abstract class SetSingletonRule<T> extends ExternalResource {
     /**
      * @param get Getter for the singleton value
      * @param set Setter for the singleton value
-     * @return
      */
     public static <T> SetSingletonRule<T> create(Supplier<T> get, Consumer<T> set) {
         return create(get, set, null);
@@ -90,11 +88,7 @@ public abstract class SetSingletonRule<T> extends ExternalResource {
     /** Getter for the singleton value */
     public abstract T getValue();
 
-    /**
-     * Get the old value of the singleton
-     *
-     * @return
-     */
+    /** Get the old value of the singleton */
     public T getOldValue() {
         return oldValue;
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/util/TestUtils.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/TestUtils.java
@@ -189,12 +189,7 @@ public class TestUtils {
         return hasProperty("present", is(true));
     }
 
-    /**
-     * Match string matching a regular expression
-     *
-     * @param regex
-     * @return
-     */
+    /** Match string matching a regular expression */
     public static Matcher<String> matchesRegex(String regex) {
         final Pattern p = Pattern.compile(regex);
         return new CustomMatcher<String>("matching /" + regex + "/") {
@@ -210,7 +205,6 @@ public class TestUtils {
      * Assert that an Optional is present, and returns its value if it is. Use this for checking the
      * behaviour of the unit under test.
      *
-     * @param opt
      * @return The optional's value
      */
     public static <T> T assertPresent(Optional<T> opt) throws AssertionError {
@@ -221,7 +215,6 @@ public class TestUtils {
      * Require that an Optional is present, and returns its value if it is. Use this where the test
      * should have ensured that it will be present.
      *
-     * @param opt
      * @return The optional's value
      */
     public static <T> T requirePresent(Optional<T> opt) throws IllegalStateException {

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
@@ -125,10 +125,7 @@ public class BDBQuotaStore implements QuotaStore {
         this.diskQuotaEnabled = !disabled;
     }
 
-    /**
-     * @throws InterruptedException
-     * @see {@link #close()}
-     */
+    /** @see {@link #close()} */
     public void startUp() throws InterruptedException, IOException {
         if (!diskQuotaEnabled) {
             log.info(

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/EntityStoreBuilder.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/EntityStoreBuilder.java
@@ -38,11 +38,9 @@ public class EntityStoreBuilder {
     }
 
     /**
-     * @param storeDirectory
      * @param bdbEnvProperties properties for the {@link EnvironmentConfig}, or {@code null}. If not
      *     provided {@code environment.properties} will be looked up for inside {@code
      *     storeDirectory}
-     * @return
      */
     public EntityStore buildEntityStore(
             final File storeDirectory, final Properties bdbEnvProperties) {

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -232,8 +232,6 @@ public class BDBQuotaStoreTest {
     /**
      * Combined test for {@link BDBQuotaStore#addToQuotaAndTileCounts(TileSet, Quota, Collection)}
      * and {@link BDBQuotaStore#addHitsAndSetAccesTime(Collection)}
-     *
-     * @throws Exception
      */
     @Test
     public void testPageStatsGathering() throws Exception {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/CacheCleaner.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/CacheCleaner.java
@@ -122,7 +122,6 @@ public class CacheCleaner implements DisposableBean {
      *
      * @param layerNames the layers to expire tile pages from
      * @param quotaResolver live limit and used quota to monitor until it reaches its limit
-     * @throws InterruptedException
      * @see {@link org.geowebcache.diskquota.ExpirationPolicy#expireByLayerNames}
      */
     public void expireByLayerNames(

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
@@ -50,7 +50,6 @@ import org.geowebcache.io.GeoWebCacheXStream;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.storage.DefaultStorageFinder;
-import org.geowebcache.storage.StorageException;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.springframework.util.Assert;
 
@@ -86,7 +85,6 @@ public class ConfigLoader {
      *     file
      * @param tld used only to validate the presence of a layer at {@link #loadConfig()} and ignore
      *     the layer quota definition if the {@link TileLayer} does not exist
-     * @throws IOException
      */
     public ConfigLoader(
             final DefaultStorageFinder storageFinder,
@@ -105,7 +103,6 @@ public class ConfigLoader {
      * @param storageFinder used to get the location of the cache directory
      * @param tld used only to validate the presence of a layer at {@link #loadConfig()} and ignore
      *     the layer quota definition if the {@link TileLayer} does not exist
-     * @throws IOException
      */
     public ConfigLoader(
             final ConfigurationResourceProvider resourceProvider,
@@ -117,13 +114,7 @@ public class ConfigLoader {
         this.tileLayerDispatcher = tld;
     }
 
-    /**
-     * Saves the configuration to the root cache directory
-     *
-     * @param config
-     * @throws IOException
-     * @throws ConfigurationException
-     */
+    /** Saves the configuration to the root cache directory */
     public void saveConfig(DiskQuotaConfig config) throws IOException, ConfigurationException {
         if (!resourceProvider.hasOutput()) {
             log.error("Unable to save DiskQuota to resource :" + resourceProvider.getLocation());
@@ -302,14 +293,7 @@ public class ConfigLoader {
         return xs;
     }
 
-    /**
-     * Opens an output stream for a file relative to the cache storage folder
-     *
-     * @param fileNameRelPath
-     * @return
-     * @throws IOException
-     * @throws ConfigurationException
-     */
+    /** Opens an output stream for a file relative to the cache storage folder */
     public OutputStream getStorageOutputStream(String... fileNameRelPath)
             throws IOException, ConfigurationException {
         File rootCacheDir = getFileStorageDir(fileNameRelPath);
@@ -322,9 +306,7 @@ public class ConfigLoader {
      * Opens a stream over an existing file relative to the cache storage folder
      *
      * @param fileNameRelPath the file name relative to the cache storage folder to open
-     * @return
      * @throws IOException if {@code fileName} doesn't exist
-     * @throws ConfigurationException
      */
     public InputStream getStorageInputStream(String... fileNameRelPath)
             throws IOException, ConfigurationException {
@@ -337,8 +319,6 @@ public class ConfigLoader {
     /**
      * @param fileNameRelPath file path relative to the cache storage directory, where the last
      *     entry is the file name and any previous one directory names
-     * @return
-     * @throws StorageException
      */
     private File getFileStorageDir(String[] fileNameRelPath) throws ConfigurationException {
         File parentDir = getRootCacheDir();

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaConfig.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaConfig.java
@@ -252,20 +252,12 @@ public class DiskQuotaConfig implements Cloneable, Serializable {
         return clone;
     }
 
-    /**
-     * Returns the quota store name
-     *
-     * @return
-     */
+    /** Returns the quota store name */
     public String getQuotaStore() {
         return quotaStore;
     }
 
-    /**
-     * Sets the quota store name
-     *
-     * @param quotaStore
-     */
+    /** Sets the quota store name */
     public void setQuotaStore(String quotaStore) {
         this.quotaStore = quotaStore;
     }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaMonitor.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaMonitor.java
@@ -101,8 +101,6 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
     /**
      * @param configLoader loads and saves the layers quota config and usage status
      * @param tld provides access to the layers configured for disk quota insurance quota usage
-     * @throws IOException
-     * @throws ConfigurationException
      */
     public DiskQuotaMonitor(
             final DefaultStorageFinder storageFinder,
@@ -139,11 +137,7 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
         return quotaStoreProvider;
     }
 
-    /**
-     * Returns the quota store monitored by this class
-     *
-     * @return
-     */
+    /** Returns the quota store monitored by this class */
     public QuotaStore getQuotaStore() {
         return quotaStore;
     }
@@ -210,7 +204,6 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
      *   <li>{@link #isRunning() == true}
      * </ul>
      *
-     * @throws ConfigurationException
      * @see {@link #shutDown(int)}
      */
     public void startUp() throws ConfigurationException, IOException {
@@ -329,8 +322,6 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
      * <ul>
      *   <li>{@link #isEnabled() == true}
      * </ul>
-     *
-     * @param config
      */
     public void saveConfig(DiskQuotaConfig config) {
         Assert.isTrue(diskQuotaEnabled, "called saveConfig but DiskQuota is disabled!");
@@ -346,12 +337,7 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
         }
     }
 
-    /**
-     * Reloads the configuration from disk
-     *
-     * @throws IOException
-     * @throws ConfigurationException
-     */
+    /** Reloads the configuration from disk */
     public void reloadConfig() throws ConfigurationException, IOException {
         DiskQuotaConfig config = configLoader.loadConfig();
         this.quotaConfig.setFrom(config);
@@ -365,9 +351,6 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
     /**
      * Launches a background task to traverse the cache and compute the disk usage of each layer
      * that has no {@link LayerQuota#getUsedQuota() used quota} already loaded.
-     *
-     * @return
-     * @throws InterruptedException
      */
     private LayerCacheInfoBuilder launchCacheInfoGatheringThreads() throws InterruptedException {
 
@@ -438,8 +421,6 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
      * Sets the {@link LayerQuota#setExpirationPolicy(ExpirationPolicy) expiration policy} to all
      * the configured layer quotas based on their {@link LayerQuota#getExpirationPolicyName()
      * declared expiration policy name}
-     *
-     * @throws ConfigurationException
      */
     private void attachConfiguredLayers() throws ConfigurationException {
 

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
@@ -86,8 +86,6 @@ final class LayerCacheInfoBuilder {
      * <p>Note the cache information gathering is performed asynchronously and hence this method
      * returns immediately. To check whether the information collect for a given layer has finished
      * use the {@link #isRunning(String) isRunning(layerName)} method.
-     *
-     * @param tileLayer
      */
     public void buildCacheInfo(final TileLayer tileLayer) {
 
@@ -317,7 +315,6 @@ final class LayerCacheInfoBuilder {
      * Returns whether cache information is still being gathered for the layer named after {@code
      * layerName}.
      *
-     * @param layerName
      * @return {@code true} if the cache information gathering for {@code layerName} is not finished
      */
     public boolean isRunning(String layerName) {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesConsumer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesConsumer.java
@@ -217,10 +217,7 @@ public class QueuedQuotaUpdatesConsumer implements Callable<Long> {
         return null;
     }
 
-    /**
-     * @param updateData
-     * @throws InterruptedException
-     */
+    /** */
     private void performAggregatedUpdate(final QuotaUpdate updateData) throws InterruptedException {
 
         final TileSet tileSet = updateData.getTileSet();
@@ -237,11 +234,7 @@ public class QueuedQuotaUpdatesConsumer implements Callable<Long> {
         accumulatedUpdate.add(updateData);
     }
 
-    /**
-     * Makes sure no cached updates are held for too long before synchronizing with the store
-     *
-     * @throws InterruptedException
-     */
+    /** Makes sure no cached updates are held for too long before synchronizing with the store */
     private void checkAggregatedTimeouts() throws InterruptedException {
         if (aggregatedDelayedUpdates.size() == 0) {
             return;
@@ -272,10 +265,8 @@ public class QueuedQuotaUpdatesConsumer implements Callable<Long> {
      * store, either because it's been held for too long, or because too many updates have happened
      * on it since the last time it was saved to the store.
      *
-     * @param timedUpadte
      * @return {@code true} if it's ok to prune the timedUpdate from the {@link
      *     #aggregatedDelayedUpdates local cache}
-     * @throws InterruptedException
      */
     private boolean checkAggregatedTimeout(TimedQuotaUpdate timedUpadte)
             throws InterruptedException {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesProducer.java
@@ -160,10 +160,6 @@ class QueuedQuotaUpdatesProducer implements BlobStoreListener {
      * QuotaUpdate} payload to {@link #queuedUpdates} so that the consumer thread performs the
      * update without blocking the calling thread.
      *
-     * @param layerName
-     * @param gridSetId
-     * @param blobFormat
-     * @param parametersId
      * @param amount positive to signal a quota increase, negative to signal a quota decrease
      * @param tileIndex tile index
      */

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
@@ -73,10 +73,7 @@ public class QueuedUsageStatsConsumer implements Callable<Long> {
         }
     }
 
-    /**
-     * @param quotaStore
-     * @param queue
-     */
+    /** */
     public QueuedUsageStatsConsumer(
             final QuotaStore quotaStore,
             final BlockingQueue<UsageStats> queue,
@@ -154,7 +151,6 @@ public class QueuedUsageStatsConsumer implements Callable<Long> {
     /**
      * @param requestedTile represents a single tile that was requested and for which its tile page
      *     needs to be looked up and updated
-     * @throws InterruptedException
      */
     private void performAggregatedUpdate(final UsageStats requestedTile)
             throws InterruptedException {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStore.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStore.java
@@ -34,16 +34,13 @@ public interface QuotaStore {
      * Returns the globally used quota
      *
      * @return A Quota object (may be null)
-     * @throws InterruptedException
      */
     public abstract Quota getGloballyUsedQuota() throws InterruptedException;
 
     /**
      * Returns the quota used by the specified tileSetId
      *
-     * @param tileSetId
      * @return A Quota object (never null)
-     * @throws InterruptedException
      */
     public abstract Quota getUsedQuotaByTileSetId(final String tileSetId)
             throws InterruptedException;
@@ -54,10 +51,8 @@ public interface QuotaStore {
             throws InterruptedException;
 
     /**
-     * @param layerName
      * @return the used quota for the given layer, may need to create a new one before returning if
      *     no quota usage information for that layer already exists
-     * @throws InterruptedException
      */
     public abstract Quota getUsedQuotaByLayerName(final String layerName)
             throws InterruptedException;
@@ -75,10 +70,6 @@ public interface QuotaStore {
     /**
      * Adds the {@link TilePage#getNumPresentTilesInPage() number of tiles} present in each of the
      * argument pages
-     *
-     * @param quotaDiff
-     * @param tileCountDiffs
-     * @throws InterruptedException
      */
     public abstract void addToQuotaAndTileCounts(
             final TileSet tileSet,
@@ -92,26 +83,15 @@ public interface QuotaStore {
      * values for the stored versions of the page statistics using {@link
      * PageStats#addHitsAndAccessTime(long, int, int)}; these values are influenced by the {@code
      * PageStats}' {@link PageStats#getFillFactor() fillFactor}.
-     *
-     * @param statsUpdates
-     * @return
      */
     public abstract Future<List<PageStats>> addHitsAndSetAccesTime(
             final Collection<PageStatsPayload> statsUpdates);
 
-    /**
-     * @param layerNames
-     * @return
-     * @throws InterruptedException
-     */
+    /** */
     public abstract TilePage getLeastFrequentlyUsedPage(final Set<String> layerNames)
             throws InterruptedException;
 
-    /**
-     * @param layerNames
-     * @return
-     * @throws InterruptedException
-     */
+    /** */
     public abstract TilePage getLeastRecentlyUsedPage(final Set<String> layerNames)
             throws InterruptedException;
 
@@ -121,10 +101,6 @@ public interface QuotaStore {
 
     public abstract void deleteParameters(String layerName, String parametersId);
 
-    /**
-     * Closes the quota store, releasing any resources the store might be depending onto
-     *
-     * @throws Exception
-     */
+    /** Closes the quota store, releasing any resources the store might be depending onto */
     public abstract void close() throws Exception;
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreFactory.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreFactory.java
@@ -31,18 +31,10 @@ public interface QuotaStoreFactory {
      * cannot be handled
      *
      * @param ctx the application context, should the store depend on other beans
-     * @param quotaStoreName
-     * @return
-     * @throws ConfigurationException
-     * @throws Exception
      */
     public QuotaStore getQuotaStore(ApplicationContext ctx, String quotaStoreName)
             throws IOException, ConfigurationException;
 
-    /**
-     * Lists the quota store names supported by this factory
-     *
-     * @return
-     */
+    /** Lists the quota store names supported by this factory */
     List<String> getSupportedStoreNames();
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaUpdate.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaUpdate.java
@@ -25,13 +25,8 @@ public class QuotaUpdate {
     private long[] tileIndex;
 
     /**
-     * @param layerName
-     * @param gridsetId
-     * @param blobFormat
-     * @param parametersId
      * @param size bytes to add or subtract from a quota: positive value increase quota, negative
      *     value decreases it
-     * @param tileIndex
      */
     public QuotaUpdate(
             String layerName,

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/rest/controller/DiskQuotaController.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/rest/controller/DiskQuotaController.java
@@ -110,8 +110,6 @@ public class DiskQuotaController {
     /**
      * Applies the set values in {@code newConfig} (the non null ones) to {@code config}
      *
-     * @param config
-     * @param newConfig
      * @throws IllegalArgumentException as per {@link DiskQuotaConfig#setCacheCleanUpFrequency},
      *     {@link DiskQuotaConfig#setDiskBlockSize}, {@link
      *     DiskQuotaConfig#setMaxConcurrentCleanUps} , {@link DiskQuotaConfig#setCacheCleanUpUnits}
@@ -174,9 +172,7 @@ public class DiskQuotaController {
     /**
      * Private method for retunring a JSON representation of the Statistics
      *
-     * @param config
      * @return a {@link ResponseEntity} object
-     * @throws JSONException
      */
     private ResponseEntity<?> getJsonRepresentation(DiskQuotaConfig config) throws JSONException {
         XStream xs =
@@ -191,9 +187,7 @@ public class DiskQuotaController {
     /**
      * Private method for retunring an XML representation of the Statistics
      *
-     * @param config
      * @return a {@link ResponseEntity} object
-     * @throws JSONException
      */
     private ResponseEntity<?> getXmlRepresentation(DiskQuotaConfig config) {
         XStream xStream = getConfiguredXStream(new GeoWebCacheXStream());
@@ -205,7 +199,6 @@ public class DiskQuotaController {
     /**
      * This method adds to the input {@link XStream} an alias for the CacheStatistics
      *
-     * @param xs
      * @return an updated XStream
      */
     public static XStream getConfiguredXStream(XStream xs) {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/LayerQuota.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/LayerQuota.java
@@ -40,11 +40,7 @@ public final class LayerQuota implements Serializable {
         readResolve();
     }
 
-    /**
-     * Supports initialization of instance variables during XStream deserialization
-     *
-     * @return
-     */
+    /** Supports initialization of instance variables during XStream deserialization */
     private Object readResolve() {
         return this;
     }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
@@ -107,8 +107,6 @@ class PagePyramid {
     /**
      * @param gridSubsetCoverages grid subset coverage per level, as per {@link
      *     GridSubset#getCoverages()}
-     * @param zoomStop
-     * @param zoomStart
      */
     public PagePyramid(final long[][] gridSubsetCoverages, int zoomStart, int zoomStop) {
         this.gridSubsetCoverages = new TreeMap<Integer, long[]>();
@@ -240,9 +238,6 @@ class PagePyramid {
     /**
      * Returns a grid subset coverage range suitable for {@link TileRange}
      *
-     * @param pageX
-     * @param pageY
-     * @param level
      * @return {@code [minTileX, minTileY, maxTileX, maxTileY, zoomlevel]}
      */
     public long[][] toGridCoverage(int pageX, int pageY, int level) {

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/Quota.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/Quota.java
@@ -90,11 +90,7 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
         this.bytes = units.toBytes(value);
     }
 
-    /**
-     * Supports initialization of instance variables during XStream deserialization
-     *
-     * @return
-     */
+    /** Supports initialization of instance variables during XStream deserialization */
     private Object readResolve() {
         if (this.bytes == null) {
             this.bytes = BigInteger.ZERO;
@@ -112,11 +108,7 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
                 .toString();
     }
 
-    /**
-     * Adds {@code bytes} bytes to this quota
-     *
-     * @param bytes
-     */
+    /** Adds {@code bytes} bytes to this quota */
     public void add(BigInteger bytes) {
         this.bytes = this.bytes.add(bytes);
     }
@@ -136,11 +128,7 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
         this.bytes = this.bytes.add(quota.getBytes());
     }
 
-    /**
-     * Subtracts {@code bytes} bytes from this quota
-     *
-     * @param bytes
-     */
+    /** Subtracts {@code bytes} bytes from this quota */
     public void subtract(final BigInteger bytes) {
         this.bytes = this.bytes.subtract(bytes);
     }
@@ -155,12 +143,7 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
         subtract(units.toBytes(amount));
     }
 
-    /**
-     * Returns the difference between this quota and the argument one, in this quota's units
-     *
-     * @param quota
-     * @return
-     */
+    /** Returns the difference between this quota and the argument one, in this quota's units */
     public Quota difference(Quota quota) {
         BigInteger difference = this.bytes.subtract(quota.getBytes());
         return new Quota(difference);
@@ -168,8 +151,6 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
 
     /**
      * Returns a more user friendly string representation of this quota, like in 1.1GB, 0.75MB, etc.
-     *
-     * @return
      */
     public String toNiceString() {
         StorageUnit bestFit = StorageUnit.bestFit(bytes);
@@ -197,12 +178,7 @@ public class Quota implements Cloneable, Comparable<Quota>, Serializable {
         return bytes.compareTo(o.getBytes());
     }
 
-    /**
-     * Shorthand for {@code setBytes(unit.convertTo(value, StorageUnit.B).toBigInteger())}
-     *
-     * @param value
-     * @param unit
-     */
+    /** Shorthand for {@code setBytes(unit.convertTo(value, StorageUnit.B).toBigInteger())} */
     public void setValue(double value, StorageUnit unit) {
         setBytes(unit.convertTo(value, StorageUnit.B).toBigInteger());
     }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/StorageUnit.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/StorageUnit.java
@@ -68,24 +68,12 @@ public enum StorageUnit {
         return target.fromBytes(toBytes(value));
     }
 
-    /**
-     * Returns the most appropriate storage unit to represent the given amount
-     *
-     * @param value
-     * @param units
-     * @return
-     */
+    /** Returns the most appropriate storage unit to represent the given amount */
     public static StorageUnit bestFit(double value, StorageUnit units) {
         return bestFit(BigDecimal.valueOf(value), units);
     }
 
-    /**
-     * Returns the most appropriate storage unit to represent the given amount
-     *
-     * @param value
-     * @param units
-     * @return
-     */
+    /** Returns the most appropriate storage unit to represent the given amount */
     public static StorageUnit bestFit(BigDecimal value, StorageUnit units) {
         BigDecimal bytes = new BigDecimal(units.toBytes(value));
         // use compareTo because BigDecimal.equals does not consider 1.0 and 1.00 to be equal, so

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/TilePageCalculator.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/TilePageCalculator.java
@@ -90,7 +90,6 @@ public class TilePageCalculator {
     /**
      * Returns a grid subset coverage range suitable for {@link TileRange}
      *
-     * @param page
      * @return {@code [minTileX, minTileY, maxTileX, maxTileY, zoomlevel]}
      */
     public long[][] toGridCoverage(TileSet tileSet, TilePage page) {

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/LayerCacheInfoBuilderTest.java
@@ -26,7 +26,6 @@ import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.filter.parameters.ParametersUtils;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
-import org.geowebcache.mime.MimeException;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.blobstore.file.DefaultFilePathGenerator;
@@ -117,14 +116,7 @@ public class LayerCacheInfoBuilderTest extends TestCase {
      *
      * assertEquals(0L, usedQuota.difference(expectedUsedQuota).getBytes().longValue()); }
      */
-    /**
-     * Seeds {@code numFiles} fake tiles of {@code fileSize} each at random tile indices
-     *
-     * @param layer
-     * @param numFiles
-     * @throws MimeException
-     * @throws IOException
-     */
+    /** Seeds {@code numFiles} fake tiles of {@code fileSize} each at random tile indices */
     private void mockSeed(TileLayer layer, int numFiles, int fileSize)
             throws GeoWebCacheException, IOException {
         final String layerName = layer.getName();

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
@@ -47,10 +47,6 @@ public class JDBCConfiguration implements Serializable {
     /**
      * Loads a XML configuration from the specified file. The file must adhere to the {@code
      * geowebcache-diskquota-jdbc.xsd} schema.
-     *
-     * @param sourceFile
-     * @return
-     * @throws IOException
      */
     public static JDBCConfiguration load(File sourceFile) throws ConfigurationException {
 
@@ -67,8 +63,6 @@ public class JDBCConfiguration implements Serializable {
      * geowebcache-diskquota-jdbc.xsd} schema.
      *
      * @param is InputStream to load the configuration from
-     * @return
-     * @throws IOException
      */
     public static JDBCConfiguration load(InputStream is) throws ConfigurationException {
         XStream xs = getXStream();
@@ -363,10 +357,7 @@ public class JDBCConfiguration implements Serializable {
         }
     }
 
-    /**
-     * @param allowEnvParametrization
-     * @return
-     */
+    /** */
     public JDBCConfiguration clone(boolean allowEnvParametrization) {
 
         JDBCConfiguration conf = (JDBCConfiguration) SerializationUtils.clone(this);

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
@@ -100,38 +100,22 @@ public class JDBCQuotaStore implements QuotaStore {
         this.executor = Executors.newFixedThreadPool(1);
     }
 
-    /**
-     * Gets the SQL dialect used by this quota store
-     *
-     * @return
-     */
+    /** Gets the SQL dialect used by this quota store */
     public SQLDialect getDialect() {
         return dialect;
     }
 
-    /**
-     * Returns the SQL dialect used by this quota store
-     *
-     * @return
-     */
+    /** Returns the SQL dialect used by this quota store */
     public void setDialect(SQLDialect dialect) {
         this.dialect = dialect;
     }
 
-    /**
-     * Returns he database schema used by this store
-     *
-     * @return
-     */
+    /** Returns he database schema used by this store */
     public String getSchema() {
         return schema;
     }
 
-    /**
-     * Sets the database schema used by this store
-     *
-     * @param schema
-     */
+    /** Sets the database schema used by this store */
     public void setSchema(String schema) {
         this.schema = schema;
     }
@@ -287,9 +271,6 @@ public class JDBCQuotaStore implements QuotaStore {
 
     /**
      * Return a empty quota object in case a null value is passed, otherwise return the passed value
-     *
-     * @param optionalQuota
-     * @return
      */
     private Quota nonNullQuota(Quota optionalQuota) {
         if (optionalQuota == null) {
@@ -585,12 +566,7 @@ public class JDBCQuotaStore implements QuotaStore {
                 });
     }
 
-    /**
-     * Sorts the payloads by page key
-     *
-     * @param tileCountDiffs
-     * @return
-     */
+    /** Sorts the payloads by page key */
     protected List<PageStatsPayload> sortPayloads(Collection<PageStatsPayload> tileCountDiffs) {
         List<PageStatsPayload> result = new ArrayList<PageStatsPayload>(tileCountDiffs);
         Collections.sort(

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -245,13 +245,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
         return store;
     }
 
-    /**
-     * Prepares a simple data source for the embedded H2
-     *
-     * @param cacheDirFinder
-     * @return
-     * @throws ConfigurationException
-     */
+    /** Prepares a simple data source for the embedded H2 */
     private DataSource getH2DataSource(DefaultStorageFinder cacheDirFinder)
             throws ConfigurationException {
         File storeDirectory = new File(cacheDirFinder.getDefaultPath(), "diskquota_page_store_h2");

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SQLDialect.java
@@ -125,11 +125,7 @@ public class SQLDialect {
                 }
             };
 
-    /**
-     * Checks if the database schema is present, if missing it generates it
-     *
-     * @param template
-     */
+    /** Checks if the database schema is present, if missing it generates it */
     public void initializeTables(String schema, SimpleJdbcTemplate template) {
         String prefix;
         if (schema == null) {
@@ -147,13 +143,7 @@ public class SQLDialect {
         }
     }
 
-    /**
-     * Checks if the specified table exists
-     *
-     * @param template
-     * @param tableName
-     * @return
-     */
+    /** Checks if the specified table exists */
     private boolean tableExists(
             SimpleJdbcTemplate template, final String schema, final String tableName) {
         try {
@@ -287,8 +277,6 @@ public class SQLDialect {
     /**
      * Whatever source table to use when there is not a real table to use as the source, e.g.,
      * "select 1" vs "select 1 from dual". For most databases not adding anything is just fine.
-     *
-     * @param sb
      */
     protected void addEmtpyTableReference(StringBuilder sb) {
         // nothing to do
@@ -417,12 +405,6 @@ public class SQLDialect {
     /**
      * Updates the fill factor in a page provided the old fill factor is still the one we read from
      * the db, otherwise updates nothing
-     *
-     * @param schema
-     * @param keyParam
-     * @param newfillFactorParam
-     * @param oldFillFactorParam
-     * @return
      */
     public String conditionalUpdatePageStatsFillFactor(
             String schema, String keyParam, String newfillFactorParam, String oldFillFactorParam) {
@@ -438,14 +420,7 @@ public class SQLDialect {
         return sb.toString();
     }
 
-    /**
-     * Forces the fill factor in a page to the desired value
-     *
-     * @param schema
-     * @param keyParam
-     * @param newfillFactorParam
-     * @return
-     */
+    /** Forces the fill factor in a page to the desired value */
     public String updatePageStatsFillFactor(
             String schema, String keyParam, String newfillFactorParam) {
         StringBuilder sb = new StringBuilder("UPDATE ");
@@ -461,12 +436,6 @@ public class SQLDialect {
     /**
      * Updates the fill factor in a page provided the old fill factor is still the one we read from
      * the db, otherwise updates nothing
-     *
-     * @param schema
-     * @param keyParam
-     * @param newFrequencyParam
-     * @param oldFrequencyParam
-     * @return
      */
     public String updatePageStats(
             String schema,

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SimpleJdbcTemplate.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/SimpleJdbcTemplate.java
@@ -37,11 +37,6 @@ public class SimpleJdbcTemplate extends NamedParameterJdbcTemplate {
     /**
      * Queries the template for a single object, but makes the result optial, it is ok not to find
      * any object in the db
-     *
-     * @param sql
-     * @param rowMapper
-     * @param params
-     * @return
      */
     public <T> T queryForOptionalObject(String sql, RowMapper<T> rowMapper, Map params) {
         try {

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/FixtureUtilities.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/FixtureUtilities.java
@@ -76,10 +76,8 @@ public class FixtureUtilities {
      * file directory. For example, an id <code>a.b.foo</code> would be resolved to
      * <code>.geotools/a/b/foo.properties<code>.
      *
-     * @param fixtureDirectory
      *            the base fixture configuration file directory, typically ".geotools" in the user
      *            home directory.
-     * @param fixtureId
      *            the fixture id
      */
     public static File getFixtureFile(File fixtureDirectory, String fixtureId) {

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -665,8 +665,6 @@ public abstract class JDBCQuotaStoreTest {
     /**
      * Combined test for {@link JDBCQuotaStore#addToQuotaAndTileCounts(TileSet, Quota, Collection)}
      * and {@link JDBCQuotaStore#addHitsAndSetAccesTime(Collection)}
-     *
-     * @throws Exception
      */
     @Test
     public void testPageStatsGathering() throws Exception {
@@ -925,23 +923,14 @@ public abstract class JDBCQuotaStoreTest {
         return count;
     }
 
-    /**
-     * Asserts the quota used by this tile set is null
-     *
-     * @param tileSet
-     */
+    /** Asserts the quota used by this tile set is null */
     private void assertQuotaZero(TileSet tileSet) {
         Quota quota = store.getUsedQuotaByTileSetId(tileSet.getId());
         assertNotNull(quota);
         assertEquals(0, quota.getBytes().longValue());
     }
 
-    /**
-     * Asserts the quota used by this tile set is null
-     *
-     * @param layerName
-     * @throws InterruptedException
-     */
+    /** Asserts the quota used by this tile set is null */
     private void assertQuotaZero(String layerName) throws InterruptedException {
         Quota quota = store.getUsedQuotaByLayerName(layerName);
         assertNotNull(quota);

--- a/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastLoader.java
+++ b/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastLoader.java
@@ -113,11 +113,7 @@ public class HazelcastLoader implements InitializingBean {
         return instance != null;
     }
 
-    /**
-     * Setter for the Hazelcast instance
-     *
-     * @param instance
-     */
+    /** Setter for the Hazelcast instance */
     public void setInstance(HazelcastInstance instance) {
         this.instance = instance;
     }

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GML31ParsingUtils.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GML31ParsingUtils.java
@@ -120,9 +120,6 @@ class GML31ParsingUtils {
      *
      * <p>Postcondition: reader gets positioned at the end tag of the element it started parsing the
      * geometry at
-     *
-     * @return
-     * @throws XMLStreamException
      */
     public Geometry parseGeometry(final XMLStreamReader reader) throws XMLStreamException {
 
@@ -166,8 +163,6 @@ class GML31ParsingUtils {
      *
      * <p>Postcondition: reader positioned at the {@link GML#MultiPoint MultiPoint} end tag of the
      * starting tag
-     *
-     * @throws XMLStreamException
      */
     private Geometry parseMultiPoint(XMLStreamReader reader, int dimension)
             throws XMLStreamException {
@@ -217,8 +212,6 @@ class GML31ParsingUtils {
      *
      * <p>Postcondition: reader positioned at the {@link GML#MultiLineString MultiLineString} end
      * tag of the starting tag
-     *
-     * @throws XMLStreamException
      */
     private MultiLineString parseMultiLineString(XMLStreamReader reader, int dimension)
             throws XMLStreamException {
@@ -259,8 +252,6 @@ class GML31ParsingUtils {
      *
      * <p>Postcondition: reader positioned at the {@link GML#MultiSurface MultiSurface} end tag of
      * the starting tag
-     *
-     * @param reader
      */
     private Geometry parseMultiSurface(XMLStreamReader reader, int dimension)
             throws XMLStreamException {
@@ -335,11 +326,6 @@ class GML31ParsingUtils {
      *
      * <p>Postcondition: reader positioned at the {@link GML#Polygon Polygon} end tag of the
      * starting tag
-     *
-     * @param reader
-     * @param dimension
-     * @return
-     * @throws XMLStreamException
      */
     private Polygon parsePolygon(XMLStreamReader reader, int dimension) throws XMLStreamException {
         Polygon geom;

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSParsingUtils.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSParsingUtils.java
@@ -31,13 +31,7 @@ class GeoRSSParsingUtils {
         return dateTime;
     }
 
-    /**
-     * Being at a start element tag, returns its coalesced text value
-     *
-     * @param reader
-     * @return
-     * @throws XMLStreamException
-     */
+    /** Being at a start element tag, returns its coalesced text value */
     public static String text(XMLStreamReader reader) throws XMLStreamException {
         reader.require(START_ELEMENT, null, null);
         StringBuilder sb = new StringBuilder();
@@ -56,10 +50,6 @@ class GeoRSSParsingUtils {
     /**
      * Consumes the current element (given by tagName) until it's end element is fount (assuming
      * there's no nested element called the same)
-     *
-     * @param reader
-     * @param tagName
-     * @throws XMLStreamException
      */
     public static void consume(XMLStreamReader reader, QName tagName) throws XMLStreamException {
 
@@ -77,10 +67,6 @@ class GeoRSSParsingUtils {
     /**
      * Safely advances until the next tag element (either start or end element) and returns its
      * name, or {@code null} in case the end of document is reached before any tag
-     *
-     * @param reader
-     * @return
-     * @throws XMLStreamException
      */
     public static QName nextTag(XMLStreamReader reader) throws XMLStreamException {
 

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
@@ -212,8 +212,6 @@ class GeoRSSPollTask implements Runnable {
     /**
      * For debug purposes only, writes down the bitmask images to the directory specified by the
      * System property (ej, {@code -Dorg.geowebcache.georss.debugToDisk=target/})
-     *
-     * @param matrix
      */
     private void _logImagesToDisk(final GeometryRasterMaskBuilder matrix) {
         if (null == System.getProperty("org.geowebcache.georss.debugToDisk")) {

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPoller.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPoller.java
@@ -50,7 +50,6 @@ public class GeoRSSPoller {
      * interval} polls the layers feed for change sets and if changes are found spawns a reseed
      * process on the tiles affected by the change set.
      *
-     * @param seeder
      * @param startUpDelaySecs seconds to wait before start polling the layers
      */
     public GeoRSSPoller(final TileBreeder seeder, final int startUpDelaySecs) {

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeometryRasterMaskBuilder.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeometryRasterMaskBuilder.java
@@ -314,7 +314,6 @@ public class GeometryRasterMaskBuilder {
     /**
      * Returns the tile range of the mask bounding box at a specific zoom level.
      *
-     * @param level
      * @return the bounds of the set tiles for the given level, or {@code null} if none is set
      */
     public synchronized long[] getCoveredBounds(final int level) {
@@ -352,11 +351,7 @@ public class GeometryRasterMaskBuilder {
         return coveredBounds;
     }
 
-    /**
-     * Package visible method for testing purposes only!
-     *
-     * @return
-     */
+    /** Package visible method for testing purposes only! */
     public BufferedImage[] getByLevelMasks() {
         final int numMaskedLevels = Math.min(getNumLevels(), maxMaskLevel + 1);
         BufferedImage[] maskedLevels = new BufferedImage[numMaskedLevels];

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/GeoRSSTileRangeBuilderTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/GeoRSSTileRangeBuilderTest.java
@@ -68,11 +68,7 @@ public class GeoRSSTileRangeBuilderTest extends TestCase {
                 layer.getGridSubset(gridsetId).getCoverages().length, tileRangeMask.getNumLevels());
     }
 
-    /**
-     * Test for {@link GeometryRasterMaskBuilder#getCoveredBounds(int)}
-     *
-     * @throws Exception
-     */
+    /** Test for {@link GeometryRasterMaskBuilder#getCoveredBounds(int)} */
     public void testCoveredBounds() throws Exception {
         GeometryRasterMaskBuilder tileRangeMask = buildSampleFilterMatrix(layer, gridsetId);
 

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTest.java
@@ -53,8 +53,6 @@ public class RasterMaskTest extends TestCase {
     /**
      * Once the matrix is built, test the expected tiles are marked as covered by the consumed
      * geometries
-     *
-     * @throws Exception
      */
     public void testTileIsPresent() throws Exception {
         GeometryRasterMaskBuilder mask =

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTestUtils.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTestUtils.java
@@ -80,8 +80,6 @@ public class RasterMaskTestUtils {
      *   <li>A Point at {@code 0, 45}
      *   <li>A LineString at {@code -90 -45, -90 45}
      * </ul>
-     *
-     * @return
      */
     private static Geometry[] createSampleEntries() throws Exception {
         Geometry[] entries = { //

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/StaxGeoRSSReaderTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/StaxGeoRSSReaderTest.java
@@ -96,8 +96,6 @@ public class StaxGeoRSSReaderTest extends TestCase {
      * @param fileName file name to create the java.io.Reader for, located at {@code <this
      *     package>/test-data/<fileName>}
      * @return a reader over {@code test-data/fileName}
-     * @throws FileNotFoundException
-     * @throws UnsupportedEncodingException
      */
     private Reader reader(final String fileName)
             throws FileNotFoundException, UnsupportedEncodingException {

--- a/geowebcache/gmaps/src/main/java/org/geowebcache/service/gmaps/GMapsConverter.java
+++ b/geowebcache/gmaps/src/main/java/org/geowebcache/service/gmaps/GMapsConverter.java
@@ -147,11 +147,6 @@ public class GMapsConverter extends Service {
      * Convert Google's tiling coordinates into an {x,y,x}
      *
      * <p>see http://code.google.com/apis/maps/documentation/overlays.html#Custom_Map_Types
-     *
-     * @param zoomLevel
-     * @param x
-     * @param y
-     * @return
      */
     public static long[] convert(long zoomLevel, long x, long y) throws ServiceException {
         // Extent is the total number of tiles in y direction

--- a/geowebcache/gmaps/src/main/java/org/geowebcache/service/mgmaps/MGMapsConverter.java
+++ b/geowebcache/gmaps/src/main/java/org/geowebcache/service/mgmaps/MGMapsConverter.java
@@ -138,11 +138,6 @@ public class MGMapsConverter extends Service {
      * <p>see http://code.google.com/apis/maps/documentation/overlays.html#Custom_Map_Types
      *
      * <p>Modified by JaakL for mgmaps zoom understanding: zoom = 17 - zoom
-     *
-     * @param zoomLevel
-     * @param x
-     * @param y
-     * @return
      */
     public static long[] convert(long zoomLevel, long x, long y) throws ServiceException {
         if (zoomLevel > 17) {

--- a/geowebcache/gmaps/src/test/java/org/geowebcache/service/gmaps/GMapsConverterTest.java
+++ b/geowebcache/gmaps/src/test/java/org/geowebcache/service/gmaps/GMapsConverterTest.java
@@ -29,11 +29,7 @@ public class GMapsConverterTest extends TestCase {
         super.setUp();
     }
 
-    /**
-     * see http://code.google.com/apis/maps/documentation/overlays.html# Custom_Map_Types
-     *
-     * @throws Exception
-     */
+    /** see http://code.google.com/apis/maps/documentation/overlays.html# Custom_Map_Types */
     public void testGMapsConverter() throws Exception {
         /* Check origin location */
         int x = 0;

--- a/geowebcache/gmaps/src/test/java/org/geowebcache/service/mgmaps/MGMapsConverterTest.java
+++ b/geowebcache/gmaps/src/test/java/org/geowebcache/service/mgmaps/MGMapsConverterTest.java
@@ -10,11 +10,7 @@ public class MGMapsConverterTest extends TestCase {
         super.setUp();
     }
 
-    /**
-     * see Modified for MGMaps API
-     *
-     * @throws Exception
-     */
+    /** see Modified for MGMaps API */
     public void testMGMapsConverter() throws Exception {
         /* Check origin location */
         int x = 0;

--- a/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLService.java
+++ b/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLService.java
@@ -93,7 +93,6 @@ public class KMLService extends Service {
      * /kml/layername/tilekey.format.extension (kml or kmz, overlay) Example 3:
      * /kml/layername/tilekey.format (data)
      *
-     * @param pathInfo
      * @return {layername, tilekey, format, wrapperformat}
      */
     protected static String[] parseRequest(String pathInfo) {
@@ -284,11 +283,7 @@ public class KMLService extends Service {
         return new String(requestUrl.substring(0, endOffset - 1));
     }
 
-    /**
-     * Creates a superoverlay, ie. a short description and network links to the first overlays.
-     *
-     * @param tile
-     */
+    /** Creates a superoverlay, ie. a short description and network links to the first overlays. */
     private void handleSuperOverlay(ConveyorKMLTile tile) throws GeoWebCacheException {
         TileLayer layer = tile.getLayer();
 
@@ -364,14 +359,7 @@ public class KMLService extends Service {
         writeTileResponse(tile, true, stats, mimeStr);
     }
 
-    /**
-     * Creates a network link to the first tile in the pyramid
-     *
-     * @param superString
-     * @param bbox
-     * @param url
-     * @return
-     */
+    /** Creates a network link to the first tile in the pyramid */
     private static String superOverlayNetworLink(String superString, BoundingBox bbox, String url) {
         String xml =
                 "\n<NetworkLink><name>Super-overlay: "
@@ -506,11 +494,7 @@ public class KMLService extends Service {
      * Creates an overlay element: 1) Header 2) Network links to regions where we have more data 3)
      * Overlay (link to data) 4) Footer
      *
-     * @param tile
-     * @param isPackaged
      * @return The html for the overlay element
-     * @throws ServiceException
-     * @throws GeoWebCacheException
      */
     private String createOverlay(ConveyorKMLTile tile, boolean isPackaged)
             throws ServiceException, GeoWebCacheException {
@@ -621,12 +605,7 @@ public class KMLService extends Service {
         return buf.toString();
     }
 
-    /**
-     * This creates the header for the overlay
-     *
-     * @param bbox
-     * @return
-     */
+    /** This creates the header for the overlay */
     private static String createOverlayHeader(BoundingBox bbox, boolean setMaxLod) {
         int maxLodPixels = -1;
         if (setMaxLod) {
@@ -647,12 +626,6 @@ public class KMLService extends Service {
     /**
      * For KML features / vector data OR for the next level
      *
-     * @param layer
-     * @param bbox
-     * @param gridLocUrl
-     * @param tileIdx
-     * @param maxLodPixels
-     * @param refreshTags
      * @return The network link element html
      */
     private static String createNetworkLinkElement(
@@ -687,15 +660,7 @@ public class KMLService extends Service {
         return xml;
     }
 
-    /**
-     * Used for linking to a raster image
-     *
-     * @param gridLoc
-     * @param urlStr
-     * @param bbox
-     * @param formatExtension
-     * @return
-     */
+    /** Used for linking to a raster image */
     private static String createGroundOverLayElement(
             long[] gridLoc,
             String urlStr,

--- a/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMZHelper.java
+++ b/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMZHelper.java
@@ -57,7 +57,6 @@ public class KMZHelper {
      * @param mime Mime type of the WMS request (image format)
      * @param linkGridLocs The grid location to filer
      * @return The filtered grid location
-     * @throws GeoWebCacheException
      */
     public static long[][] filterGridLocs(
             StorageBroker sb,
@@ -122,14 +121,7 @@ public class KMZHelper {
         return linkGridLocs;
     }
 
-    /**
-     * @param namePfx
-     * @param overlayXml
-     * @param dataXml
-     * @param response
-     * @return
-     * @throws ServiceException
-     */
+    /** */
     protected static byte[] createZippedKML(
             String namePfx, String formatExtension, byte[] overlayXml, Resource dataXml)
             throws ServiceException {
@@ -149,10 +141,6 @@ public class KMZHelper {
      * Writes two byte[] into a zip -> like a zipfile with two files
      *
      * @param namePfx prefix for files inside file
-     * @param overlay
-     * @param data
-     * @param out
-     * @throws IOException
      */
     private static void writeZippedKML(
             String namePfx, String formatExtension, byte[] overlay, Resource data, OutputStream out)

--- a/geowebcache/kml/src/test/java/org/geowebcache/service/kml/KMLServiceTest.java
+++ b/geowebcache/kml/src/test/java/org/geowebcache/service/kml/KMLServiceTest.java
@@ -8,11 +8,7 @@ public class KMLServiceTest extends TestCase {
         super.setUp();
     }
 
-    /**
-     * Tests
-     *
-     * @throws Exception
-     */
+    /** Tests */
     public void test1ParseRequest() throws Exception {
         String[] retVals = KMLService.parseRequest("/kml/topp:states.kml");
 

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -856,7 +856,7 @@
            <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.0.0</version>
+              <version>3.1.1</version>
               <configuration>
                     <logViolationsToConsole>true</logViolationsToConsole>
                     <!-- ignore generated classes, e.g., javacc ones -->

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/MemoryCacheController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/MemoryCacheController.java
@@ -69,11 +69,7 @@ public class MemoryCacheController {
         this.context = context;
     }
 
-    /**
-     * Setter for the BlobStore
-     *
-     * @param store
-     */
+    /** Setter for the BlobStore */
     public void setBlobStore(BlobStore store) {
         this.store = store;
     }
@@ -122,9 +118,7 @@ public class MemoryCacheController {
     /**
      * Private method for retunring a JSON representation of the Statistics
      *
-     * @param stats
      * @return a {@link ResponseEntity} object
-     * @throws JSONException
      */
     private ResponseEntity<?> getJsonRepresentation(CacheStatistics stats) throws JSONException {
         XStream xs =
@@ -139,9 +133,7 @@ public class MemoryCacheController {
     /**
      * Private method for retunring an XML representation of the Statistics
      *
-     * @param stats
      * @return a {@link ResponseEntity} object
-     * @throws JSONException
      */
     private ResponseEntity<?> getXmlRepresentation(CacheStatistics stats) {
         XStream xStream = getConfiguredXStream(new GeoWebCacheXStream());
@@ -153,7 +145,6 @@ public class MemoryCacheController {
     /**
      * This method adds to the input {@link XStream} an alias for the CacheStatistics
      *
-     * @param xs
      * @return an updated XStream
      */
     public static XStream getConfiguredXStream(XStream xs) {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/SeedController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/SeedController.java
@@ -53,12 +53,7 @@ public class SeedController {
 
     @Autowired protected DefaultingConfiguration xmlConfig;
 
-    /**
-     * GET method for querying running GWC tasks
-     *
-     * @param req
-     * @return
-     */
+    /** GET method for querying running GWC tasks */
     @RequestMapping(
         value = "/seed.json",
         method = RequestMethod.GET,
@@ -68,13 +63,7 @@ public class SeedController {
         return seedService.getRunningTasks(req);
     }
 
-    /**
-     * GET method for querying running tasks for the provided layer
-     *
-     * @param req
-     * @param layer
-     * @return
-     */
+    /** GET method for querying running tasks for the provided layer */
     @RequestMapping(
         value = "/seed/{layer}.json",
         method = RequestMethod.GET,
@@ -84,24 +73,13 @@ public class SeedController {
         return seedService.getRunningLayerTasks(req, layer);
     }
 
-    /**
-     * GET method for displaying the GeoWebCache UI form.
-     *
-     * @param request
-     * @param layer
-     * @return
-     */
+    /** GET method for displaying the GeoWebCache UI form. */
     @RequestMapping(value = "/seed/{layer}", method = RequestMethod.GET)
     public ResponseEntity<?> doFormGet(HttpServletRequest request, @PathVariable String layer) {
         return formService.handleGet(request, layer);
     }
 
-    /**
-     * POST method to kill [all, running, pending] tasks
-     *
-     * @param request
-     * @return
-     */
+    /** POST method to kill [all, running, pending] tasks */
     @RequestMapping(value = "/seed", method = RequestMethod.POST)
     public ResponseEntity doPost(HttpServletRequest request) {
         String response = seedService.handleKillAllThreads(request, null);
@@ -117,10 +95,7 @@ public class SeedController {
     /**
      * POST method for Seeding and Truncating
      *
-     * @param request
-     * @param layer
      * @param params Query parameters, including urlencoded form values
-     * @return
      */
     @RequestMapping(value = "/seed/{layer:.+}", method = RequestMethod.POST)
     public ResponseEntity<?> doPost(

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/TileLayerController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/TileLayerController.java
@@ -53,24 +53,14 @@ public class TileLayerController extends GWCController {
     DO GET
      */
 
-    /**
-     * Get List of layers as xml
-     *
-     * @param request
-     * @return
-     */
+    /** Get List of layers as xml */
     @RequestMapping(value = "/layers", method = RequestMethod.GET)
     public XStreamListAliasWrapper layersGet(HttpServletRequest request) {
         return new XStreamListAliasWrapper(
                 layerDispatcher.getLayerNames(), "layer", Set.class, this.getClass());
     }
 
-    /**
-     * Get layer by name and requested output {xml, json}
-     *
-     * @param layer
-     * @return
-     */
+    /** Get layer by name and requested output {xml, json} */
     @RequestMapping(value = "/layers/{layer}", method = RequestMethod.GET)
     public TileLayer layerGet(@PathVariable String layer) {
         return findTileLayer(layer, layerDispatcher);

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/ServerConfigurationPOJO.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/ServerConfigurationPOJO.java
@@ -134,7 +134,6 @@ public class ServerConfigurationPOJO implements ServerConfiguration {
      * LockProvider} bean. If the passed lockProvider is not a bean, sets the bean name to null.
      *
      * @param lockProvider The lock provider bean
-     * @throws IOException
      */
     @Override
     public void setLockProvider(LockProvider lockProvider) throws IOException {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/SeedService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/SeedService.java
@@ -72,12 +72,7 @@ public class SeedService {
         context = appCtx.getApplicationContext();
     }
 
-    /**
-     * GET method for querying running GWC tasks
-     *
-     * @param request
-     * @return
-     */
+    /** GET method for querying running GWC tasks */
     public ResponseEntity<?> getRunningTasks(HttpServletRequest request) {
         try {
             XStream xs = new GeoWebCacheXStream(new JsonHierarchicalStreamDriver());
@@ -95,13 +90,7 @@ public class SeedService {
         }
     }
 
-    /**
-     * GET method for querying running tasks for the provided layer
-     *
-     * @param request
-     * @param layer
-     * @return
-     */
+    /** GET method for querying running tasks for the provided layer */
     public ResponseEntity<?> getRunningLayerTasks(HttpServletRequest request, String layer) {
         try {
             XStream xs = new GeoWebCacheXStream(new JsonHierarchicalStreamDriver());
@@ -132,13 +121,7 @@ public class SeedService {
         }
     }
 
-    /**
-     * Method to kill running tasks for all of GWC or just the provided layer.
-     *
-     * @param request
-     * @param layer
-     * @return
-     */
+    /** Method to kill running tasks for all of GWC or just the provided layer. */
     public String handleKillAllThreads(HttpServletRequest request, String layer) {
         final TileLayer tl;
         if (layer != null) {
@@ -212,14 +195,7 @@ public class SeedService {
         }
     }
 
-    /**
-     * Method to do the seeding and truncating.
-     *
-     * @param request
-     * @param extension
-     * @param layer
-     * @return
-     */
+    /** Method to do the seeding and truncating. */
     public ResponseEntity<?> doSeeding(
             HttpServletRequest request, String layer, String extension, String body) {
         XStream xs = configXStream(new GeoWebCacheXStream(new DomDriver()));
@@ -247,12 +223,7 @@ public class SeedService {
         }
     }
 
-    /**
-     * METHOD that handles the seeding/truncating task from the POST method.
-     *
-     * @param layerName
-     * @param obj
-     */
+    /** METHOD that handles the seeding/truncating task from the POST method. */
     protected void handleRequest(String layerName, Object obj) {
         final SeedRequest sr = (SeedRequest) obj;
         try {

--- a/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSService.java
+++ b/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSService.java
@@ -178,7 +178,6 @@ public class TMSService extends Service {
     /**
      * Split the TMS parameters out of the given request
      *
-     * @param request
      * @return A map of the parameters with keys {@literal "layerId"}, {@literal "gridSetId"},
      *     {@literal "x"}, {@literal "y"}, {@literal "z"}, and {@literal "fileExtension"}.
      *     Optionally also {@literal "gridSetId"} and {@literal "format"}. Returns an empty Optional

--- a/geowebcache/ve/src/main/java/org/geowebcache/service/ve/VEConverter.java
+++ b/geowebcache/ve/src/main/java/org/geowebcache/service/ve/VEConverter.java
@@ -134,7 +134,6 @@ public class VEConverter extends Service {
     /**
      * Convert a quadkey into the internal representation {x,y,z} of a grid location
      *
-     * @param strQuadKey
      * @return internal representation
      */
     @SuppressWarnings("PMD.EmptyIfStmt")

--- a/geowebcache/ve/src/test/java/org/geowebcache/service/ve/VEConverterTest.java
+++ b/geowebcache/ve/src/test/java/org/geowebcache/service/ve/VEConverterTest.java
@@ -14,8 +14,6 @@ public class VEConverterTest extends TestCase {
      * Remember, quadkeys look like this: 0 1 2 3
      *
      * <p>And the "most zoomed out" is level 1,
-     *
-     * @throws Exception
      */
     public void testVEConverter() throws Exception {
         /* Check origin location */

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
@@ -635,10 +635,6 @@ public class RestIntegrationTest {
     /**
      * Check that the given request gives a 401 Forbidden when not authenticated, and otherwise has
      * a response matching the given matcher
-     *
-     * @param request
-     * @param authenticatedStatus
-     * @throws Exception
      */
     protected void testSecured(HttpUriRequest request, Matcher<Integer> authenticatedStatus)
             throws Exception {

--- a/geowebcache/wms/src/main/java/org/geowebcache/config/wms/GetCapabilitiesConfiguration.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/config/wms/GetCapabilitiesConfiguration.java
@@ -134,11 +134,7 @@ public class GetCapabilitiesConfiguration implements TileLayerConfiguration, Gri
         this.cachedParameters = cachedParameters;
     }
 
-    /**
-     * Optionally used by Spring
-     *
-     * @param backendTimeout
-     */
+    /** Optionally used by Spring */
     public void setBackendTimeout(int backendTimeout) {
         this.backendTimeout = backendTimeout;
     }
@@ -191,9 +187,6 @@ public class GetCapabilitiesConfiguration implements TileLayerConfiguration, Gri
     /**
      * Finds URL to WMS service and attempts to slice away the service parameter, since we will add
      * that anyway.
-     *
-     * @param wms
-     * @return
      */
     private String getWMSUrl(WebMapServer wms) {
         // // http://sigma.openplans.org:8080/geoserver/wms?SERVICE=WMS&

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageDecoder.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageDecoder.java
@@ -28,14 +28,7 @@ public interface ImageDecoder {
     /** Returns the list of the supported mimetypes */
     public List<String> getSupportedMimeTypes();
 
-    /**
-     * Decodes the selected input object.
-     *
-     * @param input
-     * @param aggressiveInputStreamOptimization
-     * @param map
-     * @return
-     */
+    /** Decodes the selected input object. */
     public BufferedImage decode(
             Object input, boolean aggressiveInputStreamOptimization, Map<String, Object> map)
             throws Exception;

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageDecoderImpl.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageDecoderImpl.java
@@ -52,11 +52,6 @@ public class ImageDecoderImpl implements ImageDecoder {
     /**
      * Creates a new Instance of ImageEncoder supporting or not OutputStream optimization, with the
      * defined MimeTypes and Spi classes.
-     *
-     * @param aggressiveInputStreamOptimization
-     * @param supportedMimeTypes
-     * @param readerSpi
-     * @param initializer
      */
     public ImageDecoderImpl(
             boolean aggressiveInputStreamOptimization,
@@ -91,8 +86,6 @@ public class ImageDecoderImpl implements ImageDecoder {
      * @param source Source object to read
      * @param aggressiveInputStreamOptimization Parameter used if aggressive outputStream
      *     optimization must be used.
-     * @param map
-     * @throws IOException
      */
     public BufferedImage decode(
             Object source, boolean aggressiveInputStreamOptimization, Map<String, Object> map)
@@ -160,11 +153,7 @@ public class ImageDecoderImpl implements ImageDecoder {
         return null;
     }
 
-    /**
-     * Returns the ImageSpiReader associated to
-     *
-     * @return
-     */
+    /** Returns the ImageSpiReader associated to */
     ImageReaderSpi getReaderSpi() {
         return spi;
     }

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoder.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoder.java
@@ -26,15 +26,7 @@ import org.geowebcache.mime.MimeType;
  */
 public interface ImageEncoder {
 
-    /**
-     * Encodes the selected image
-     *
-     * @param image
-     * @param destination
-     * @param aggressiveOutputStreamOptimization
-     * @param type
-     * @param option
-     */
+    /** Encodes the selected image */
     public void encode(
             RenderedImage image,
             Object destination,

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoderImpl.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoderImpl.java
@@ -244,7 +244,6 @@ public class ImageEncoderImpl implements ImageEncoder {
      * @param destination Destination object where the image is written.
      * @param aggressiveOutputStreamOptimization Parameter used if aggressive outputStream
      *     optimization must be used.
-     * @throws IOException
      */
     public void encode(
             RenderedImage image,
@@ -311,11 +310,7 @@ public class ImageEncoderImpl implements ImageEncoder {
         }
     }
 
-    /**
-     * Returns the ImageSpiWriter associated to
-     *
-     * @return
-     */
+    /** Returns the ImageSpiWriter associated to */
     ImageWriterSpi getWriterSpi() {
         return spi;
     }
@@ -342,10 +337,6 @@ public class ImageEncoderImpl implements ImageEncoder {
     /**
      * Creates a new Instance of ImageEncoder supporting or not OutputStream optimization, with the
      * defined MimeTypes and Spi classes.
-     *
-     * @param aggressiveOutputStreamOptimization
-     * @param supportedMimeTypes
-     * @param writerSpi
      */
     public ImageEncoderImpl(
             boolean aggressiveOutputStreamOptimization,

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageIOInitializer.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageIOInitializer.java
@@ -55,7 +55,6 @@ public class ImageIOInitializer {
      * Static initializer for the {@link ImageIOInitializer} class.
      *
      * @param excludedSpis List of the Spis to exclude.
-     * @return
      */
     public static synchronized ImageIOInitializer getInstance(ArrayList<String> excludedSpis) {
         if (instance == null) {
@@ -118,11 +117,7 @@ public class ImageIOInitializer {
         return excludedSpis;
     }
 
-    /**
-     * Sets the list of the SPI names to deregister
-     *
-     * @param excludedSpis
-     */
+    /** Sets the list of the SPI names to deregister */
     public void setExcludedSpis(List<String> excludedSpis) {
         this.excludedSpis = excludedSpis;
     }

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
@@ -362,11 +362,7 @@ public class WMSService extends Service {
         return wmsFuser;
     }
 
-    /**
-     * Handles a getfeatureinfo request
-     *
-     * @param tile
-     */
+    /** Handles a getfeatureinfo request */
     private void handleGetFeatureInfo(ConveyorTile tile) throws GeoWebCacheException {
         TileLayer tl = tld.getTileLayer(tile.getLayerId());
 

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -787,23 +787,14 @@ public class WMSTileFuser {
         }
     }
 
-    /**
-     * Setting of the ApplicationContext associated for extracting the related beans
-     *
-     * @param context
-     * @throws BeansException
-     */
+    /** Setting of the ApplicationContext associated for extracting the related beans */
     public void setApplicationContext(ApplicationContext context) throws BeansException {
         applicationContext = context;
         decoderMap = applicationContext.getBean(ImageDecoderContainer.class);
         encoderMap = applicationContext.getBean(ImageEncoderContainer.class);
     }
 
-    /**
-     * Setting of the hints configuration taken from the WMSService
-     *
-     * @param hintsConfig
-     */
+    /** Setting of the hints configuration taken from the WMSService */
     public void setHintsConfiguration(String hintsConfig) {
         if (hints == null) {
             hints = HintsLevel.getHintsForMode(hintsConfig).getRenderingHints();

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
@@ -194,9 +194,6 @@ public class WMSGetCapabilitiesTest {
     /**
      * Returns an XPath expression equivalent to the given string which can safely include both "
      * and ' characters.
-     *
-     * @param s
-     * @return
      */
     String xpathString(String s) {
         StringBuilder b = new StringBuilder();

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
@@ -96,12 +96,7 @@ public class WMTSService extends Service {
             this.hasStyle = hasStyle;
         }
 
-        /**
-         * Returns the parsed KVP, or null if the path does not match the request pattern
-         *
-         * @param request
-         * @return
-         */
+        /** Returns the parsed KVP, or null if the path does not match the request pattern */
         public Map<String, String> toKVP(HttpServletRequest request) {
             final Matcher matcher = pattern.matcher(request.getPathInfo());
             if (!matcher.matches()) {

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -912,8 +912,6 @@ public class WMTSServiceTest {
      * Generates a layer with "elevation" and "time" dimensions and mime types "image/png" ,
      * "image/jpeg" , "text/plain" , "text/html" , "application/vnd.ogc.gml" then checks if in the
      * capabilities documents each <ResourceURL> elements contains both the dimensions components.
-     *
-     * @throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test


### PR DESCRIPTION
Updates to latest checkstyle plugin. Since last update, it deprecated and removed some checks, and made javadoc tests stricter (the settings removed were used to make it more lax). Basically had to remove all empty javadoc param/return/throws tags.