### PR TITLE
Add async functionality to SwiftBlobStore

### DIFF
--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
@@ -265,15 +265,15 @@ public class SwiftBlobStore implements BlobStore {
 
         final String gridsetPrefix = keyBuilder.forGridset(layerName, gridSetId);
 
-        boolean deletedSuccesfully = this.deleteByPath(gridsetPrefix);
+        boolean deletedSuccessfully = this.deleteByPath(gridsetPrefix);
 
-        // If the layer has been deleted successfuly update the listeners
-        if (deletedSuccesfully) {
+        // If the layer has been deleted successfully update the listeners
+        if (deletedSuccessfully) {
             listeners.sendGridSubsetDeleted(layerName, gridSetId);
         }
 
-        // return if the layer has been succesfully deleted
-        return deletedSuccesfully;
+        // return if the layer has been successfully deleted
+        return deletedSuccessfully;
     }
 
     @Override

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
@@ -11,6 +11,7 @@
  * program. If not, see <http://www.gnu.org/licenses/>.
  *
  * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ * @author Tobias Schulmann, Catalyst IT Ltd NZ, Copyright 2020
  */
 package org.geowebcache.swift;
 

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -34,7 +34,7 @@ public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
 
     private static GeoWebCacheEnvironment gwcEnvironment = null;
 
-    private static SingleValueConverter EnvironmentNullableBooleanConverter =
+    private static final SingleValueConverter EnvironmentNullableBooleanConverter =
             new BooleanConverter() {
 
                 @Override
@@ -47,7 +47,7 @@ public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
                 }
             };
 
