### PR TITLE
Remove duplicate env variable lookup code, always use GWCVars

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheExtensions.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheExtensions.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.config.BaseConfiguration;
+import org.geowebcache.util.GWCVars;
 import org.geowebcache.util.SuppressFBWarnings;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -347,13 +348,10 @@ public class GeoWebCacheExtensions implements ApplicationContextAware, Applicati
      * @param propertyName The property name to be searched
      * @param context The Spring context (may be null)
      * @return The property value, or null if not found
+     * @see GWCVars#findEnvVar(ApplicationContext, String)
      */
     public static String getProperty(String propertyName, ApplicationContext context) {
-        if (context instanceof WebApplicationContext) {
-            return getProperty(propertyName, ((WebApplicationContext) context).getServletContext());
-        } else {
-            return getProperty(propertyName, (ServletContext) null);
-        }
+        return GWCVars.findEnvVar(context, propertyName);
     }
 
     /**
@@ -370,7 +368,9 @@ public class GeoWebCacheExtensions implements ApplicationContextAware, Applicati
      * @param propertyName The property name to be searched
      * @param context The servlet context used to look into web.xml (may be null)
      * @return The property value, or null if not found
+     * @deprecated since 1.21, use {@link GWCVars#findEnvVar(ApplicationContext, String)} instead
      */
