### PR TITLE
Introduce 512px tiles as a possible alternative for the default gridsets

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/DefaultGridsets.java
@@ -14,6 +14,7 @@
  */
 package org.geowebcache.config;
 
+import java.util.Arrays;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
@@ -33,14 +34,26 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
 
     private final GridSet WORLD_EPSG4326;
 
+    private final GridSet WORLD_EPSG4326x2;
+
     private final GridSet WORLD_EPSG3857;
+
+    private final GridSet WORLD_EPSG3857x2;
 
     public GridSet worldEpsg4326() {
         return new GridSet(WORLD_EPSG4326);
     }
 
+    public GridSet worldEpsg4326x2() {
+        return new GridSet(WORLD_EPSG4326x2);
+    }
+
     public GridSet worldEpsg3857() {
         return new GridSet(WORLD_EPSG3857);
+    }
+
+    public GridSet worldEpsg3857x2() {
+        return new GridSet(WORLD_EPSG3857x2);
     }
 
     /**
@@ -79,10 +92,29 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
                         true);
         WORLD_EPSG4326.setDescription(
                 "A default WGS84 tile matrix set where the first zoom level "
-                        + "covers the world with two tiles on the horizonal axis and one tile "
+                        + "covers the world with two tiles on the horizontal axis and one tile "
                         + "over the vertical axis and each subsequent zoom level is calculated by half "
-                        + "the resolution of its previous one.");
+                        + "the resolution of its previous one. Tiles are 256px wide.");
         addInternal(WORLD_EPSG4326);
+
+        WORLD_EPSG4326x2 =
+                GridSetFactory.createGridSet(
+                        unprojectedName + "x2",
+                        SRS.getEPSG4326(),
+                        BoundingBox.WORLD4326,
+                        false,
+                        GridSetFactory.DEFAULT_LEVELS,
+                        null,
+                        GridSetFactory.DEFAULT_PIXEL_SIZE_METER,
+                        512,
+                        512,
+                        true);
+        WORLD_EPSG4326x2.setDescription(
+                "A default WGS84 tile matrix set where the first zoom level "
+                        + "covers the world with two tiles on the horizontal axis and one tile "
+                        + "over the vertical axis and each subsequent zoom level is calculated by half "
+                        + "the resolution of its previous one. Tiles are 512px wide.");
+        addInternal(WORLD_EPSG4326x2);
 
         final SRS googleMapsCompatibleSRS = useEPSG900913 ? SRS.getEPSG900913() : SRS.getEPSG3857();
         log.debug(
@@ -104,7 +136,6 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
                         256,
                         256,
                         false);
-
         WORLD_EPSG3857.setDescription(
                 "This well-known scale set has been defined to be compatible with Google Maps and"
                         + " Microsoft Live Map projections and zoom levels. Level 0 allows representing the whole "
@@ -112,6 +143,27 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
                         + "of 256x256 pixels and so on in powers of 2. Scale denominator is only accurate near the equator.");
 
         addInternal(WORLD_EPSG3857);
+
+        WORLD_EPSG3857x2 =
+                GridSetFactory.createGridSet(
+                        mercatorName + "x2",
+                        googleMapsCompatibleSRS,
+                        BoundingBox.WORLD3857,
+                        false,
+                        halveResolutions(commonPractice900913Resolutions()),
+                        null,
+                        1.0D,
+                        GridSetFactory.DEFAULT_PIXEL_SIZE_METER,
+                        null,
+                        512,
+                        512,
+                        false);
+        WORLD_EPSG3857x2.setDescription(
+                "This well-known scale set has been defined to be compatible with Google Maps and"
+                        + " Microsoft Live Map projections and zoom levels. Level 0 allows representing the whole "
+                        + "world in a single 512x512 pixels. The next level represents the whole world in 2x2 tiles "
+                        + "of 512x512 pixels and so on in powers of 2. Scale denominator is only accurate near the equator.");
+        addInternal(WORLD_EPSG3857x2);
 
         log.debug("Adding GlobalCRS84Pixel");
         GridSet GlobalCRS84Pixel =
@@ -182,6 +234,10 @@ public class DefaultGridsets extends SimpleGridSetConfiguration {
                         + " tiles of 256x256 pixels and so on in powers of 2. Scale denominator is only accurate near the equator.");
 
         addInternal(GoogleCRS84Quad);
+    }
+
+    private double[] halveResolutions(double[] resolutions) {
+        return Arrays.stream(resolutions).map(r -> r / 2).toArray();
     }
 
     @Override

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/DefaultGridSetsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/DefaultGridSetsTest.java
@@ -17,9 +17,11 @@ package org.geowebcache.grid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import org.geowebcache.config.DefaultGridsets;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 public class DefaultGridSetsTest {
@@ -85,5 +87,55 @@ public class DefaultGridSetsTest {
                 "Unexpected default mercator GridSet",
                 googleMapsCompatible,
                 defaultMercatorGridSet);
+    }
+
+    @Test
+    public void test4326x2() {
+        DefaultGridsets gs = new DefaultGridsets(true, true);
+        GridSet base = gs.worldEpsg4326();
+        GridSet x2 = gs.worldEpsg4326x2();
+
+        // description
+        assertThat(base.getDescription(), CoreMatchers.containsString("256"));
+        assertThat(x2.getDescription(), CoreMatchers.containsString("512"));
+
+        // tile sizes
+        assertEquals(256, base.getTileWidth());
+        assertEquals(256, base.getTileHeight());
+        assertEquals(512, x2.getTileWidth());
+        assertEquals(512, x2.getTileHeight());
+
+        // reference pixel size and scale denominators
+        for (int level = 0; level < base.getNumLevels(); level++) {
+            assertEquals(
+                    base.getGrid(level).getScaleDenominator(),
+                    x2.getGrid(level).getScaleDenominator() * 2,
+                    1e-6);
+        }
+    }
+
+    @Test
+    public void test3857x2() {
+        DefaultGridsets gs = new DefaultGridsets(true, true);
+        GridSet base = gs.worldEpsg3857();
+        GridSet x2 = gs.worldEpsg3857x2();
+
+        // description
+        assertThat(base.getDescription(), CoreMatchers.containsString("256x256"));
+        assertThat(x2.getDescription(), CoreMatchers.containsString("512x512"));
+
+        // tile sizes
+        assertEquals(256, base.getTileWidth());
+        assertEquals(256, base.getTileHeight());
+        assertEquals(512, x2.getTileWidth());
+        assertEquals(512, x2.getTileHeight());
+
+        // reference pixel size and scale denominators
+        for (int level = 0; level < base.getNumLevels(); level++) {
+            assertEquals(
+                    base.getGrid(level).getScaleDenominator(),
+                    x2.getGrid(level).getScaleDenominator() * 2,
+                    1e-6);
+        }
     }
 }

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
@@ -876,7 +876,7 @@ public class RestIntegrationTest {
 
             Document doc = getResponseEntityAsXML(response);
 
-            assertThat(doc, hasXPath("count(/gridSets/gridSet)", equalTo("7")));
+            assertThat(doc, hasXPath("count(/gridSets/gridSet)", equalTo("9")));
             assertThat(doc, hasXPath("/gridSets/gridSet[1]/name", equalTo("EPSG:2163")));
             assertThat(
                     doc,
@@ -898,7 +898,7 @@ public class RestIntegrationTest {
             assertEquals(200, response.getStatusLine().getStatusCode());
 
             JSONArray jsonArray = getResponseEntityAsJSONArray(response);
-            assertEquals(7, jsonArray.length());
+            assertEquals(9, jsonArray.length());
             assertEquals("EPSG:2163", jsonArray.get(0));
         }
     }


### PR DESCRIPTION
As hires screens and 512px tiles are getting common also outside of the "Apple kingdom", it's nice to have them as a default option for GWC and, as as consequence, for GeoServer as well.