### PR TITLE
Update the PostgreSQL jdbc driver from 9.4.1208 to 42.2.14 (1.17.x backport)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -27,7 +27,7 @@
     <jsr305.version>3.0.1</jsr305.version>
     <log4j.version>1.2.14</log4j.version>
     <h2.version>1.1.119</h2.version>
-    <postgresql.version>9.4.1208</postgresql.version>
+    <postgresql.version>42.2.14</postgresql.version>
     <oracle.version/>
     <java.awt.headless>true</java.awt.headless>
     <jalopy.phase>disabled</jalopy.phase>


### PR DESCRIPTION
backports #858 

Update the PostgreSQL jdbc driver from 9.4.1208 to 42.2.14, resolves CVE-2020-13692 (PostgreSQL JDBC Driver (aka PgJDBC) before 42.2.13 allows XXE) .

see also https://github.com/geoserver/geoserver/pull/4314