### PR TITLE
Update spring-security to 5.1.11 and spring-framework to 5.1.16 (1.17.x backport)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -13,9 +13,9 @@
     <gt.version>23-SNAPSHOT</gt.version>
     <jts.version>1.16.1</jts.version>
     <jaiext.version>1.1.14</jaiext.version>
-    <spring.version>5.1.13.RELEASE</spring.version>
+    <spring.version>5.1.16.RELEASE</spring.version>
+    <spring.security.version>5.1.11.RELEASE</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>
-    <spring.security.version>5.1.8.RELEASE</spring.security.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>


### PR DESCRIPTION
backports #857

See also:
- https://osgeo-org.atlassian.net/browse/GEOS-9650
- https://github.com/geoserver/geoserver/pull/4313