### PR TITLE
Fix ServiceMetadataURL in cases where baseUrl contains query string parameters

### DIFF
--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -166,10 +166,16 @@ public class WMTSGetCapabilities {
             operationsMetadata(xml);
 
             contents(xml);
+            String kvpBaseUrl = baseUrl;
+            if (kvpBaseUrl.indexOf('?') == -1) {
+                kvpBaseUrl += "?";
+            } else {
+                kvpBaseUrl += "&";
+            }
             xml.indentElement("ServiceMetadataURL")
                     .attribute(
                             "xlink:href",
-                            baseUrl + "?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0")
+                            kvpBaseUrl + "SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0")
                     .endElement();
 
             xml.indentElement("ServiceMetadataURL")

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -166,16 +166,11 @@ public class WMTSGetCapabilities {
             operationsMetadata(xml);
 
             contents(xml);
-            String kvpBaseUrl = baseUrl;
-            if (kvpBaseUrl.indexOf('?') == -1) {
-                kvpBaseUrl += "?";
-            } else {
-                kvpBaseUrl += "&";
-            }
+            
             xml.indentElement("ServiceMetadataURL")
                     .attribute(
                             "xlink:href",
-                            kvpBaseUrl + "SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0")
+                            WMTSUtils.getKvpServiceMetadataURL(baseUrl))
                     .endElement();
 
             xml.indentElement("ServiceMetadataURL")

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -166,11 +166,9 @@ public class WMTSGetCapabilities {
             operationsMetadata(xml);
 
             contents(xml);
-            
+
             xml.indentElement("ServiceMetadataURL")
-                    .attribute(
-                            "xlink:href",
-                            WMTSUtils.getKvpServiceMetadataURL(baseUrl))
+                    .attribute("xlink:href", WMTSUtils.getKvpServiceMetadataURL(baseUrl))
                     .endElement();
 
             xml.indentElement("ServiceMetadataURL")

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
@@ -57,4 +57,24 @@ final class WMTSUtils {
         }
         return dimensions;
     }
+    
+    public static String getKvpServiceMetadataURL(String baseUrl) {
+    	String base = baseUrl;
+    	
+    	// Remove stray ? and &'s at the end of the URL
+    	int l = base.length();
+    	while (l > 0 && (base.charAt(l-1) == '?' || base.charAt(l-1) == '&')) {
+    		base = base.substring(0, l-1);
+    		l--;
+    	}
+    	
+    	// Append the correct delimiter
+        if (base.indexOf('?') == -1) {
+            base += "?";
+        } else {
+            base += "&";
+        }
+
+        return base + "SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0";
+    }
 }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
@@ -60,6 +60,13 @@ final class WMTSUtils {
     
     public static String getKvpServiceMetadataURL(String baseUrl) {
     	String base = baseUrl;
+    	String anchor = "";
+    	
+    	// Split anchor
+    	if (base.indexOf('#') != -1) {
+    		anchor = base.substring(base.indexOf('#'));
+    		base = base.substring(0, base.indexOf('#'));
+    	}
     	
     	// Remove stray ? and &'s at the end of the URL
     	int l = base.length();
@@ -75,6 +82,6 @@ final class WMTSUtils {
             base += "&";
         }
 
-        return base + "SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0";
+        return base + "SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0" + anchor;
     }
 }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
@@ -57,25 +57,25 @@ final class WMTSUtils {
         }
         return dimensions;
     }
