### PR TITLE
Update JAI-EXT to 1.1.21

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <gt.version>27-SNAPSHOT</gt.version>
     <jts.version>1.18.2</jts.version>
-    <jaiext.version>1.1.20</jaiext.version>
+    <jaiext.version>1.1.21</jaiext.version>
     <spring.version>5.1.20.RELEASE</spring.version>
     <spring.security.version>5.1.13.RELEASE</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>


### PR DESCRIPTION
Updates to latest JAI-EXT, follows up with https://github.com/geotools/geotools/pull/3650