### PR TITLE
Upgrade imageio-ext to 1.3.6 (geotiff 32bit, deflate/lzw compressed, with predictor = 2) 1.19.x

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -68,7 +68,7 @@
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs></maven.test.jvmargs>
-    <imageio-ext.version>1.3.5</imageio-ext.version>
+    <imageio-ext.version>1.3.6</imageio-ext.version>
     <hazelcast.version>3.11-BETA-1</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
     <fmt.action>format</fmt.action>


### PR DESCRIPTION
Backport of https://github.com/GeoWebCache/geowebcache/pull/957 to 1.19.x