### PR TITLE
swiftblob pom.xml consistency fix

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -50,7 +50,6 @@
     <lint>deprecation</lint>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jclouds.version>2.2.0</jclouds.version>
-    <mockito.version>3.2.4</mockito.version>
   </properties>
   
   <repositories>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -49,6 +49,8 @@
     <qa>false</qa>
     <lint>deprecation</lint>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jclouds.version>2.2.0</jclouds.version>
+    <mockito.version>3.2.4</mockito.version>
   </properties>
   
   <repositories>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -2,9 +2,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- mvn -Dtest=StorageBrokerTest -Dmaven.test.jvmargs='-XX:+HeapDumpOnOutOfMemoryError -Xms32m -Xmx32m' test -->
     <modelVersion>4.0.0</modelVersion>
-    <properties>
-        <jclouds.version>2.2.0</jclouds.version>
-    </properties>
 
     <parent>
         <groupId>org.geowebcache</groupId>
@@ -45,13 +42,9 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.4</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-        </plugins>
-    </build>
 </project>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -15,7 +15,6 @@
     <name>Swift Storage</name>
     <url>http://geowebcache.org</url>
 
-
     <dependencies>
         <dependency>
             <groupId>org.geowebcache</groupId>
@@ -42,7 +41,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
PR to make swiftblob's pom.xml file more consistent with others as described in #823. Moved dependency versions to `geowebcache/pom.xml` and removed redundant sections in `geowebcache/swiftblob/pom.xml`