+    @Deprecated
     public static String getProperty(String propertyName, ServletContext context) {
         // TODO: this code comes from the data directory lookup and it's useful as
         // long as we don't provide a way for the user to manually inspect the three contexts

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageFinder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageFinder.java
@@ -15,12 +15,13 @@
 package org.geowebcache.storage;
 
 import java.io.File;
-import javax.servlet.ServletContext;
+import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.geowebcache.util.GWCVars;
+import org.geowebcache.util.GWCVars.Variable;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -81,37 +82,17 @@ public class DefaultStorageFinder {
      * C) System environment variable<br>
      */
     private void determineDefaultPrefix() {
-        ServletContext serlvCtx = context.getServletContext();
-
-        final String[] typeStrs = {
-            "Java environment variable ",
-            "Servlet context parameter ",
-            "System environment variable "
-        };
-
         final String[] varStrs = {GWC_CACHE_DIR, GS_DATA_DIR, "TEMP", "TMP"};
 
         String msgPrefix = null;
         int iVar = 0;
         for (int i = 0; i < varStrs.length && defaultPrefix == null; i++) {
-            for (int j = 0; j < typeStrs.length && defaultPrefix == null; j++) {
-                String value = null;
-                String varStr = varStrs[i];
-                String typeStr = typeStrs[j];
-
-                switch (j) {
-                    case 0:
-                        value = System.getProperty(varStr);
-                        break;
-                    case 1:
-                        value = serlvCtx.getInitParameter(varStr);
-                        break;
-                    case 2:
-                        value = System.getenv(varStr);
-                        break;
-                }
-
-                if (value == null || value.equalsIgnoreCase("")) {
+            String varStr = varStrs[i];
+            List<Variable> found = GWCVars.findVariable(context, varStr);
+            for (Variable v : found) {
+                String typeStr = v.getType().getSource();
+                String value = v.getValue();
+                if (value == null || value.isEmpty()) {
                     if (log.isDebugEnabled()) {
                         log.debug(typeStr + varStr + " is unset");
                     }

--- a/geowebcache/core/src/main/java/org/geowebcache/util/GWCVars.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/GWCVars.java
@@ -14,10 +14,14 @@
  */
 package org.geowebcache.util;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.geowebcache.storage.DefaultStorageFinder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -35,46 +39,127 @@ public class GWCVars {
 
     public static final int CACHE_USE_WMS_BACKEND_VALUE = -4;
 
-    public static String findEnvVar(ApplicationContext context, String varStr) {
-        ServletContext serlvCtx = null;
-        if (context instanceof WebApplicationContext) {
-            serlvCtx = ((WebApplicationContext) context).getServletContext();
-        }
-
-        final String[] typeStrs = {
-            "Java environment variable ",
-            "servlet context parameter ",
-            "system environment variable "
+    /**
+     * enum containing and describing the possible sources of lookup for "environment variables", in
+     * order of precedence.
+     */
+    public static enum VariableType {
+        ENV("Java system property") {
+            protected @Override String apply(ApplicationContext context, String varName) {
+                return System.getProperty(varName);
+            }
+        },
+        SERVLET("servlet context parameter") {
+            protected @Override String apply(ApplicationContext context, String varName) {
+                if (context instanceof WebApplicationContext) {
+                    ServletContext servletContext =
+                            ((WebApplicationContext) context).getServletContext();
+                    return servletContext == null ? null : servletContext.getInitParameter(varName);
+                }
+                return null;
+            }
+        },
+        SYSTEM("system environment variable") {
+            protected @Override String apply(ApplicationContext context, String varName) {
+                return System.getenv(varName);
+            }
         };
 
-        String value = null;
+        private final String source;
 
-        for (int j = 0; j < typeStrs.length && value == null; j++) {
-            String typeStr = typeStrs[j];
-
-            switch (j) {
-                case 0:
-                    value = System.getProperty(varStr);
-                    break;
-                case 1:
-                    if (serlvCtx != null) {
-                        value = serlvCtx.getInitParameter(varStr);
-                    }
-                    break;
-                case 2:
-                    value = System.getenv(varStr);
-                    break;
-            }
-
-            if (value != null) {
-                if (varStr.equals(DefaultStorageFinder.GWC_METASTORE_PASSWORD)) {
-                    log.info("Found " + typeStr + " for " + varStr + " set to <hidden>");
-                } else {
-                    log.info("Found " + typeStr + " for " + varStr + " set to " + value);
-                }
-            }
+        private VariableType(String source) {
+            this.source = source;
         }
 
-        return value;
+        public String getSource() {
+            return source;
+        }
+
+        protected abstract String apply(ApplicationContext context, String varName);
+
+        /**
+         * @return a non-null {@literal Variable} with the evaluated value for the given variable
+         *     name, possibly {@literal null}.
+         */
+        Variable get(ApplicationContext context, String varName) {
+            return Variable.ofNullable(this, varName, this.apply(context, varName));
+        }
+    }
+
+    /**
+     * Type holder for the result of a variable lookup of a given
+     * {@link VariableType}. The {@link #getValue() value) may be {@literal null}.
+     */
+    public static class Variable {
+        private final VariableType type;
+        private final String name;
+        private final String value;
+
+        private Variable(VariableType type, String name, String value) {
+            this.type = type;
+            this.name = name;
+            this.value = value;
+        }
+
+        public VariableType getType() {
+            return type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        static Variable ofNullable(VariableType type, String name, String nullableValue) {
+            Objects.requireNonNull(type);
+            Objects.requireNonNull(name);
+            return new Variable(type, name, nullableValue);
+        }
+    }
+
+    /**
+     * The first non-null value for the given variable name in the order of lookup precedence
+     * defined by {@link VariableType} (that is, Java system property -> servlet context parameter
+     * -> system environment variable)
+     */
+    public static String findEnvVar(ApplicationContext context, String varStr) {
+        return lookup(context, varStr)
+                .map(GWCVars::log)
+                .filter(GWCVars::nonNullValue)
+                .findFirst()
+                .map(Variable::getValue)
+                .orElse(null);
+    }
+
+    /**
+     * @return all the results of a given variable look up in order of precedence, without filtering
+     *     for null (i.e. not set) values
+     */
+    public static List<Variable> findVariable(ApplicationContext context, String varName) {
+        return lookup(context, varName).collect(Collectors.toList());
+    }
+
+    private static Stream<Variable> lookup(ApplicationContext context, String varName) {
+
+        return Arrays.stream(VariableType.values()).map(t -> t.get(context, varName));
+    }
+
+    private static boolean nonNullValue(Variable v) {
+        return v.getValue() == null ? false : true;
+    }
+
+    private static Variable log(Variable v) {
+        String value = v.getValue();
+        String source = v.getType().getSource();
+        String name = v.getName();
+        if (value == null && log.isTraceEnabled()) {
+            log.info("Not found " + source + " for " + name);
+        } else if (value != null && log.isInfoEnabled()) {
+            log.info("Found " + source + " for " + name + " set to " + value);
+        }
+        return v;
     }
 }


### PR DESCRIPTION
Variable lookups using system-property/servlet-context/system-environment
precedence was being performed at several places with slightly different
logic (checking for nulls or not).

Use GWCVars as the single utility to perform variable lookups.

Deprecate `GeoWebCacheExtensions.getProperty(String, ServletContext)`  in favor of `GWCVars.findEnvVar(ApplicationContext, String)`.