### PR TITLE
Fix bad operation check in DELETE_LAYER from Memory Blobstore

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/memory/MemoryBlobStore.java
@@ -732,7 +732,7 @@ public class MemoryBlobStore implements BlobStore, ApplicationContextAware {
             @Override
             public boolean executeOperation(BlobStore store, Object... objs)
                     throws StorageException {
-                if (objs == null || objs.length < 2 || !(objs[0] instanceof String)) {
+                if (objs == null || objs.length < 1 || !(objs[0] instanceof String)) {
                     return false;
                 }
                 return store.delete((String) objs[0]);


### PR DESCRIPTION
The object length check in DELETE_LAYER operation from MemoryBlobStore has to be set to 1 instead of 2 as the object will be always the layername. 
Currently it will never delete the layer from the blobstore