### PR TITLE
Avoid assertTrue for tests that can be expressed with dedicated assertions (equals, null, same, array, and so on). Add PMD rule to enforce it.

### DIFF
--- a/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/config/CacheInfoPersisterTest.java
+++ b/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/config/CacheInfoPersisterTest.java
@@ -46,7 +46,7 @@ public class CacheInfoPersisterTest extends TestCase {
         assertEquals(0.0037383177570093459, sr.getXYTolerance(), 1e-6);
         assertEquals(2, sr.getZTolerance(), 1e-6);
         assertEquals(2, sr.getMTolerance(), 1e-6);
-        assertEquals(true, sr.isHighPrecision());
+        assertTrue(sr.isHighPrecision());
         assertEquals(2193, sr.getWKID());
         assertEquals(2193, sr.getLatestWKID());
     }

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConfigProviderTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConfigProviderTest.java
@@ -61,6 +61,6 @@ public class AzureBlobStoreConfigProviderTest {
         assertEquals("myname", abConfig.getAccountName());
         assertEquals("${MYKEY}", abConfig.getAccountKey());
         assertEquals("30", abConfig.getMaxConnections());
-        assertEquals(true, abConfig.isEnabled());
+        assertTrue(abConfig.isEnabled());
     }
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/DemoTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/DemoTest.java
@@ -1,6 +1,7 @@
 package org.geowebcache;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/geowebcache/core/src/test/java/org/geowebcache/MockExtensionRuleTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/MockExtensionRuleTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import org.hamcrest.Matchers;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
@@ -15,6 +15,7 @@
 package org.geowebcache.config;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.net.MalformedURLException;