-    
+
     public static String getKvpServiceMetadataURL(String baseUrl) {
-    	String base = baseUrl;
-    	String anchor = "";
-    	
-    	// Split anchor
-    	if (base.indexOf('#') != -1) {
-    		anchor = base.substring(base.indexOf('#'));
-    		base = base.substring(0, base.indexOf('#'));
-    	}
-    	
-    	// Remove stray ? and &'s at the end of the URL
-    	int l = base.length();
-    	while (l > 0 && (base.charAt(l-1) == '?' || base.charAt(l-1) == '&')) {
-    		base = base.substring(0, l-1);
-    		l--;
-    	}
-    	
-    	// Append the correct delimiter
+        String base = baseUrl;
+        String anchor = "";
+
+        // Split anchor
+        if (base.indexOf('#') != -1) {
+            anchor = base.substring(base.indexOf('#'));
+            base = base.substring(0, base.indexOf('#'));
+        }
+
+        // Remove stray ? and &'s at the end of the URL
+        int l = base.length();
+        while (l > 0 && (base.charAt(l - 1) == '?' || base.charAt(l - 1) == '&')) {
+            base = base.substring(0, l - 1);
+            l--;
+        }
+
+        // Append the correct delimiter
         if (base.indexOf('?') == -1) {
             base += "?";
         } else {

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
@@ -1,0 +1,48 @@
+package org.geowebcache.service.wmts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class WMTSUtilsTest {
+
+	 @Test
+	 public void testKvpServiceMetadataURLNoParameters() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/"); 
+		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+	 
+	 @Test
+	 public void testKvpServiceMetadataURLNoParameters_questionMark() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?"); 
+		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+
+
+	 @Test
+	 public void testKvpServiceMetadataURLSingleParameter() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo"); 
+		assertEquals("https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+
+	 @Test
+	 public void testKvpServiceMetadataURLSingleParameter_ampersand() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&"); 
+		assertEquals("https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+
+
+	 @Test
+	 public void testKvpServiceMetadataURLMultipleParameters() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa"); 
+		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+
+	 @Test
+	 public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&"); 
+		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+	 }
+
+
+}

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
@@ -6,56 +6,68 @@ import org.junit.Test;
 
 public class WMTSUtilsTest {
 
-	 @Test
-	 public void testKvpServiceMetadataURLNoParameters() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/"); 
-		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
-	 
+    @Test
+    public void testKvpServiceMetadataURLNoParameters() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/");
+        assertEquals(
+                "https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+    }
 
-	 @Test
-	 public void testKvpServiceMetadataURLNoParametersWithAnchor() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/#anchor"); 
-		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#anchor", result);
-	 }
-	 
-	 
-	 @Test
-	 public void testKvpServiceMetadataURLNoParameters_questionMark() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?"); 
-		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
+    @Test
+    public void testKvpServiceMetadataURLNoParametersWithAnchor() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/#anchor");
+        assertEquals(
+                "https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#anchor",
+                result);
+    }
 
+    @Test
+    public void testKvpServiceMetadataURLNoParameters_questionMark() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?");
+        assertEquals(
+                "https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
+    }
 
-	 @Test
-	 public void testKvpServiceMetadataURLSingleParameter() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo"); 
-		assertEquals("https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
+    @Test
+    public void testKvpServiceMetadataURLSingleParameter() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo");
+        assertEquals(
+                "https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0",
+                result);
+    }
 
-	 @Test
-	 public void testKvpServiceMetadataURLSingleParameter_ampersand() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&"); 
-		assertEquals("https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
+    @Test
+    public void testKvpServiceMetadataURLSingleParameter_ampersand() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&");
+        assertEquals(
+                "https://www.foo.com/?bar=doo&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0",
+                result);
+    }
 
+    @Test
+    public void testKvpServiceMetadataURLMultipleParameters() throws Exception {
+        String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa");
+        assertEquals(
+                "https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0",
+                result);
+    }
 
-	 @Test
-	 public void testKvpServiceMetadataURLMultipleParameters() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa"); 
-		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
+    @Test
+    public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands() throws Exception {
+        String result =
+                WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&");
+        assertEquals(
+                "https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0",
+                result);
+    }
 
-	 @Test
-	 public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&"); 
-		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
-	 }
-
-	 @Test
-	 public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands_withAnchor() throws Exception {
-		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&#hello"); 
-		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#hello", result);
-	 }
-
+    @Test
+    public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands_withAnchor()
+            throws Exception {
+        String result =
+                WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&#hello");
+        assertEquals(
+                "https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#hello",
+                result);
+    }
 }

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSUtilsTest.java
@@ -12,6 +12,14 @@ public class WMTSUtilsTest {
 		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
 	 }
 	 
+
+	 @Test
+	 public void testKvpServiceMetadataURLNoParametersWithAnchor() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/#anchor"); 
+		assertEquals("https://www.foo.com/?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#anchor", result);
+	 }
+	 
+	 
 	 @Test
 	 public void testKvpServiceMetadataURLNoParameters_questionMark() throws Exception {
 		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?"); 
@@ -44,5 +52,10 @@ public class WMTSUtilsTest {
 		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0", result);
 	 }
 
+	 @Test
+	 public void testKvpServiceMetadataURLMultipleParameters_manyAmpersands_withAnchor() throws Exception {
+		String result = WMTSUtils.getKvpServiceMetadataURL("https://www.foo.com/?bar=doo&dii=daa&&&#hello"); 
+		assertEquals("https://www.foo.com/?bar=doo&dii=daa&SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0#hello", result);
+	 }
 
 }


### PR DESCRIPTION
Geowebcache may be used in situations where the baseUrl contains query string parameters. One such case is in GeoServer when using the authkey community extension. This fix appends a `?` only when no `?` appears in the baseUrl and an `&` in other cases.