### PR TITLE
Use LevelID as ArcGIS cache gridset's name

### DIFF
--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
@@ -55,7 +55,7 @@ class GridSetBuilder {
          */
         final double[] scaleDenominators = null;
         final Double metersPerUnit;
-        final String[] scaleNames = null;
+        final String[] scaleNames;
         final int tileWidth = tileCacheInfo.getTileCols();
         final int tileHeight = tileCacheInfo.getTileRows();
         final boolean yCoordinateFirst = false;
@@ -71,6 +71,9 @@ class GridSetBuilder {
             resolutions = resAndScales[0];
 
             double[] scales = resAndScales[1];
+
+            scaleNames = getScaleNames(lodInfos);
+
             // TODO: check whether pixelSize computed above should be used instead
             metersPerUnit = (GridSetFactory.DEFAULT_PIXEL_SIZE_METER * scales[0]) / resolutions[0];
         }
@@ -126,13 +129,25 @@ class GridSetBuilder {
 
     private double[][] getResolutions(List<LODInfo> lodInfos) {
         final int numLevelsOfDetail = lodInfos.size();
-        double[][] resolutionsAndScales = new double[2][numLevelsOfDetail];
+        double[][] resolutionsAndScales = new double[3][numLevelsOfDetail];
         LODInfo lodInfo;
         for (int i = 0; i < numLevelsOfDetail; i++) {
             lodInfo = lodInfos.get(i);
             resolutionsAndScales[0][i] = lodInfo.getResolution();
             resolutionsAndScales[1][i] = lodInfo.getScale();
+            resolutionsAndScales[2][i] = lodInfo.getLevelID();
         }
         return resolutionsAndScales;
+    }
+
+    private String[] getScaleNames(List<LODInfo> lodInfos) {
+        final int numLevelsOfDetail = lodInfos.size();
+        String[] scaleNames = new String[numLevelsOfDetail];
+        LODInfo lodInfo;
+        for (int i = 0; i < numLevelsOfDetail; i++) {
+            lodInfo = lodInfos.get(i);
+            scaleNames[i] = String.valueOf(lodInfo.getLevelID());
+        }
+        return scaleNames;
     }
 }

--- a/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/layer/GridSetBuilderTest.java
+++ b/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/layer/GridSetBuilderTest.java
@@ -66,6 +66,7 @@ public class GridSetBuilderTest {
             LODInfo lodInfo = lodInfos.get(i);
             Assert.assertEquals(lodInfo.getResolution(), resolutions[i], 0d);
             Assert.assertEquals(lodInfo.getScale(), gridset.getGrid(i).getScaleDenominator(), 1e-6);
+            Assert.assertEquals(String.valueOf(lodInfo.getLevelID()), gridset.getGrid(i).getName());
         }
     }
 }


### PR DESCRIPTION
Arcgis cache layer extension does not assign any scale name to gridsets, so `GridSetFactory` make it as `gridsetName:i` , like `EPSG:4326_arcgis:0`. This patch use `levelID`, like `0`, `1`, `2` ..., as scaleName, and it is correspond with our practice in WMTS.