@@ -60,7 +61,7 @@ public class DefaultingConfigurationTest {
         config.setDefaultValues(tl);
         boolean cacheBypass = tl.isCacheBypassAllowed();
         int timeout = tl.getBackendTimeout();
-        assertEquals(cacheBypass, false);
+        assertFalse(cacheBypass);
         assertEquals(timeout, 120);
         assertNull(tl.getFormatModifiers());
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationRoundTripTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationRoundTripTest.java
@@ -14,7 +14,8 @@
  */
 package org.geowebcache.config;
 
-import static org.geowebcache.config.GWCConfigIntegrationTestData.*;
+import static org.geowebcache.config.GWCConfigIntegrationTestData.BLOBSTORES;
+import static org.geowebcache.config.GWCConfigIntegrationTestData.LAYERS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTestData.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTestData.java
@@ -19,7 +19,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.geowebcache.filter.parameters.StringParameterFilter;
-import org.geowebcache.grid.*;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSet;
+import org.geowebcache.grid.GridSetFactory;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.grid.GridSubsetFactory;
+import org.geowebcache.grid.SRS;
 import org.geowebcache.layer.wms.WMSLayer;
 
 /** Test data for {@link GWCConfigIntegrationTest} */

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GridSetConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GridSetConfigurationTest.java
@@ -14,8 +14,8 @@
  */
 package org.geowebcache.config;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import java.util.Optional;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/LayerConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/LayerConfigurationTest.java
@@ -14,8 +14,8 @@
  */
 package org.geowebcache.config;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import java.util.Optional;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
@@ -15,7 +15,12 @@
 package org.geowebcache.config;
 
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
@@ -15,7 +15,10 @@
 package org.geowebcache.config;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
@@ -50,63 +53,63 @@ public class XMLConfigurationBackwardsCompatibilityTest {
     public void testLoadPre10() throws Exception {
         Iterable<TileLayer> layers = loadResource("geowebcache_pre10.xml");
         TileLayer layer = findLayer(layers, "topp:states");
-        assertTrue(layer != null);
+        assertNotNull(layer);
         TileLayer layer2 = findLayer(layers, "topp:states2");
         GridSubset grid = layer2.getGridSubsetForSRS(SRS.getSRS(2163));
-        assertTrue(layer2 != null);
-        assertTrue(grid != null);
+        assertNotNull(layer2);
+        assertNotNull(grid);
     }
 
     @Test
     public void testLoad10() throws Exception {
         Iterable<TileLayer> layers = loadResource("geowebcache_10.xml");
         TileLayer layer = findLayer(layers, "topp:states");
-        assertTrue(layer != null);
+        assertNotNull(layer);
         // assertEquals(layer.getCachePrefix(), "/var/lib/geowebcache/topp_states");
         TileLayer layer2 = findLayer(layers, "topp:states2");
         GridSubset grid = layer2.getGridSubsetForSRS(SRS.getSRS(2163));
-        assertTrue(layer2 != null);
-        assertTrue(grid != null);
+        assertNotNull(layer2);
+        assertNotNull(grid);
     }
 
     @Test
     public void testLoad101() throws Exception {
         Iterable<TileLayer> layers = loadResource("geowebcache_101.xml");
         TileLayer layer = findLayer(layers, "topp:states");
-        assertTrue(layer != null);
+        assertNotNull(layer);
         // assertEquals(layer.getCachePrefix(), "/var/lib/geowebcache/topp_states");
         TileLayer layer2 = findLayer(layers, "topp:states2");
         GridSubset grid = layer2.getGridSubsetForSRS(SRS.getSRS(2163));
-        assertTrue(layer2 != null);
-        assertTrue(grid != null);
+        assertNotNull(layer2);
+        assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
         assertEquals(layer.getBackendTimeout().intValue(), 60);
         assertEquals(layer2.getBackendTimeout().intValue(), 235);
-        assertEquals(layer.isCacheBypassAllowed().booleanValue(), true);
-        assertEquals(layer2.isCacheBypassAllowed().booleanValue(), false);
+        assertTrue(layer.isCacheBypassAllowed().booleanValue());
+        assertFalse(layer2.isCacheBypassAllowed().booleanValue());
     }
 
     @Test
     public void testLoad114() throws Exception {
         Iterable<TileLayer> layers = loadResource("geowebcache_114.xml");
         TileLayer layer = findLayer(layers, "topp:states");
-        assertTrue(layer != null);
+        assertNotNull(layer);
         // assertEquals(layer.getCachePrefix(), "/var/lib/geowebcache/topp_states");
         TileLayer layer2 = findLayer(layers, "topp:states2");
         GridSubset grid = layer2.getGridSubsetForSRS(SRS.getSRS(2163));
-        assertTrue(layer2 != null);
-        assertTrue(grid != null);
+        assertNotNull(layer2);
+        assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
         assertEquals(layer.getBackendTimeout().intValue(), 120);
         assertEquals(layer2.getBackendTimeout().intValue(), 120);
-        assertEquals(layer.isCacheBypassAllowed().booleanValue(), true);
-        assertEquals(layer2.isCacheBypassAllowed().booleanValue(), true);
+        assertTrue(layer.isCacheBypassAllowed().booleanValue());
+        assertTrue(layer2.isCacheBypassAllowed().booleanValue());
 
         FormatModifier fm = layer.getFormatModifier(ImageMime.jpeg);
         assertEquals(fm.getBgColor(), "0xDDDDDD");
-        assertTrue(fm.getRequestFormat().equals(ImageMime.png));
+        assertEquals(fm.getRequestFormat(), ImageMime.png);
 
         List<RequestFilter> filters = layer.getRequestFilters();
         assertEquals(filters.get(0).getName(), "testWMSRasterFilter");
@@ -117,22 +120,22 @@ public class XMLConfigurationBackwardsCompatibilityTest {
     public void testLoad115() throws Exception {
         Iterable<TileLayer> layers = loadResource("geowebcache_115.xml");
         TileLayer layer = findLayer(layers, "topp:states");
-        assertTrue(layer != null);
+        assertNotNull(layer);
         // assertEquals(layer.getCachePrefix(), "/var/lib/geowebcache/topp_states");
         TileLayer layer2 = findLayer(layers, "topp:states2");
         GridSubset grid = layer2.getGridSubsetForSRS(SRS.getSRS(2163));
-        assertTrue(layer2 != null);
-        assertTrue(grid != null);
+        assertNotNull(layer2);
+        assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
         assertEquals(layer.getBackendTimeout().intValue(), 120);
         assertEquals(layer2.getBackendTimeout().intValue(), 120);
-        assertEquals(layer.isCacheBypassAllowed().booleanValue(), true);
-        assertEquals(layer2.isCacheBypassAllowed().booleanValue(), true);
+        assertTrue(layer.isCacheBypassAllowed().booleanValue());
+        assertTrue(layer2.isCacheBypassAllowed().booleanValue());
 
         FormatModifier fm = layer.getFormatModifier(ImageMime.jpeg);
         assertEquals(fm.getBgColor(), "0xDDDDDD");
-        assertTrue(fm.getRequestFormat().equals(ImageMime.png));
+        assertEquals(fm.getRequestFormat(), ImageMime.png);
 
         List<RequestFilter> filters = layer.getRequestFilters();
         RequestFilter filter0 = filters.get(0);

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationConstructorsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationConstructorsTest.java
@@ -21,7 +21,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -17,8 +17,19 @@ package org.geowebcache.config;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -268,7 +279,7 @@ public class XMLConfigurationTest {
         assertThat(config2.getLayer("testLayer"), TestUtils.isPresent());
 
         WMSLayer l = (WMSLayer) config2.getLayer("testLayer").get();
-        assertTrue(Arrays.equals(wmsURL, l.getWMSurl()));
+        assertArrayEquals(wmsURL, l.getWMSurl());
         assertEquals(wmsStyles, l.getStyles());
         assertEquals(wmsLayers, l.getWmsLayers());
         assertEquals(mimeFormats, l.getMimeFormats());
@@ -549,7 +560,7 @@ public class XMLConfigurationTest {
 
         final String currVersion = XMLConfiguration.getCurrentSchemaVersion();
         assertNotNull(currVersion);
-        assertFalse(previousVersion.equals(currVersion));
+        assertNotEquals(previousVersion, currVersion);
 
         config = new XMLConfiguration(null, configDir.getAbsolutePath());
         config.setGridSetBroker(gridSetBroker);

--- a/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
@@ -16,7 +16,7 @@ package org.geowebcache.config.legends;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/FloatParameterFilterTest.java
@@ -19,7 +19,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.XStream;
 import java.util.Arrays;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/IntegerParameterFilterTest.java
@@ -19,7 +19,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.XStream;
 import java.util.Arrays;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
@@ -17,7 +17,7 @@ package org.geowebcache.filter.parameters;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.Map;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/RegexParameterFilterTest.java
@@ -20,7 +20,10 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.XStream;
 import java.util.Arrays;

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/StringParameterFilterTest.java
@@ -20,7 +20,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.XStream;
 import java.util.Arrays;

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/BoundingBoxTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/BoundingBoxTest.java
@@ -1,6 +1,7 @@
 package org.geowebcache.grid;
 
-import java.util.Arrays;
+import static org.junit.Assert.assertArrayEquals;
+
 import junit.framework.TestCase;
 
 public class BoundingBoxTest extends TestCase {
@@ -24,7 +25,7 @@ public class BoundingBoxTest extends TestCase {
         if (bboxStr.equalsIgnoreCase("-180.0,-90.0,180.0,90.0")) {
             assertTrue(true);
         } else {
-            assertTrue(false);
+            fail();
         }
     }
 
@@ -49,7 +50,7 @@ public class BoundingBoxTest extends TestCase {
         assertEquals(5D, intersection.getWidth());
         assertEquals(5D, intersection.getHeight());
         assertTrue(intersection.isSane());
-        assertTrue(Arrays.equals(new double[] {5, 5, 10, 10}, intersection.getCoords()));
+        assertArrayEquals(new double[] {5, 5, 10, 10}, intersection.getCoords(), 0.0);
     }
 
     /** Two bboxes don't intersect, BoundingBox.intersection()'s result should be the empty bbox */

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridCalculatorTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridCalculatorTest.java
@@ -1,5 +1,7 @@
 package org.geowebcache.grid;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.util.Arrays;
 import java.util.Collections;
 import junit.framework.TestCase;
@@ -35,7 +37,7 @@ public class GridCalculatorTest extends TestCase {
                 System.out.println(
                         i + " " + Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -61,7 +63,7 @@ public class GridCalculatorTest extends TestCase {
             if (!Arrays.equals(solution[i], bounds)) {
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -88,7 +90,7 @@ public class GridCalculatorTest extends TestCase {
             if (!Arrays.equals(solution[i], bounds)) {
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -116,7 +118,7 @@ public class GridCalculatorTest extends TestCase {
             if (!Arrays.equals(solution[i], bounds)) {
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -137,7 +139,7 @@ public class GridCalculatorTest extends TestCase {
                 System.out.println("test1gridLevels900913, level " + i);
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -164,7 +166,7 @@ public class GridCalculatorTest extends TestCase {
                 System.out.println("test2gridLevels900913, level " + i);
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -192,7 +194,7 @@ public class GridCalculatorTest extends TestCase {
                 System.out.println("test3gridLevels900913, level " + i);
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -204,7 +206,7 @@ public class GridCalculatorTest extends TestCase {
 
         long[] bestFit = grid.getCoverageBestFit();
         long[] solution = {0, 0, 0, 0, 0};
-        assertTrue(Arrays.equals(bestFit, solution));
+        assertArrayEquals(bestFit, solution);
     }
 
     public void test6gridLoctoBounds4326() throws Exception {
@@ -251,7 +253,7 @@ public class GridCalculatorTest extends TestCase {
             if (!Arrays.equals(solution[i], bounds)) {
                 System.out.println(Arrays.toString(solution[i]) + "  " + Arrays.toString(bounds));
             }
-            assertTrue(Arrays.equals(solution[i], bounds));
+            assertArrayEquals(solution[i], bounds);
         }
     }
 
@@ -322,16 +324,16 @@ public class GridCalculatorTest extends TestCase {
 
         // Check the actual max bounds
         long[] solution = {0, 0, 0};
-        assertTrue(Arrays.equals(solution, gridSubset.closestIndex(bbox)));
+        assertArrayEquals(solution, gridSubset.closestIndex(bbox));
 
         // Test a grid location
         long[] gridLoc = {1, 0, 1};
         BoundingBox bboxSolution =
                 new BoundingBox(599484.8750000002, 4912451.9275, 611635.5437500004, 4924602.59625);
-        assertTrue(bboxSolution.equals(gridSubset.boundsFromIndex(gridLoc)));
+        assertEquals(bboxSolution, gridSubset.boundsFromIndex(gridLoc));
 
         // Now lets go the other way
-        assertTrue(Arrays.equals(gridLoc, gridSubset.closestIndex(bboxSolution)));
+        assertArrayEquals(gridLoc, gridSubset.closestIndex(bboxSolution));
     }
 
     public void testTopLeftNaive() throws Exception {
@@ -356,11 +358,11 @@ public class GridCalculatorTest extends TestCase {
         // Check the actual max bounds
         long[] solution = {0, 0, 0};
         long[] closest = gridSubset.closestIndex(new BoundingBox(-180.0, -90.0, 0.0, 90.0));
-        assertTrue(Arrays.equals(solution, closest));
+        assertArrayEquals(solution, closest);
 
         long[] solution2 = {1, 0, 0};
         closest = gridSubset.closestIndex(new BoundingBox(0.0, -90.0, 180.0, 90.0));
-        assertTrue(Arrays.equals(solution2, closest));
+        assertArrayEquals(solution2, closest);
 
         long[] t1 = {0, 0, 1}; // 90x90 degrees
         BoundingBox test1 = gridSubset.boundsFromIndex(t1);
@@ -396,17 +398,17 @@ public class GridCalculatorTest extends TestCase {
         // Check the actual max bounds
         long[] solution = {0, 0, 0};
         long[] closest = gridSubset.closestIndex(bbox);
-        assertTrue(Arrays.equals(solution, closest));
+        assertArrayEquals(solution, closest);
 
         // Test a grid location
         long[] gridLoc = {1, 0, 1};
         BoundingBox bboxSolution =
                 new BoundingBox(599484.8750000002, 4912451.9275, 611635.5437500004, 4924602.59625);
-        assertTrue(bboxSolution.equals(gridSubset.boundsFromIndex(gridLoc)));
+        assertEquals(bboxSolution, gridSubset.boundsFromIndex(gridLoc));
 
         // Now lets go the other way
         closest = gridSubset.closestIndex(bboxSolution);
-        assertTrue(Arrays.equals(gridLoc, closest));
+        assertArrayEquals(gridLoc, closest);
     }
 
     private BoundingBox createApproximateTileBounds(

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetBrokerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetBrokerTest.java
@@ -21,7 +21,12 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Optional;

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridSetTest.java
@@ -3,10 +3,9 @@ package org.geowebcache.grid;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import org.geowebcache.config.DefaultGridsets;
 import org.hamcrest.Matcher;
@@ -148,8 +147,8 @@ public class GridSetTest {
         long[] idxBL = gridSetBL.closestIndex(box);
         long[] solution = {0, 0, 1};
 
-        assertTrue(Arrays.equals(idxTL, solution));
-        assertTrue(Arrays.equals(idxBL, solution));
+        assertArrayEquals(idxTL, solution);
+        assertArrayEquals(idxBL, solution);
     }
 
     @Test
@@ -159,8 +158,8 @@ public class GridSetTest {
         long[] rectBL = gridSetBL.closestRectangle(box);
         long[] solution = {0, 0, 1, 0, 1};
 
-        assertTrue(Arrays.equals(rectTL, solution));
-        assertTrue(Arrays.equals(rectBL, solution));
+        assertArrayEquals(rectTL, solution);
+        assertArrayEquals(rectBL, solution);
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/GridSubSetFactoryTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/GridSubSetFactoryTest.java
@@ -1,6 +1,7 @@
 package org.geowebcache.grid;
 
-import java.util.Arrays;
+import static org.junit.Assert.assertArrayEquals;
+
 import java.util.Collections;
 import junit.framework.TestCase;
 import org.geowebcache.config.DefaultGridsets;
@@ -19,7 +20,7 @@ public class GridSubSetFactoryTest extends TestCase {
         long[] ret = grid.getCoverage(0);
         long[] correct = {1, 0, 1, 0, 0};
 
-        assertTrue(Arrays.equals(correct, ret));
+        assertArrayEquals(correct, ret);
     }
 
     public void testCoverageBounds2() throws Exception {
@@ -31,7 +32,7 @@ public class GridSubSetFactoryTest extends TestCase {
         long[] ret = grid.getCoverage(1);
         long[] correct = {2, 1, 3, 1, 1};
 
-        assertTrue(Arrays.equals(correct, ret));
+        assertArrayEquals(correct, ret);
     }
 
     public void testGridNames() throws Exception {
@@ -61,7 +62,7 @@ public class GridSubSetFactoryTest extends TestCase {
         assertEquals(3, coverages.length);
         long[] correct = {2, 0, 3, 0};
 
-        assertTrue(Arrays.equals(correct, coverages[0]));
+        assertArrayEquals(correct, coverages[0]);
     }
 
     public void testGridIndex() throws Exception {

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
@@ -14,7 +14,11 @@
  */
 package org.geowebcache.layer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Set;

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/MetaTileTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/MetaTileTest.java
@@ -224,10 +224,10 @@ public class MetaTileTest extends TestCase {
 
         // The actual gutter is calculated right at construction time
         wmsParams = mt.getWMSParams();
-        assertTrue(mt.getGutter()[0] == layer.gutter);
-        assertTrue(mt.getGutter()[1] == layer.gutter);
-        assertTrue(mt.getGutter()[2] == layer.gutter);
-        assertTrue(mt.getGutter()[3] == layer.gutter);
+        assertEquals(mt.getGutter()[0], (int) layer.gutter);
+        assertEquals(mt.getGutter()[1], (int) layer.gutter);
+        assertEquals(mt.getGutter()[2], (int) layer.gutter);
+        assertEquals(mt.getGutter()[3], (int) layer.gutter);
 
         height = Integer.parseInt(wmsParams.get("HEIGHT"));
 

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
@@ -28,7 +28,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
@@ -397,7 +400,7 @@ public class WMSLayerTest extends TileLayerTest {
         // proxy the request, and check the response
         layer.proxyRequest(tile);
 
-        assertEquals(null, servletResp.getContentType());
+        assertNull(servletResp.getContentType());
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/mime/XMLMimeTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/mime/XMLMimeTest.java
@@ -1,6 +1,9 @@
 package org.geowebcache.mime;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -13,7 +16,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromFormat("application/vnd.ogc.se_xml");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -28,7 +31,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromFormat("application/vnd.google-earth.kml+xml");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -38,7 +41,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromExtension("kml");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -53,7 +56,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromFormat("application/vnd.google-earth.kmz");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -63,7 +66,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromExtension("kmz");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -78,7 +81,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromFormat("application/vnd.ogc.gml");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -88,7 +91,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromExtension("gml");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -103,7 +106,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromFormat("application/vnd.ogc.gml/3.1.1");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);
@@ -113,7 +116,7 @@ public class XMLMimeTest {
         try {
             result = MimeType.createFromExtension("gml3");
         } catch (MimeException e) {
-            assertTrue("Format not found", false);
+            fail("Format not found");
         }
         // Ensure it is not null
         assertNotNull(result);

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreConfigurationIntegrationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/CompositeBlobStoreConfigurationIntegrationTest.java
@@ -18,7 +18,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import org.geowebcache.GeoWebCacheException;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/TransientCacheTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/TransientCacheTest.java
@@ -15,8 +15,11 @@
 
 package org.geowebcache.storage;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.base.Ticker;
 import java.io.InputStream;

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStoreTest.java
@@ -12,7 +12,12 @@
  */
 package org.geowebcache.storage.blobstore.memory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +36,9 @@ import org.geowebcache.storage.StorageBrokerTest;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.storage.blobstore.file.FileBlobStore;
 import org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * This test class is used for testing {@link
@@ -290,13 +297,13 @@ public class MemoryBlobStoreTest {
                 is.close();
             } catch (IOException e) {
                 LOG.error(e.getMessage(), e);
-                assertTrue(false);
+                fail();
             }
             try {
                 is2.close();
             } catch (IOException e) {
                 LOG.error(e.getMessage(), e);
-                assertTrue(false);
+                fail();
             }
         }
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/util/MockLockProvider.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/util/MockLockProvider.java
@@ -1,6 +1,8 @@
 package org.geowebcache.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
@@ -14,6 +14,8 @@
  */
 package org.geowebcache.diskquota.storage;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -168,35 +170,35 @@ public class PagePyramidTest extends TestCase {
         int[] pageIndexTarget = {Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE};
         int[] expected = {0, 0, 0};
         pyramid.pageIndexForTile(0, 0, 0, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         expected = new int[] {1, 1, 0};
         pyramid.pageIndexForTile(1, 1, 0, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         // grid coverages:
         // { 3, 3, 10, 10, 1 },// 1x1 tiles
         expected = new int[] {0, 0, 1};
         pyramid.pageIndexForTile(3, 3, 1, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         expected = new int[] {1, 1, 1};
         pyramid.pageIndexForTile(4, 4, 1, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         expected = new int[] {7, 7, 1};
         pyramid.pageIndexForTile(10, 10, 1, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         // grid coverages:
         // { 1000, 1000, 3000, 3000, 3 } // 77x77 pages, 26x26 tiles
         expected = new int[] {0, 0, 3};
         pyramid.pageIndexForTile(1000, 1000, 3, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
 
         expected = new int[] {1, 1, 3};
         pyramid.pageIndexForTile(1026, 1026, 3, pageIndexTarget);
-        assertTrue(Arrays.toString(pageIndexTarget), Arrays.equals(expected, pageIndexTarget));
+        assertArrayEquals(Arrays.toString(pageIndexTarget), expected, pageIndexTarget);
     }
 
     private List<Long> asList(long... coverage) {

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -1,6 +1,7 @@
 package org.geowebcache.diskquota.jdbc;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -901,14 +902,14 @@ public abstract class JDBCQuotaStoreTest {
         long[][] expected = tilePageCalculator.toGridCoverage(testTileSet, page);
         long[][] tilesForPage = store.getTilesForPage(page);
 
-        assertTrue(Arrays.equals(expected[0], tilesForPage[0]));
+        assertArrayEquals(expected[0], tilesForPage[0]);
 
         page = new TilePage(testTileSet.getId(), 0, 0, 1);
 
         expected = tilePageCalculator.toGridCoverage(testTileSet, page);
         tilesForPage = store.getTilesForPage(page);
 
-        assertTrue(Arrays.equals(expected[1], tilesForPage[1]));
+        assertArrayEquals(expected[1], tilesForPage[1]);
     }
 
     private int countTileSetsByLayerName(String layerName) {

--- a/geowebcache/distributed/src/test/java/org/geowebcache/blobstore/memory/distributed/HazelcastCacheProviderTest.java
+++ b/geowebcache/distributed/src/test/java/org/geowebcache/blobstore/memory/distributed/HazelcastCacheProviderTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
@@ -231,13 +232,13 @@ public class HazelcastCacheProviderTest {
                 is.close();
             } catch (IOException e) {
                 LOG.error(e.getMessage(), e);
-                assertTrue(false);
+                fail();
             }
             try {
                 is2.close();
             } catch (IOException e) {
                 LOG.error(e.getMessage(), e);
-                assertTrue(false);
+                fail();
             }
         }
     }

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/RasterMaskTest.java
@@ -61,37 +61,37 @@ public class RasterMaskTest extends TestCase {
                 new RasterMask(mask.getByLevelMasks(), fullCoverage, mask.getCoveredBounds());
 
         // level 0
-        assertEquals(true, tileRangeMask.lookup(0, 0, 0));
-        assertEquals(true, tileRangeMask.lookup(1, 0, 0));
+        assertTrue(tileRangeMask.lookup(0, 0, 0));
+        assertTrue(tileRangeMask.lookup(1, 0, 0));
 
         // level 1
         // TODO commented out by arneke
         // assertEquals(false, tileRangeMask.lookup(0, 1, 1));
-        assertEquals(true, tileRangeMask.lookup(1, 1, 1));
-        assertEquals(true, tileRangeMask.lookup(1, 0, 1));
+        assertTrue(tileRangeMask.lookup(1, 1, 1));
+        assertTrue(tileRangeMask.lookup(1, 0, 1));
 
         // level 2
-        assertEquals(false, tileRangeMask.lookup(0, 0, 2));
-        assertEquals(false, tileRangeMask.lookup(0, 1, 2));
-        assertEquals(true, tileRangeMask.lookup(1, 0, 2));
-        assertEquals(false, tileRangeMask.lookup(0, 3, 2));
-        assertEquals(true, tileRangeMask.lookup(7, 0, 2));
+        assertFalse(tileRangeMask.lookup(0, 0, 2));
+        assertFalse(tileRangeMask.lookup(0, 1, 2));
+        assertTrue(tileRangeMask.lookup(1, 0, 2));
+        assertFalse(tileRangeMask.lookup(0, 3, 2));
+        assertTrue(tileRangeMask.lookup(7, 0, 2));
 
         // level 9 (coverage is 0, 0, 1023, 511, 9)
-        assertEquals(false, tileRangeMask.lookup(0, 0, 9)); // lower left
-        assertEquals(false, tileRangeMask.lookup(0, 511, 9)); // upper left
-        assertEquals(false, tileRangeMask.lookup(1023, 511, 9)); // upper right
-        assertEquals(true, tileRangeMask.lookup(1023, 0, 9)); // lower right
+        assertFalse(tileRangeMask.lookup(0, 0, 9)); // lower left
+        assertFalse(tileRangeMask.lookup(0, 511, 9)); // upper left
+        assertFalse(tileRangeMask.lookup(1023, 511, 9)); // upper right
+        assertTrue(tileRangeMask.lookup(1023, 0, 9)); // lower right
 
-        assertEquals(true, tileRangeMask.lookup(511, 127, 9)); // point location
+        assertTrue(tileRangeMask.lookup(511, 127, 9)); // point location
 
         // line end point 1 LINESTRING(-90 -45, 90 45)
-        assertEquals(true, tileRangeMask.lookup(255, 127, 9));
+        assertTrue(tileRangeMask.lookup(255, 127, 9));
         // line end point 2 LINESTRING(-90 -45, 90 45)
-        assertEquals(true, tileRangeMask.lookup(767, 383, 9));
+        assertTrue(tileRangeMask.lookup(767, 383, 9));
 
         // center
-        assertEquals(true, tileRangeMask.lookup(511, 255, 9));
+        assertTrue(tileRangeMask.lookup(511, 255, 9));
     }
 
     public void testTileIsPresentBuffering() throws Exception {
@@ -113,15 +113,15 @@ public class RasterMaskTest extends TestCase {
          * <p>We only guarantee one tile buffering, so I'm not sure why we are testing all the tests
          * below, some of which fail. I've just commented them out to get the build back to normal.
          */
-        assertEquals(true, tileRangeMask.lookup(32, 23, 5)); // point location
+        assertTrue(tileRangeMask.lookup(32, 23, 5)); // point location
 
-        assertEquals(true, tileRangeMask.lookup(31, 23, 5)); // point's left
+        assertTrue(tileRangeMask.lookup(31, 23, 5)); // point's left
         // assertEquals(true, tileRangeMask.lookup(33, 23, 5));// point's right
 
-        assertEquals(true, tileRangeMask.lookup(32, 24, 5)); // point's top
+        assertTrue(tileRangeMask.lookup(32, 24, 5)); // point's top
         // assertEquals(true, tileRangeMask.lookup(32, 22, 5));// point's bottom
 
-        assertEquals(true, tileRangeMask.lookup(31, 24, 5)); // point's top left
+        assertTrue(tileRangeMask.lookup(31, 24, 5)); // point's top left
         // assertEquals(true, tileRangeMask.lookup(33, 24, 5));// point's top right
         // assertEquals(true, tileRangeMask.lookup(31, 22, 5));// point's bottom left
         // assertEquals(true, tileRangeMask.lookup(33, 22, 5));// point's bottom right
@@ -141,21 +141,21 @@ public class RasterMaskTest extends TestCase {
 
         // level 5 (coverage is 0, 0, 63, 31)
 
-        assertEquals(false, tileRangeMask.lookup(0, 0, 5));
-        assertEquals(false, tileRangeMask.lookup(0, 31, 5));
-        assertEquals(false, tileRangeMask.lookup(63, 31, 5));
-        assertEquals(true, tileRangeMask.lookup(63, 0, 5));
+        assertFalse(tileRangeMask.lookup(0, 0, 5));
+        assertFalse(tileRangeMask.lookup(0, 31, 5));
+        assertFalse(tileRangeMask.lookup(63, 31, 5));
+        assertTrue(tileRangeMask.lookup(63, 0, 5));
 
-        assertEquals(true, tileRangeMask.lookup(32, 23, 5)); // point location
+        assertTrue(tileRangeMask.lookup(32, 23, 5)); // point location
 
-        assertEquals(true, tileRangeMask.lookup(31, 23, 5)); // point's left
-        assertEquals(true, tileRangeMask.lookup(33, 23, 5)); // point's right
-        assertEquals(true, tileRangeMask.lookup(32, 24, 5)); // point's top
-        assertEquals(true, tileRangeMask.lookup(32, 22, 5)); // point's bottom
+        assertTrue(tileRangeMask.lookup(31, 23, 5)); // point's left
+        assertTrue(tileRangeMask.lookup(33, 23, 5)); // point's right
+        assertTrue(tileRangeMask.lookup(32, 24, 5)); // point's top
+        assertTrue(tileRangeMask.lookup(32, 22, 5)); // point's bottom
 
-        assertEquals(true, tileRangeMask.lookup(31, 24, 5)); // point's top left
-        assertEquals(true, tileRangeMask.lookup(33, 24, 5)); // point's top right
-        assertEquals(true, tileRangeMask.lookup(31, 22, 5)); // point's bottom left
-        assertEquals(true, tileRangeMask.lookup(33, 22, 5)); // point's bottom right
+        assertTrue(tileRangeMask.lookup(31, 24, 5)); // point's top left
+        assertTrue(tileRangeMask.lookup(33, 24, 5)); // point's top right
+        assertTrue(tileRangeMask.lookup(31, 22, 5)); // point's bottom left
+        assertTrue(tileRangeMask.lookup(33, 22, 5)); // point's bottom right
     }
 }

--- a/geowebcache/kml/src/test/java/org/geowebcache/service/kml/KMLServiceTest.java
+++ b/geowebcache/kml/src/test/java/org/geowebcache/service/kml/KMLServiceTest.java
@@ -12,28 +12,28 @@ public class KMLServiceTest extends TestCase {
     public void test1ParseRequest() throws Exception {
         String[] retVals = KMLService.parseRequest("/kml/topp:states.kml");
 
-        assertTrue(retVals[0].equals("topp:states"));
-        assertTrue(retVals[1].length() == 0);
-        assertTrue(retVals[2].equals("kml"));
-        assertTrue(retVals[3] == null);
+        assertEquals("topp:states", retVals[0]);
+        assertEquals(0, retVals[1].length());
+        assertEquals("kml", retVals[2]);
+        assertNull(retVals[3]);
     }
 
     public void test2ParseRequest() throws Exception {
         String[] retVals = KMLService.parseRequest("/kml/topp:states.jpeg.kml");
 
-        assertTrue(retVals[0].equals("topp:states"));
-        assertTrue(retVals[1].length() == 0);
-        assertTrue(retVals[2].equals("jpeg"));
-        assertTrue(retVals[3].equals("kml"));
+        assertEquals("topp:states", retVals[0]);
+        assertEquals(0, retVals[1].length());
+        assertEquals("jpeg", retVals[2]);
+        assertEquals("kml", retVals[3]);
     }
 
     public void test3ParseRequest() throws Exception {
         String[] retVals = KMLService.parseRequest("/kml/topp:states/x1y2z3.jpeg.kml");
 
-        assertTrue(retVals[0].equals("topp:states"));
-        assertTrue(retVals[1].equals("x1y2z3"));
-        assertTrue(retVals[2].equals("jpeg"));
-        assertTrue(retVals[3].equals("kml"));
+        assertEquals("topp:states", retVals[0]);
+        assertEquals("x1y2z3", retVals[1]);
+        assertEquals("jpeg", retVals[2]);
+        assertEquals("kml", retVals[3]);
         int[] test = {1, 2, 3};
         assertEquals(test[0], KMLService.parseGridLocString(retVals[1])[0]);
         assertEquals(test[1], KMLService.parseGridLocString(retVals[1])[1]);

--- a/geowebcache/pmd-ruleset.xml
+++ b/geowebcache/pmd-ruleset.xml
@@ -41,6 +41,9 @@ under the License.
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
     <rule ref="category/java/bestpractices.xml/SystemPrintln" />
     <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach" />
+    <rule ref="category/java/bestpractices.xml/UseAssertEqualsInsteadOfAssertTrue" />
+    <rule ref="category/java/bestpractices.xml/UseAssertNullInsteadOfAssertTrue" />
+    <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue" />
 
     <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
     <rule ref="category/java/codestyle.xml/DuplicateImports" />

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigProviderTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConfigProviderTest.java
@@ -57,6 +57,6 @@ public class S3BlobStoreConfigProviderTest {
         S3BlobStoreInfo s3Config = (S3BlobStoreInfo) config;
         assertEquals("MYBUCKET", s3Config.getBucket());
         assertEquals(30, s3Config.getMaxConnections().intValue());
-        assertEquals(true, s3Config.isEnabled());
+        assertTrue(s3Config.isEnabled());
     }
 }

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -492,17 +492,17 @@ public class SwiftBlobStoreTest {
 
         // Test if layer name is empty
         String result = this.swiftBlobStore.getLayerMetadata("", "sample_key");
-        assertEquals(null, result);
+        assertNull(result);
 
         // Test if layer name is invalid
         result = this.swiftBlobStore.getLayerMetadata(INVALID_TEST_LAYER_NAME, "sample_key");
-        assertEquals(null, result);
+        assertNull(result);
 
         // Test if metadata is null
         result =
                 this.swiftBlobStore.getLayerMetadata(
                         "valid layer name without metadata", "sample_key");
-        assertEquals(null, result);
+        assertNull(result);
 
         // Test when layer name is valid
         result = this.swiftBlobStore.getLayerMetadata(VALID_TEST_LAYER_NAME, "sample_key");
@@ -512,7 +512,7 @@ public class SwiftBlobStoreTest {
         // Test when layer name is valid and key is invalid
         result = this.swiftBlobStore.getLayerMetadata(VALID_TEST_LAYER_NAME, "");
         verify(objectApi, times(1)).get("");
-        assertEquals(null, result);
+        assertNull(result);
     }
 
     @Test

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
@@ -143,12 +143,13 @@ public class WMSServiceTest {
 
         assertEquals(expectedGridset, tileRequest.getGridSetId());
         assertEquals("image/png", tileRequest.getMimeType().getMimeType());
-        assertTrue(
+        assertArrayEquals(
                 "Expected "
                         + Arrays.toString(tileIndex)
                         + " got "
                         + Arrays.toString(tileRequest.getTileIndex()),
-                Arrays.equals(tileIndex, tileRequest.getTileIndex()));
+                tileIndex,
+                tileRequest.getTileIndex());
     }
 
     private TileLayer mockTileLayer(String layerName, List<String> gridSetNames) throws Exception {
@@ -338,7 +339,7 @@ public class WMSServiceTest {
         assertEquals(Conveyor.RequestHandler.SERVICE, conv.reqHandler);
         assertNotNull(conv.getLayerId());
         assertEquals(layerName, conv.getLayerId());
-        assertTrue(!conv.getFilteringParameters().isEmpty());
+        assertFalse(conv.getFilteringParameters().isEmpty());
         assertEquals(timeValue, conv.getFilteringParameters().get("TIME"));
     }
 


### PR DESCRIPTION
Follow up on similar GeoTools work