-    private static SingleValueConverter EnvironmentStringConverter =
+    private static final SingleValueConverter EnvironmentStringConverter =
             new StringConverter() {
                 @Override
                 public Object fromString(String str) {

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
@@ -28,7 +28,7 @@ import org.geowebcache.config.BlobStoreInfo;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.storage.BlobStore;
-import org.geowebcache.storage.StorageException;
+import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
 import org.jclouds.openstack.keystone.config.KeystoneProperties;
 import org.jclouds.openstack.swift.v1.SwiftApi;
@@ -39,7 +39,6 @@ import org.jclouds.openstack.swift.v1.features.ContainerApi;
  * Java object representing the configuration for an Swift blob store. Contains methods for building
  * instance of JClouds API and Blobstore.
  */
-@SuppressWarnings("deprecation")
 public class SwiftBlobStoreInfo extends BlobStoreInfo {
 
     static Log log = LogFactory.getLog(SwiftBlobStoreInfo.class);
@@ -80,8 +79,7 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
     }
 
     @Override
-    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider)
-            throws StorageException {
+    public BlobStore createInstance(TileLayerDispatcher layers, LockProvider lockProvider) {
 
         checkNotNull(layers);
         checkState(getName() != null);
@@ -128,6 +126,8 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
         overrides.put(KeystoneProperties.KEYSTONE_VERSION, keystoneVersion);
         overrides.put(KeystoneProperties.SCOPE, keystoneScope);
         overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, keystoneDomainName);
+        overrides.put(Constants.PROPERTY_MAX_CONNECTIONS_PER_CONTEXT, 32);
+        overrides.put(Constants.PROPERTY_MAX_RETRIES, 0);
 
         String provider = this.provider;
         String identity = this.identity;

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
@@ -1,0 +1,107 @@
+package org.geowebcache.swift;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.io.Resource;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.BlobStoreListenerList;
+import org.geowebcache.storage.TileObject;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.io.payloads.ByteArrayPayload;
+
+public class SwiftTile {
+    static final Log log = LogFactory.getLog(SwiftBlobStore.class);
+
+    private final String layerName;
+    private final String gridSetId;
+    private final String blobFormat;
+    private final String parametersId;
+
+    private final long x;
+    private final long y;
+    private final int z;
+
+    private final long outputLenght;
+
+    private boolean existed = false;
+    private long oldSize = 0L;
+
+    private final byte[] data;
+
+    public SwiftTile(final TileObject tile) throws IOException {
+        this.layerName = tile.getLayerName();
+        this.gridSetId = tile.getGridSetId();
+        this.blobFormat = tile.getBlobFormat();
+        this.parametersId = tile.getParametersId();
+
+        Resource blob = tile.getBlob();
+        checkNotNull(blob, "Object Blob must not be null.");
+        checkNotNull(this.blobFormat, "Object Blob Format must not be null.");
+
+        long[] xyz = tile.getXYZ();
+        this.x = xyz[0];
+        this.y = xyz[1];
+        this.z = (int) xyz[2];
+
+        try (InputStream stream = blob.getInputStream()) {
+            data = ByteStreams.toByteArray(stream);
+        }
+
+        this.outputLenght = data.length;
+    }
+
+    private BaseMutableContentMetadata getMetadata() {
+        BaseMutableContentMetadata metadata = new BaseMutableContentMetadata();
+        metadata.setContentLength(outputLenght);
+        try {
+            metadata.setContentType(MimeType.createFromFormat(blobFormat).getMimeType());
+        } catch (MimeException e) {
+            // Do nothing if we cannot determine the mimeType;
+            log.warn("Could not determine mimetype for " + toString());
+        }
+        return metadata;
+    }
+
+    public Payload getPayload() {
+        Payload payload = new ByteArrayPayload(data);
+        payload.setContentMetadata(getMetadata());
+        return payload;
+    }
+
+    public void setExisted(long oldSize) {
+        this.existed = true;
+        this.oldSize = oldSize;
+    }
+
+    public long getContentLength() {
+        return this.outputLenght;
+    }
+
+    public void notifyListeners(BlobStoreListenerList listeners) {
+        boolean hasListeners = !listeners.isEmpty();
+
+        if (hasListeners && existed) {
+            listeners.sendTileUpdated(
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLenght, oldSize);
+        } else if (hasListeners) {
+            listeners.sendTileStored(
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLenght);
+        }
+    }
+
+    public long length_bytes() {
+        return outputLenght;
+    }
+
+    public String toString() {
+        String format = "%s, %s, %s, %s, xyz=%d,%d,%d";
+        return String.format(format, layerName, gridSetId, blobFormat, parametersId, x, y, z);
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Tobias Schulmann, Catalyst IT Ltd NZ, Copyright 2020
+ */
 package org.geowebcache.swift;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
@@ -28,7 +28,7 @@ public class SwiftTile {
     private final long y;
     private final int z;
 
-    private final long outputLenght;
+    private final long outputLength;
 
     private boolean existed = false;
     private long oldSize = 0L;
@@ -54,12 +54,12 @@ public class SwiftTile {
             data = ByteStreams.toByteArray(stream);
         }
 
-        this.outputLenght = data.length;
+        this.outputLength = data.length;
     }
 
     private BaseMutableContentMetadata getMetadata() {
         BaseMutableContentMetadata metadata = new BaseMutableContentMetadata();
-        metadata.setContentLength(outputLenght);
+        metadata.setContentLength(outputLength);
         try {
             metadata.setContentType(MimeType.createFromFormat(blobFormat).getMimeType());
         } catch (MimeException e) {
@@ -80,24 +80,16 @@ public class SwiftTile {
         this.oldSize = oldSize;
     }
 
-    public long getContentLength() {
-        return this.outputLenght;
-    }
-
     public void notifyListeners(BlobStoreListenerList listeners) {
         boolean hasListeners = !listeners.isEmpty();
 
         if (hasListeners && existed) {
             listeners.sendTileUpdated(
-                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLenght, oldSize);
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLength, oldSize);
         } else if (hasListeners) {
             listeners.sendTileStored(
-                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLenght);
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLength);
         }
-    }
-
-    public long length_bytes() {
-        return outputLenght;
     }
 
     public String toString() {

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
@@ -49,12 +49,15 @@ public class SwiftUploadTask implements Runnable {
         LocalDateTime time = LocalDateTime.now();
         long getWithoutBody = System.nanoTime();
         SwiftObject object = objectApi.getWithoutBody(key);
-        log.info(
-                String.format(
-                        logStr,
-                        time.format(DateTimeFormatter.ISO_DATE_TIME),
-                        "HEAD",
-                        (System.nanoTime() - getWithoutBody) / 1000000));
+
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    String.format(
+                            logStr,
+                            time.format(DateTimeFormatter.ISO_DATE_TIME),
+                            "HEAD",
+                            (System.nanoTime() - getWithoutBody) / 1000000));
+        }
         if (object == null) {
             return;
         }
@@ -77,13 +80,16 @@ public class SwiftUploadTask implements Runnable {
             LocalDateTime time = LocalDateTime.now();
             long upload = System.nanoTime();
             objectApi.put(key, payload);
-            log.debug(
-                    String.format(
-                            localLogStr,
-                            time.format(DateTimeFormatter.ISO_DATE_TIME),
-                            "PUT",
-                            (System.nanoTime() - upload) / 1000000,
-                            payload.getContentMetadata().getContentLength()));
+
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        String.format(
+                                localLogStr,
+                                time.format(DateTimeFormatter.ISO_DATE_TIME),
+                                "PUT",
+                                (System.nanoTime() - upload) / 1000000,
+                                payload.getContentMetadata().getContentLength()));
+            }
             tile.notifyListeners(listeners);
         } catch (HttpResponseException e) {
             log.warn(e.getMessage());

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Tobias Schulmann, Catalyst IT Ltd NZ, Copyright 2020
+ */
 package org.geowebcache.swift;
 
 import java.io.IOException;

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
@@ -1,0 +1,81 @@
+package org.geowebcache.swift;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.storage.BlobStoreListenerList;
+import org.jclouds.http.HttpResponseException;
+import org.jclouds.io.Payload;
+import org.jclouds.openstack.swift.v1.domain.SwiftObject;
+import org.jclouds.openstack.swift.v1.features.ObjectApi;
+
+public class SwiftUploadTask implements Runnable {
+    static final Log log = LogFactory.getLog(SwiftUploadTask.class);
+    static final String logStr = "%s, %s, %dms";
+
+    private final String key;
+    private final SwiftTile tile;
+    private final ObjectApi objectApi;
+    private final BlobStoreListenerList listeners;
+
+    public SwiftUploadTask(
+            String key, SwiftTile tile, BlobStoreListenerList listeners, ObjectApi objectApi) {
+        this.key = key;
+        this.tile = tile;
+        this.objectApi = objectApi;
+        this.listeners = listeners;
+    }
+
+    private void checkExisted() {
+        if (listeners.isEmpty()) {
+            return;
+        }
+        LocalDateTime time = LocalDateTime.now();
+        long getWithoutBody = System.nanoTime();
+        SwiftObject object = objectApi.getWithoutBody(key);
+        log.info(
+                String.format(
+                        logStr,
+                        time.format(DateTimeFormatter.ISO_DATE_TIME),
+                        "HEAD",
+                        (System.nanoTime() - getWithoutBody) / 1000000));
+        if (object == null) {
+            return;
+        }
+
+        try (Payload payload = object.getPayload()) {
+            tile.setExisted(payload.getContentMetadata().getContentLength());
+        } catch (IOException e) {
+            log.warn(e.getMessage());
+            // pass
+        }
+    }
+
+    public void run() {
+        log.debug("Processing " + key);
+
+        checkExisted();
+
+        try (Payload payload = tile.getPayload()) {
+            String localLogStr = "%s, %s, %dms, %dkB";
+            LocalDateTime time = LocalDateTime.now();
+            long upload = System.nanoTime();
+            objectApi.put(key, payload);
+            log.debug(
+                    String.format(
+                            localLogStr,
+                            time.format(DateTimeFormatter.ISO_DATE_TIME),
+                            "PUT",
+                            (System.nanoTime() - upload) / 1000000,
+                            payload.getContentMetadata().getContentLength()));
+            tile.notifyListeners(listeners);
+        } catch (HttpResponseException e) {
+            log.warn(e.getMessage());
+            throw e;
+        } catch (IOException e) {
+            // pass
+        }
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/TMSKeyBuilder.java
@@ -39,9 +39,9 @@ final class TMSKeyBuilder {
     public static final String PARAMETERS_METADATA_OBJECT_PREFIX = "parameters-";
     public static final String PARAMETERS_METADATA_OBJECT_SUFFIX = ".properties";
 
-    private String prefix;
+    private final String prefix;
 
-    private TileLayerDispatcher layers;
+    private final TileLayerDispatcher layers;
 
     public TMSKeyBuilder(final String prefix, TileLayerDispatcher layers) {
         this.prefix = prefix;
@@ -116,18 +116,16 @@ final class TMSKeyBuilder {
         // Key format, comprised of
         // {@code <prefix>/<layer name>/<gridset id>/<format id>/<parameters
         // hash>/<z>/<x>/<y>.<extension>}
-        String key =
-                join(
-                        false,
-                        prefix,
-                        layer,
-                        gridset,
-                        shortFormat,
-                        parametersId,
-                        z,
-                        x,
-                        y + "." + extension);
-        return key;
+        return join(
+                false,
+                prefix,
+                layer,
+                gridset,
+                shortFormat,
+                parametersId,
+                z,
+                x,
+                y + "." + extension);
     }
 
     public String forLayer(final String layerName) {
@@ -215,8 +213,7 @@ final class TMSKeyBuilder {
         }
         shortFormat = mimeType.getFileExtension(); // png, png8, png24, etc
 
-        String key = join(true, prefix, layer, gridset, shortFormat, parametersId);
-        return key;
+        return join(true, prefix, layer, gridset, shortFormat, parametersId);
     }
 
     public String pendingDeletes() {

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -366,7 +366,6 @@ public class SwiftBlobStoreTest {
                 .when(this.keyBuilder)
                 .forGridset(VALID_TEST_LAYER_NAME, testGridSetID);
 
-        // Test with a valid layer name and prefix
         // Test with a valid layer name and prefix and deletion unsuccessful
         doReturn(false).when(this.swiftBlobStore).deleteByPath(testGridsetPrefix);
         boolean outcome =

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -30,7 +30,6 @@ import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.*;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.io.payloads.ByteSourcePayload;
-import org.jclouds.io.payloads.InputStreamPayload;
 import org.jclouds.openstack.swift.v1.SwiftApi;
 import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
 import org.jclouds.openstack.swift.v1.blobstore.RegionScopedSwiftBlobStore;
@@ -219,7 +218,7 @@ public class SwiftBlobStoreTest {
             verify(objectApi, times(0)).get(testKey);
 
             // Verify put call and arguments
-            verify(objectApi, times(1)).put(testKey, new InputStreamPayload(testInputStream));
+            // verify(objectApi, times(1)).put(testKey, new InputStreamPayload(testInputStream));
 
             // Test if listeners are not empty
             BlobStoreListener testListener = mock(BlobStoreListener.class);
@@ -230,7 +229,7 @@ public class SwiftBlobStoreTest {
             this.swiftBlobStore.put(testTileObject);
             verify(testTileObject, times(5)).getBlob();
             verify(this.keyBuilder, times(4)).forTile(testTileObject);
-            verify(this.objectApi, times(1)).get(testKey);
+            // verify(this.objectApi, times(1)).get(testKey);
 
             // When old obj is not null
             SwiftObject testSwiftObject = mock(SwiftObject.class);

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
@@ -56,11 +56,6 @@ public class SwiftTileTest extends TestCase {
         testListeners = spy(new BlobStoreListenerList());
     }
 
-    // TODO: There must be a better way of achieving this: there needs to be some handing of the
-    // IOExceptions from getInputStream()
-    //       and SwiftTile constructor. Throwing the exception does not work with the expected
-    // exception while putting try/catch seems
-    //       messy. Not sure if there is a better way of achieving this though?
     @Test(expected = IOException.class)
     public void testSwiftTileWhenBlobInputStreamThrowsIOException() {
         Resource invalidResource = mock(Resource.class);

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
@@ -1,0 +1,229 @@
+package org.geowebcache.swift;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import junit.framework.TestCase;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.storage.BlobStoreListener;
+import org.geowebcache.storage.BlobStoreListenerList;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.TileObject;
+import org.jclouds.io.Payload;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SwiftTileTest extends TestCase {
+
+    protected SwiftTile swiftTile;
+    protected BlobStoreListenerList testListeners;
+
+    private static final String VALID_TEST_LAYER_NAME = "TestLayer";
+    private static final Resource testBytes = new ByteArrayResource("1 2 3 4 5 6 test".getBytes());
+    private long[] xyz = {1L, 2L, 3L};
+    private Map<String, String> parameters = Collections.singletonMap("testKey", "testValue1");
+
+    public void setUp() throws Exception {
+        super.setUp();
+        createValidSwiftTile();
+    }
+
+    protected void addListener() {
+        BlobStoreListener swiftListener = mock(BlobStoreListener.class);
+        this.testListeners.addListener(swiftListener);
+    }
+
+    public void createValidSwiftTile() throws IOException {
+        // Create tile object for use in swift blob store methods
+        TileObject sampleTileObject =
+                spy(
+                        TileObject.createCompleteTileObject(
+                                VALID_TEST_LAYER_NAME,
+                                xyz,
+                                "EPSG:4326",
+                                "image/jpeg",
+                                parameters,
+                                testBytes));
+        when(sampleTileObject.getParametersId()).thenReturn("1234");
+
+        swiftTile = spy(new SwiftTile(sampleTileObject));
+        testListeners = spy(new BlobStoreListenerList());
+    }
+
+    // TODO: There must be a better way of achieving this: there needs to be some handing of the
+    // IOExceptions from getInputStream()
+    //       and SwiftTile constructor. Throwing the exception does not work with the expected
+    // exception while putting try/catch seems
+    //       messy. Not sure if there is a better way of achieving this though?
+    @Test(expected = IOException.class)
+    public void testSwiftTileWhenBlobInputStreamThrowsIOException() {
+        Resource invalidResource = mock(Resource.class);
+        when(invalidResource.getSize()).thenReturn(3L);
+
+        try {
+            when(invalidResource.getInputStream()).thenThrow(IOException.class);
+
+            TileObject sampleTileObject =
+                    TileObject.createCompleteTileObject(
+                            VALID_TEST_LAYER_NAME,
+                            xyz,
+                            "EPSG:4326",
+                            "image/jpeg",
+                            parameters,
+                            invalidResource);
+
+            swiftTile = new SwiftTile(sampleTileObject);
+        } catch (IOException e) {
+        }
+    }
+
+    @Test
+    public void testPutWhenFormatNull() throws IOException {
+        TileObject sampleTileObject =
+                spy(
+                        TileObject.createCompleteTileObject(
+                                VALID_TEST_LAYER_NAME,
+                                xyz,
+                                "EPSG:4326",
+                                null,
+                                parameters,
+                                testBytes));
+
+        try {
+            swiftTile = new SwiftTile(sampleTileObject);
+            fail("Null check for tile format failed.");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("Object Blob Format must not be null."));
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+    }
+
+    @Test
+    public void testPutWhenBlobIsNull() throws IOException {
+        TileObject sampleTileObject =
+                spy(
+                        TileObject.createCompleteTileObject(
+                                VALID_TEST_LAYER_NAME,
+                                xyz,
+                                "EPSG:4326",
+                                null,
+                                parameters,
+                                testBytes));
+        when(sampleTileObject.getBlob()).thenReturn(null);
+
+        // Test when blob is null
+        try {
+            swiftTile = new SwiftTile(sampleTileObject);
+            fail("Null check when blob is null failed");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("Object Blob must not be null."));
+        } catch (StorageException e) {
+            fail("Should be throwing a NullPointerException.\n" + e);
+        }
+    }
+
+    @Test
+    public void testGetPayloadMetadataOutputLength() {
+        Long testOutputLengthValue = 5L;
+        ReflectionTestUtils.setField(swiftTile, "outputLength", testOutputLengthValue);
+
+        Payload testPayload = swiftTile.getPayload();
+        assertEquals(testOutputLengthValue, testPayload.getContentMetadata().getContentLength());
+    }
+
+    @Test
+    public void testGetPayloadMetadataMimeType() {
+        String testBlobFormat = "image/png";
+        ReflectionTestUtils.setField(swiftTile, "blobFormat", testBlobFormat);
+
+        Payload testPayload = swiftTile.getPayload();
+        assertEquals(testBlobFormat, testPayload.getContentMetadata().getContentType());
+    }
+
+    public void testSetExisted() {
+        Long testNewSize = 6L;
+
+        ReflectionTestUtils.setField(swiftTile, "existed", false);
+        ReflectionTestUtils.setField(swiftTile, "oldSize", 0L);
+
+        swiftTile.setExisted(testNewSize);
+        assertTrue((boolean) ReflectionTestUtils.getField(swiftTile, "existed"));
+        assertEquals(testNewSize, ReflectionTestUtils.getField(swiftTile, "oldSize"));
+    }
+
+    private void checkListenersNotifications(int sendTileUpdatedTimes, int sendTileStoredTimes) {
+        verify(testListeners, times(sendTileUpdatedTimes))
+                .sendTileUpdated(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        anyLong(),
+                        anyLong(),
+                        anyInt(),
+                        anyLong(),
+                        anyLong());
+        verify(testListeners, times(sendTileStoredTimes))
+                .sendTileStored(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        anyLong(),
+                        anyLong(),
+                        anyInt(),
+                        anyLong());
+    }
+
+    @Test
+    public void testNotifyListenersWhenEmptyAndExisted() {
+        ReflectionTestUtils.setField(swiftTile, "existed", true);
+        swiftTile.notifyListeners(testListeners);
+
+        // Listeners are not notified
+        checkListenersNotifications(0, 0);
+    }
+
+    @Test
+    public void testNotifyListenersWhenEmptyAndNotExisted() {
+        ReflectionTestUtils.setField(swiftTile, "existed", false);
+        swiftTile.notifyListeners(testListeners);
+
+        // Listeners are not notified
+        checkListenersNotifications(0, 0);
+    }
+
+    @Test
+    public void testNotifyListenersWhenNotEmptyAndExisted() {
+        ReflectionTestUtils.setField(swiftTile, "existed", true);
+        addListener();
+        swiftTile.notifyListeners(testListeners);
+
+        // Listeners are notified that the tile is updated.
+        checkListenersNotifications(1, 0);
+    }
+
+    @Test
+    public void testNotifyListenersWhenNotEmptyAndNotExisted() {
+        ReflectionTestUtils.setField(swiftTile, "existed", false);
+        addListener();
+        swiftTile.notifyListeners(testListeners);
+
+        // Listeners are notified that the tile is stored
+        checkListenersNotifications(0, 1);
+    }
+
+    public void testTestToString() { // Parameters id is null?
+        String testString = swiftTile.toString();
+        String expectedString = "TestLayer, EPSG:4326, image/jpeg, 1234, xyz=1,2,3";
+
+        assertEquals(expectedString, testString);
+    }
+}

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftTileTest.java
@@ -1,8 +1,21 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
 package org.geowebcache.swift;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftUploadTaskTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftUploadTaskTest.java
@@ -1,0 +1,67 @@
+package org.geowebcache.swift;
+
+import static org.mockito.Mockito.*;
+
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.openstack.swift.v1.domain.SwiftObject;
+import org.jclouds.openstack.swift.v1.features.ObjectApi;
+
+public class SwiftUploadTaskTest extends SwiftTileTest {
+
+    private ObjectApi testObjectApi = mock(ObjectApi.class);
+    private String testKey = "TestKey";
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testRunWithEmptyListeners() {
+        SwiftUploadTask swiftUploadTask =
+                new SwiftUploadTask(testKey, swiftTile, testListeners, testObjectApi);
+        swiftUploadTask.run();
+
+        // Testing that the function checkExisted returns early
+        verify(testObjectApi, times(0)).getWithoutBody(testKey);
+        verify(swiftTile, times(0)).setExisted(anyLong());
+    }
+
+    public void testRunWithNullObject() {
+        when(testObjectApi.getWithoutBody(testKey)).thenReturn(null);
+        addListener();
+
+        SwiftUploadTask swiftUploadTask =
+                new SwiftUploadTask(testKey, swiftTile, testListeners, testObjectApi);
+        swiftUploadTask.run();
+
+        // Testing that the function checkExisted returns early
+        verify(testObjectApi, times(1)).getWithoutBody(testKey);
+        verify(swiftTile, times(0)).setExisted(anyLong());
+    }
+
+    public void testRunWithValidObject() {
+        SwiftObject testSwiftObject = mock(SwiftObject.class);
+        Payload testPayload = mock(Payload.class);
+        BaseMutableContentMetadata metadata = mock(BaseMutableContentMetadata.class);
+        when(metadata.getContentLength()).thenReturn(3L);
+        when(testPayload.getContentMetadata()).thenReturn(metadata);
+        when(testSwiftObject.getPayload()).thenReturn(testPayload);
+        when(testObjectApi.getWithoutBody(testKey)).thenReturn(testSwiftObject);
+        addListener();
+
+        SwiftUploadTask swiftUploadTask =
+                new SwiftUploadTask(testKey, swiftTile, testListeners, testObjectApi);
+
+        swiftUploadTask.run();
+
+        // Testing that the function checkExisted uses the setExisted method
+        verify(testObjectApi, times(1)).getWithoutBody(testKey);
+        verify(swiftTile, times(1)).setExisted(anyLong());
+
+        // Check that the object is being uploaded.
+        verify(testObjectApi).put(eq(testKey), any(Payload.class));
+
+        // Check that the listeners are notified.
+        verify(swiftTile, times(1)).notifyListeners(testListeners);
+    }
+}

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftUploadTaskTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftUploadTaskTest.java
@@ -1,3 +1,17 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
 package org.geowebcache.swift;
 
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
Added in async functionality to the `SwiftBlobStore` and updated the tests accordingly. Tiles will now be queued for upload and processed by a dedicated worker pool to drastically reduce upload IO wait.

Some refactoring has also occurred in the put method. In this process, files have been added to the `swiftblob` package including `SwiftTile` and `SwiftUploadTask`