### PR TITLE
Use StandardCharsets when possible, add a PMD check to enforce it

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -14,6 +14,8 @@
  */
 package org.geowebcache.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomReader;
 import java.io.FileNotFoundException;
@@ -471,7 +473,7 @@ public class XMLConfiguration
         // create the XStream for serializing the configuration
         XStream xs = getConfiguredXStreamWithContext(new GeoWebCacheXStream(), Context.PERSIST);
 
-        try (OutputStreamWriter writer = new OutputStreamWriter(resourceProvider.out(), "UTF-8")) {
+        try (OutputStreamWriter writer = new OutputStreamWriter(resourceProvider.out(), UTF_8)) {
             // set version to latest
             String currentSchemaVersion = getCurrentSchemaVersion();
             getGwcConfig().setVersion(currentSchemaVersion);

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethodBase;
@@ -208,7 +209,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
                 } else if (responseMime != null
                         && responseMime.toLowerCase().startsWith("application/vnd.ogc.se_xml")) {
                     try (InputStream stream = method.getResponseBodyAsStream()) {
-                        message = IOUtils.toString(stream, "UTF-8");
+                        message = IOUtils.toString(stream, StandardCharsets.UTF_8);
                     } catch (IOException e) {
                         //
                     }

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
@@ -14,6 +14,7 @@
  */
 package org.geowebcache.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -251,6 +252,6 @@ public class XMLConfigurationBackwardsCompatibilityTest {
         tx.setOutputProperty(OutputKeys.INDENT, "yes");
 
         tx.transform(
-                new DOMSource(dom), new StreamResult(new OutputStreamWriter(System.out, "utf-8")));
+                new DOMSource(dom), new StreamResult(new OutputStreamWriter(System.out, UTF_8)));
     }
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
@@ -32,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -125,7 +126,7 @@ public class ConfigLoader {
 
         log.debug("Saving disk quota config to " + resourceProvider.getLocation());
         try (OutputStream configOut = resourceProvider.out()) {
-            xStream.toXML(config, new OutputStreamWriter(configOut, "UTF-8"));
+            xStream.toXML(config, new OutputStreamWriter(configOut, StandardCharsets.UTF_8));
         } catch (RuntimeException e) {
             log.error("Error saving DiskQuota config to file :" + resourceProvider.getLocation());
         }
@@ -257,7 +258,7 @@ public class ConfigLoader {
     private DiskQuotaConfig loadConfiguration(final InputStream configStream)
             throws XStreamException {
         XStream xstream = getConfiguredXStream(new GeoWebCacheXStream());
-        try (Reader reader = new InputStreamReader(configStream, "UTF-8")) {
+        try (Reader reader = new InputStreamReader(configStream, StandardCharsets.UTF_8)) {
             DiskQuotaConfig fromXML = loadConfiguration(reader, xstream);
             return fromXML;
         } catch (IOException e) {

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/GeoRSSTileRangeBuilderTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/GeoRSSTileRangeBuilderTest.java
@@ -14,6 +14,7 @@
  */
 package org.geowebcache.georss;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.geowebcache.georss.RasterMaskTestUtils.buildSampleFilterMatrix;
 
 import java.io.BufferedReader;
@@ -118,7 +119,7 @@ public class GeoRSSTileRangeBuilderTest {
             throws IOException, XMLStreamException, FactoryConfigurationError {
 
         try (InputStream stream = getClass().getResourceAsStream("test-data/" + fileName);
-                Reader feed = new BufferedReader(new InputStreamReader(stream, "UTF-8")); ) {
+                Reader feed = new BufferedReader(new InputStreamReader(stream, UTF_8)); ) {
             StaxGeoRSSReader reader = new StaxGeoRSSReader(feed);
             GeoRSSTileRangeBuilder b = new GeoRSSTileRangeBuilder(layer, gridsetId, 10);
             b.buildTileRangeMask(reader, null);

--- a/geowebcache/georss/src/test/java/org/geowebcache/georss/StaxGeoRSSReaderTest.java
+++ b/geowebcache/georss/src/test/java/org/geowebcache/georss/StaxGeoRSSReaderTest.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
@@ -110,6 +111,6 @@ public class StaxGeoRSSReaderTest {
         if (stream == null) {
             throw new FileNotFoundException("test-data/" + fileName);
         }
-        return new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+        return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 }

--- a/geowebcache/pmd-ruleset.xml
+++ b/geowebcache/pmd-ruleset.xml
@@ -33,6 +33,7 @@ GeoTools ruleset. See https://pmd.github.io/latest/pmd_userdocs_understanding_ru
   <rule ref="category/java/bestpractices.xml/UseTryWithResources" />
   <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" />
   <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" />
+  <rule ref="category/java/bestpractices.xml/UseStandardCharsets" />
   <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector" />
 
   <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/RestExceptionHandler.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/RestExceptionHandler.java
@@ -16,7 +16,7 @@ package org.geowebcache.rest.controller;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
@@ -44,6 +44,6 @@ public class RestExceptionHandler {
         LOGGER.log(Level.SEVERE, e.getMessage(), e);
         response.setStatus(e.getStatus().value());
         response.setContentType(MediaType.TEXT_PLAIN_VALUE);
-        StreamUtils.copy(e.getMessage(), Charset.forName("UTF-8"), os);
+        StreamUtils.copy(e.getMessage(), StandardCharsets.UTF_8, os);
     }
 }


### PR DESCRIPTION
Avoid using "magic string" when the JDK provides a constant. Follows with similar work applied to GT and GS.