### PR TITLE
#926: update jaiext to 1.1.20

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <gt.version>25-SNAPSHOT</gt.version>
     <jts.version>1.18.0</jts.version>
-    <jaiext.version>1.1.19</jaiext.version>
+    <jaiext.version>1.1.20</jaiext.version>
     <spring.version>5.1.20.RELEASE</spring.version>
     <spring.security.version>5.1.13.RELEASE</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>


### PR DESCRIPTION
Includes this fix: geosolutions-it/jai-ext#278
The fix is related to color encoding in paletted images

Requires both https://github.com/geotools/geotools/pull/3364 and https://github.com/geoserver/geoserver/pull/4772 to be merged first.