### PR TITLE
Upgrade GWC to a log4j version that does not support RCE 

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -61,7 +61,7 @@
     <httpcomponents.version>4.5.13</httpcomponents.version>
     <guava.version>27.0-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>
-    <log4j.version>1.2.14</log4j.version>
+    <log4j.version>1.2.17.norce</log4j.version>
     <h2.version>1.1.119</h2.version>
     <postgresql.version>42.2.14</postgresql.version>
     <oracle.version></oracle.version>


### PR DESCRIPTION
All network related appenders have been removed, as well as server socket related classes, see:
https://github.com/aaime/log4j/tree/1.2.17.x