### PR TITLE
Minor scalability improvements

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
@@ -25,12 +25,13 @@ public class BoundingBox implements Serializable {
 
     private static final long serialVersionUID = -2555598825074884627L;
 
-    private static NumberFormat COORD_FORMATTER = NumberFormat.getNumberInstance(Locale.ENGLISH);
+    private NumberFormat getCoordinateFormatter() {
+        NumberFormat COORD_FORMATTER = NumberFormat.getNumberInstance(Locale.ENGLISH);
 
-    static {
         COORD_FORMATTER.setMinimumFractionDigits(1);
         COORD_FORMATTER.setGroupingUsed(false);
         COORD_FORMATTER.setMaximumFractionDigits(16);
+        return COORD_FORMATTER;
     }
 
     private static Log log = LogFactory.getLog(org.geowebcache.grid.BoundingBox.class);
@@ -172,14 +173,15 @@ public class BoundingBox implements Serializable {
     /** Returns a comma separated value String suitable for URL output */
     @Override
     public String toString() {
+        NumberFormat formatter = getCoordinateFormatter();
         StringBuilder buff = new StringBuilder(40);
-        buff.append(COORD_FORMATTER.format(coords[0]));
+        buff.append(formatter.format(coords[0]));
         buff.append(',');
-        buff.append(COORD_FORMATTER.format(coords[1]));
+        buff.append(formatter.format(coords[1]));
         buff.append(',');
-        buff.append(COORD_FORMATTER.format(coords[2]));
+        buff.append(formatter.format(coords[2]));
         buff.append(',');
-        buff.append(COORD_FORMATTER.format(coords[3]));
+        buff.append(formatter.format(coords[3]));
         return buff.toString();
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -88,6 +87,8 @@ public class FileBlobStore implements BlobStore {
     private ExecutorService deleteExecutorService;
 
     private LayerMetadataStore layerMetadata;
+
+    private TempFileNameGenerator tmpGenerator = new TempFileNameGenerator();
 
     public FileBlobStore(DefaultStorageFinder defStoreFinder)
             throws StorageException, ConfigurationException {
@@ -540,7 +541,7 @@ public class FileBlobStore implements BlobStore {
     private void writeFile(File target, TileObject stObj, boolean existed) throws StorageException {
         // first write to temp file
         tmp.mkdirs();
-        File temp = new File(tmp, UUID.randomUUID().toString());
+        File temp = new File(tmp, tmpGenerator.newName());
 
         try {
             // open the output stream and read the blob into the tile

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/TempFileNameGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/TempFileNameGenerator.java
@@ -1,0 +1,39 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * <p>Copyright 2020
+ */
+package org.geowebcache.storage.blobstore.file;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Generates temporary file names with the help of random UUIDS and a counter, to avoid scalablity
+ * issues in pure random UUID generation
+ */
+class TempFileNameGenerator {
+
+    private static final int ROLL_LIMIT = 10000;
+    String base = UUID.randomUUID().toString();
+    AtomicInteger suffix = new AtomicInteger();
+
+    public String newName() {
+        int v = this.suffix.incrementAndGet();
+        if (v > ROLL_LIMIT) {
+            base = UUID.randomUUID().toString();
+            this.suffix.set(0);
+            v = this.suffix.incrementAndGet();
+        }
+        return base + v;
+    }
+}


### PR DESCRIPTION
Doing a "monitor profile" session the following two scalability issues were identified:
* NumberFormat is used to build the bounding box toString representation, which is then used during seed jobs in GeoServer seeds. It has an internal synchronization that shows up in the profile session, better to just reallocate the object instead.
* UUID.newRandomUUID, used to generate temp file names, is both a bit expensive and has synchronizations, worked around by adding a counter as a suffix to a fixed random UUID, which is replaced every N requests instead