### PR TITLE
 Update Spring/Spring security libraries to 5.1.13/5.1.8

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -13,9 +13,9 @@
     <gt.version>24-SNAPSHOT</gt.version>
     <jts.version>1.16.1</jts.version>
     <jaiext.version>1.1.14</jaiext.version>
-    <spring.version>5.1.13.RELEASE</spring.version>
+    <spring.version>5.1.14.RELEASE</spring.version>
+    <spring.security.version>5.1.9.RELEASE</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>
-    <spring.security.version>5.1.8.RELEASE</spring.security.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>


### PR DESCRIPTION
release notes:
- https://github.com/spring-projects/spring-framework/releases/tag/v5.1.14.RELEASE
- https://github.com/spring-projects/spring-security/releases/tag/5.1.9.RELEASE

see also: https://github.com/geoserver/geoserver/pull/4202