### PR TITLE
Add functionality for generalised single color tile caching.

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreSingleColorTiles.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreSingleColorTiles.java
@@ -1,0 +1,58 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.storage;
+
+import java.io.IOException;
+import java.util.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Manages the persistence of the actual data contained in cacheable objects (tiles, WFS responses).
+ * This is an extension to support single colour tile caching.
+ *
+ * <p>Blobstores may assume that the StorageObjects passed to them are completely filled in except
+ * for the blob fields.
+ */
+public interface BlobStoreSingleColorTiles extends BlobStore {
+    static Log log = LogFactory.getLog(BlobStoreSingleColorTiles.class);
+
+    /**
+     * Creates a symlink.
+     *
+     * @param tileObject The tile object.
+     * @param singleColourTileRef The tile colour reference.
+     */
+    public void putSymlink(TileObject tileObject, String singleColourTileRef);
+
+    /**
+     * Checks if a tile exists in storage given a tile name.
+     *
+     * @param singleColourTileRef The tile colour reference.
+     * @return If the tile exists in storage.
+     */
+    public boolean tileExistsInStorage(TileObject tile, String singleColourTileRef);
+
+    /**
+     * Saves a single colour tile. This is different from put as there is a different filepath
+     * defined for single color tiles.
+     *
+     * @param tile The tile object.
+     * @param singleColourTileRef The tile colour reference.
+     * @throws IOException
+     */
+    public void saveSingleColourTile(TileObject tile, String singleColourTileRef)
+            throws IOException;
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/equivtiles/CacheSingleColorBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/equivtiles/CacheSingleColorBlobStore.java
@@ -1,0 +1,262 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Dana Lambert, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.storage.blobstore.equivtiles;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.*;
+import javax.imageio.ImageIO;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.io.Resource;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.*;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * This class is an implementation of the {@link BlobStore} interface wrapping another {@link
+ * BlobStore} implementation and supporting in single color tile storage.
+ */
+public class CacheSingleColorBlobStore
+        implements BlobStoreSingleColorTiles, ApplicationContextAware {
+
+    ApplicationContext applicationContext;
+
+    /** {@link Log} object used for logging exceptions */
+    private static final Log log = LogFactory.getLog(CacheSingleColorBlobStore.class);
+
+    /** {@link BlobStore} to use when no element is found */
+    private BlobStoreSingleColorTiles store;
+
+    // Initial default capacity of ConcurrentHashMap is 16 but the JVM will resize if needed.
+    private ConcurrentHashMap<String, String> referenceHashMap = new ConcurrentHashMap<>();
+    private Set<String> cachedSimpleTiles = referenceHashMap.newKeySet();
+
+    /** Setter for the store to wrap */
+    public void setStore(BlobStoreSingleColorTiles store) {
+        log.debug("Setting the wrapped store");
+
+        if (store == null) {
+            throw new NullPointerException("Input BlobStore cannot be null");
+        }
+        this.store = store;
+    }
+
+    /** @return The wrapped {@link BlobStore} implementation */
+    public BlobStoreSingleColorTiles getStore() {
+        log.debug("Returning the wrapped store");
+        return store;
+    }
+
+    /**
+     * Check if the image tile consists of a single color.
+     *
+     * @param image The buffered image to check.
+     * @return whether the image consists of only one color.
+     */
+    private Boolean isSingleColorTile(BufferedImage image) {
+        int firstPixelColor = image.getRGB(0, 0);
+        Boolean sameColorTile = true;
+        int w = image.getWidth();
+        int h = image.getHeight();
+
+        // Iterate over all pixels & and compare to saved color value
+        outer:
+        for (int i = 0; i < h; i++) {
+            for (int j = 0; j < w; j++) {
+                int pixel = image.getRGB(j, i);
+                if (pixel != firstPixelColor) {
+                    sameColorTile = false;
+                    break outer;
+                }
+            }
+        }
+
+        return sameColorTile;
+    }
+
+    /**
+     * Creates a special path to store single color tiles.
+     *
+     * @param tile The tile object.
+     * @return the modified path if a single color tile, otherwise null.
+     * @throws IOException if there is any problem with the tile input stream.
+     */
+    private String getSingleColorRef(TileObject tile) throws IOException {
+        Resource blob = tile.getBlob();
+        String mimeType = "/";
+
+        try {
+            mimeType = MimeType.createFromFormat(tile.getBlobFormat()).getMimeType();
+        } catch (MimeException e) {
+            log.warn("Could not determine mimetype for " + tile.toString());
+        }
+
+        String singleColorRef = null;
+        String[] mimeTypeInfo = mimeType.split("/");
+        String extension = mimeTypeInfo[1];
+
+        // Read image data and see if it is a single color tile - takes too long but code works
+        String blobType = mimeTypeInfo[0];
+        if (blobType.equals("image")) {
+            // Read tile and save the first pixel color value
+            try (InputStream stream = blob.getInputStream()) {
+                BufferedImage image = ImageIO.read(stream);
+
+                if (isSingleColorTile(image)) {
+                    singleColorRef = String.format("%s.%s", image.getRGB(0, 0), extension);
+                }
+            }
+        }
+
+        return singleColorRef;
+    }
+
+    @Override
+    public void put(TileObject obj) throws StorageException {
+        try {
+            // Gets the color of the single color tile as a reference
+            // If the tile is not single colour it will return null
+            String singleColourRef = getSingleColorRef(obj);
+
+            // If the tile is a single colour
+            if (singleColourRef != null) {
+                // If the single colour tile is not stored
+                if (!cachedSimpleTiles.contains(singleColourRef)
+                        && store.tileExistsInStorage(obj, singleColourRef)) {
+                    // Upload with single colour ref
+                    store.saveSingleColourTile(obj, singleColourRef);
+                    cachedSimpleTiles.add(singleColourRef);
+                }
+                // Upload symlink
+                store.putSymlink(obj, singleColourRef);
+            } else {
+                // Upload as normal
+                store.put(obj);
+            }
+        } catch (IOException e) {
+            throw new StorageException("Error uploading tile.");
+        }
+    }
+
+    @Override
+    public boolean layerExists(String layerName) {
+        return store.layerExists(layerName);
+    }
+
+    @Override
+    public void putSymlink(TileObject tileObject, String singleColourTileRef) {
+        store.putSymlink(tileObject, singleColourTileRef);
+    }
+
+    @Override
+    public boolean tileExistsInStorage(TileObject tile, String singleColourTileRef) {
+        return store.tileExistsInStorage(tile, singleColourTileRef);
+    }
+
+    @Override
+    public void saveSingleColourTile(TileObject tile, String singleColourTileRef)
+            throws IOException {
+        store.saveSingleColourTile(tile, singleColourTileRef);
+    }
+
+    @Override
+    public boolean delete(String layerName) throws StorageException {
+        return store.delete(layerName);
+    }
+
+    @Override
+    public boolean deleteByGridsetId(String layerName, String gridSetId) throws StorageException {
+        return store.deleteByGridsetId(layerName, gridSetId);
+    }
+
+    @Override
+    public boolean delete(TileObject obj) throws StorageException {
+        return store.delete(obj);
+    }
+
+    @Override
+    public boolean delete(TileRange obj) throws StorageException {
+        return store.delete(obj);
+    }
+
+    @Override
+    public boolean get(TileObject obj) throws StorageException {
+        return store.get(obj);
+    }
+
+    @Override
+    public void clear() throws StorageException {
+        store.clear();
+    }
+
+    @Override
+    public void destroy() {
+        store.destroy();
+    }
+
+    @Override
+    public void addListener(BlobStoreListener listener) {
+        store.addListener(listener);
+    }
+
+    @Override
+    public boolean removeListener(BlobStoreListener listener) {
+        return store.removeListener(listener);
+    }
+
+    @Override
+    public boolean rename(String oldLayerName, String newLayerName) throws StorageException {
+        return store.rename(oldLayerName, newLayerName);
+    }
+
+    @Override
+    public String getLayerMetadata(String layerName, String key) {
+        return store.getLayerMetadata(layerName, key);
+    }
+
+    @Override
+    public void putLayerMetadata(String layerName, String key, String value) {
+        store.putLayerMetadata(layerName, key, value);
+    }
+
+    @Override
+    public boolean deleteByParametersId(String layerName, String parametersId)
+            throws StorageException {
+        return store.deleteByParametersId(layerName, parametersId);
+    }
+
+    @Override
+    public Set<Map<String, String>> getParameters(String layerName) throws StorageException {
+        return store.getParameters(layerName);
+    }
+
+    public Map<String, Optional<Map<String, String>>> getParametersMapping(String layerName) {
+        return store.getParametersMapping(layerName);
+    }
+
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext)
+            throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStore.java
@@ -18,11 +18,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.io.Payloads.newInputStreamPayload;
 
 import com.google.common.base.Function;
-import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
+import com.google.common.collect.*;
 import com.google.common.io.ByteStreams;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.*;
 import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
@@ -37,6 +37,7 @@ import org.jclouds.http.HttpResponseException;
 import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.io.payloads.InputStreamPayload;
 import org.jclouds.openstack.swift.v1.SwiftApi;
 import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
 import org.jclouds.openstack.swift.v1.blobstore.RegionScopedSwiftBlobStore;
@@ -44,9 +45,10 @@ import org.jclouds.openstack.swift.v1.domain.SwiftObject;
 import org.jclouds.openstack.swift.v1.features.BulkApi;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 import org.jclouds.openstack.swift.v1.options.ListContainerOptions;
+import org.jclouds.openstack.swift.v1.options.PutOptions;
 
-/** Blobstore class compatatble with Openstack Swift. */
-public class SwiftBlobStore implements BlobStore {
+/** Blobstore class compatible with Openstack Swift. */
+public class SwiftBlobStore implements BlobStoreSingleColorTiles {
 
     static Log log = LogFactory.getLog(SwiftBlobStore.class);
 
@@ -182,6 +184,50 @@ public class SwiftBlobStore implements BlobStore {
                 listeners.sendTileStored(obj);
             }
         }
+    }
+
+    /**
+     * Creates and return an alternate path used to save single color tiles.
+     *
+     * @param tile The single color tile object.
+     * @param color The color of the tile object.
+     * @return The single color path.
+     */
+    private String getSingleColorPath(TileObject tile, String color) {
+        String gridSetPrefix = keyBuilder.forGridset(tile.getLayerName(), tile.getGridSetId());
+        return String.format("%s" + "simpleTiles/%s", gridSetPrefix, color);
+    }
+
+    @Override
+    public void putSymlink(TileObject tile, String singleColourTileRef) {
+        String originalPath = keyBuilder.forTile(tile);
+        ListMultimap<String, String> objectHeaders = ArrayListMultimap.create();
+        String singleColorPath = getSingleColorPath(tile, singleColourTileRef);
+        objectHeaders.put("X-Object-Manifest", this.containerName + "/" + singleColorPath);
+
+        try (InputStream empty = new ByteArrayInputStream(new byte[0])) {
+            try (Payload payload = new InputStreamPayload(empty)) {
+                objectApi.put(originalPath, payload, PutOptions.Builder.headers(objectHeaders));
+            }
+        } catch (IOException e) {
+            log.error("An error occurred while uploading the symlink.");
+        }
+    }
+
+    @Override
+    public boolean tileExistsInStorage(TileObject tile, String singleColourTileRef) {
+        String singleColorPath = getSingleColorPath(tile, singleColourTileRef);
+        String manifestPath = this.containerName + "/" + singleColorPath;
+        return !this.blobStore.blobExists(this.containerName, manifestPath);
+    }
+
+    @Override
+    public void saveSingleColourTile(TileObject tile, String singleColourTileRef)
+            throws IOException {
+        String singleColorPath = getSingleColorPath(tile, singleColourTileRef);
+        SwiftTile swiftTile = new SwiftTile(tile);
+
+        objectApi.put(singleColorPath, swiftTile.getPayload());
     }
 
     @Override

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftTile.java
@@ -1,0 +1,113 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Tobias Schulmann, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geowebcache.io.Resource;
+import org.geowebcache.mime.MimeException;
+import org.geowebcache.mime.MimeType;
+import org.geowebcache.storage.BlobStoreListenerList;
+import org.geowebcache.storage.TileObject;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.io.payloads.ByteArrayPayload;
+
+public class SwiftTile {
+    static final Log log = LogFactory.getLog(SwiftBlobStore.class);
+
+    private final String layerName;
+    private final String gridSetId;
+    private final String blobFormat;
+    private final String parametersId;
+
+    private final long x;
+    private final long y;
+    private final int z;
+
+    private final long outputLength;
+
+    private boolean existed = false;
+    private long oldSize = 0L;
+
+    private final byte[] data;
+
+    public SwiftTile(final TileObject tile) throws IOException {
+        this.layerName = tile.getLayerName();
+        this.gridSetId = tile.getGridSetId();
+        this.blobFormat = tile.getBlobFormat();
+        this.parametersId = tile.getParametersId();
+
+        Resource blob = tile.getBlob();
+        checkNotNull(blob, "Object Blob must not be null.");
+        checkNotNull(this.blobFormat, "Object Blob Format must not be null.");
+
+        long[] xyz = tile.getXYZ();
+        this.x = xyz[0];
+        this.y = xyz[1];
+        this.z = (int) xyz[2];
+
+        try (InputStream stream = blob.getInputStream()) {
+            data = ByteStreams.toByteArray(stream);
+        }
+
+        this.outputLength = data.length;
+    }
+
+    private BaseMutableContentMetadata getMetadata() {
+        BaseMutableContentMetadata metadata = new BaseMutableContentMetadata();
+        metadata.setContentLength(outputLength);
+        try {
+            metadata.setContentType(MimeType.createFromFormat(blobFormat).getMimeType());
+        } catch (MimeException e) {
+            // Do nothing if we cannot determine the mimeType;
+            log.warn("Could not determine mimetype for " + toString());
+        }
+        return metadata;
+    }
+
+    public Payload getPayload() {
+        Payload payload = new ByteArrayPayload(data);
+        payload.setContentMetadata(getMetadata());
+        return payload;
+    }
+
+    public void setExisted(long oldSize) {
+        this.existed = true;
+        this.oldSize = oldSize;
+    }
+
+    public void notifyListeners(BlobStoreListenerList listeners) {
+        boolean hasListeners = !listeners.isEmpty();
+
+        if (hasListeners && existed) {
+            listeners.sendTileUpdated(
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLength, oldSize);
+        } else if (hasListeners) {
+            listeners.sendTileStored(
+                    layerName, gridSetId, blobFormat, parametersId, x, y, z, outputLength);
+        }
+    }
+
+    public String toString() {
+        String format = "%s, %s, %s, %s, xyz=%d,%d,%d";
+        return String.format(format, layerName, gridSetId, blobFormat, parametersId, x, y, z);
+    }
+}

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
@@ -114,7 +114,7 @@
   </bean -->
   
   <bean id="gwcStorageBroker" class="org.geowebcache.storage.DefaultStorageBroker" destroy-method="destroy">
-    <constructor-arg ref="gwcBlobStore" />
+    <constructor-arg ref="gwcCacheSingleColorBlobStore" />
     <constructor-arg ref="gwcTransientCache" />
   </bean>
   
@@ -223,6 +223,10 @@
     <property name="store" ref="gwcBlobStore" />
     <!--property name="cacheProvider" ref="guavaCacheProvider" /-->
     <!-- property name="cacheBeanName" value="guavaCacheProvider" /-->
+  </bean>
+
+  <bean id="gwcCacheSingleColorBlobStore" class="org.geowebcache.storage.blobstore.equivtiles.CacheSingleColorBlobStore" destroy-method="destroy">
+    <property name="store" ref="gwcBlobStore" />
   </bean>
   
   <bean id="gwcNullBlobStore" class="org.geowebcache.storage.blobstore.memory.NullBlobStore" destroy-method="destroy"/>


### PR DESCRIPTION
This is a generalised implementation for caching equivalent tiles utilising a wrapper BlobStore class CacheSingleColorBlobStore. A new Blobstore interface has been added called BlobStoreSingleColorTiles which contains three new methods to implement to do with sending symlinks for single colour tiles. This includes putSymlink(TileObject tileObject, String singleColourTileRef), tileExistsInStorage(TileObject tile, String singleColourTileRef) and saveSingleColourTile(TileObject tile, String singleColourTileRef).

Due to creating a new interface, there needs to be changes to CompositeBlobStore. However, this is only a proof of concept and will need to be likely updated in the future if the changes are integrated into the original Blobstore interface.
