### PR TITLE
[1.18.x backport] Update Spring to v5.1.20.RELEASE and Spring security to 5.1.13.RELEASE

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -13,8 +13,8 @@
     <gt.version>24-SNAPSHOT</gt.version>
     <jts.version>1.17.1</jts.version>
     <jaiext.version>1.1.18</jaiext.version>
-    <spring.version>5.1.16.RELEASE</spring.version>
-    <spring.security.version>5.1.11.RELEASE</spring.security.version>
+    <spring.version>5.1.20.RELEASE</spring.version>
+    <spring.security.version>5.1.13.RELEASE</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
Spring has resolved CVE-2020-5421

backports #921 
related https://github.com/geoserver/geoserver/pull/4688