### PR TITLE
backporting the httpcomponents update to 1.16.x

### DIFF
--- a/geowebcache/wms/pom.xml
+++ b/geowebcache/wms/pom.xml
@@ -37,6 +37,12 @@
     	<artifactId>commons-httpclient</artifactId>
     	<version>3.1</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.11</version>
+    </dependency>
     
     <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>


### PR DESCRIPTION
Backporting to 1.16.x per @aaime
I updated HTTPComponents and added a line to specify the version. Working from clean branch to correct previous PR.