### PR TITLE
Avoid opening TCP port while migrating metastore

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
@@ -315,11 +315,7 @@ public class MetastoreRemover {
     private String getDefaultJDBCURL(File root) {
         String path = root.getPath() + File.separator + "meta_jdbc_h2";
         String jdbcString =
-                "jdbc:h2:file:"
-                        + path
-                        + File.separator
-                        + "gwc_metastore"
-                        + ";TRACE_LEVEL_FILE=0;AUTO_SERVER=TRUE";
+                "jdbc:h2:file:" + path + File.separator + "gwc_metastore" + ";TRACE_LEVEL_FILE=0";
         return jdbcString;
     }
 }


### PR DESCRIPTION
This change removes the automatic opening of a TCP port for the H2 database, which is not necessary to the task, and can break tests in GitHub actions. See also:
https://github.com/geotools/geotools/pull/3455

It's weird that it happens only in GeoTools builds (including downstreams checks), could not spot why TBH.