### PR TITLE
Improve disk quota startup time on caches with thousands of parameter directories

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,12 +36,11 @@ jobs:
         git clone https://github.com/geoserver/geoserver.git geoserver
     - name: Build GeoServer with tests
       run: |
-        export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
-        export MAVEN_OPTS="-Xmx256m $TEST_OPTS"
+        export MAVEN_OPTS="-Xmx512m $TEST_OPTS -XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
         cd ~
         mvn -B -f geoserver/src/pom.xml install -nsu -Prelease -Dfmt.skip=true -DskipTests
         mvn -B -f geoserver/src/community/pom.xml install -nsu -DcommunityRelease -Dfmt.skip=true -DskipTests
-        mvn -B -f geoserver/src/pom.xml test -T2 -nsu -Dtest.maxHeapSize=512m -Djvm.opts="$TEST_OPTS" -Prelease -Dfmt.skip=true
+        mvn -B -f geoserver/src/pom.xml test -T2 -nsu -Djvm.opts="$TEST_OPTS" -Prelease -Dfmt.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {} 

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
@@ -53,7 +53,7 @@ final class LayerCacheInfoBuilder {
 
     private final ExecutorService threadPool;
 
-    private final Map<String, List<Future<ZoomLevelVisitor.Stats>>> perLayerRunningTasks;
+    private final Map<String, List<Future<?>>> perLayerRunningTasks;
 
     private final QuotaUpdatesMonitor quotaUsageMonitor;
 
@@ -73,15 +73,8 @@ final class LayerCacheInfoBuilder {
      * Asynchronously collects cache usage information for the given {@code tileLayer} into the
      * given {@code layerQuota} by using the provided {@link ExecutorService} at construction time.
      *
-     * <p>This method discards any {@link LayerQuota#getUsedQuota() used quota} information
-     * available for {@code layerQuota} and updates it by collecting the usage information for the
-     * layer.
-     *
-     * <p>In addition to collecting the cache usage information for the layer, the {@code
-     * layerQuota}'s {@link ExpirationPolicy expiration policy} will be given the opportunity to
-     * gather any additional information by calling the {@link
-     * ExpirationPolicy#createInfoFor(LayerQuota, String, long[], File) createInforFor(layerQuota,
-     * gridSetId, tileXYZ, file)} method for each available tile on the layer's cache.
+     * <p>This method discards any {@link LayerQuota#getQuota()} used quota} information available
+     * for {@code layerQuota} and updates it by collecting the usage information for the layer.
      *
      * <p>Note the cache information gathering is performed asynchronously and hence this method
      * returns immediately. To check whether the information collect for a given layer has finished
@@ -100,6 +93,16 @@ final class LayerCacheInfoBuilder {
 
         perLayerRunningTasks.put(layerName, new ArrayList<>());
 
+        // gathering the on disk tilesets can take a very long time, in case there are
+        // many parameters (e.g., long list of times), so moving this task also on background exec
+        Future<?> tilesetCollector =
+                threadPool.submit(() -> gatherStatsByTileset(tileLayer, layerName, layerDir));
+        // make sure the list has at this task too, so early calls to #isRunning find
+        // that something is executing, even if the stats collectors have not been created yet
+        perLayerRunningTasks.get(layerName).add(tilesetCollector);
+    }
+
+    private void gatherStatsByTileset(TileLayer tileLayer, String layerName, File layerDir) {
         final Set<TileSet> onDiskTileSets = findOnDiskTileSets(tileLayer, layerDir);
 
         for (TileSet tileSet : onDiskTileSets) {
@@ -314,15 +317,14 @@ final class LayerCacheInfoBuilder {
      */
     public boolean isRunning(String layerName) {
         try {
-            List<Future<ZoomLevelVisitor.Stats>> layerTasks = perLayerRunningTasks.get(layerName);
+            List<Future<?>> layerTasks = perLayerRunningTasks.get(layerName);
             if (layerTasks == null) {
                 return false;
             }
 
             int numRunning = 0;
-            Future<ZoomLevelVisitor.Stats> future;
-            for (Iterator<Future<ZoomLevelVisitor.Stats>> it = layerTasks.iterator();
-                    it.hasNext(); ) {
+            Future<?> future;
+            for (Iterator<Future<?>> it = layerTasks.iterator(); it.hasNext(); ) {
                 future = it.next();
                 if (future.isDone()) {
                     it.remove();

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -61,7 +61,7 @@
     <httpcomponents.version>4.5.13</httpcomponents.version>
     <guava.version>27.0-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>
-    <log4j.version>1.2.14</log4j.version>
+    <log4j.version>1.2.17.norce</log4j.version>
     <h2.version>1.1.119</h2.version>
     <postgresql.version>42.2.14</postgresql.version>
     <oracle.version></oracle.version>


### PR DESCRIPTION
When trying to create a disk quota database anew, or starting up with a database out of synch with the file system, the disk quota tries to collect stats from disk.
It mostly works using background tasks, but first it has to list all available tile caches for each layer (one for each combo of request parameters, if any). In case there are many of them (e.g., long time series, cached) this can take a lot of time, breaking the promise that ``LayerCacheInfoBuilder.buildCacheInfo`` "returns immediately". We have actually observed the quota startup stuck for ages, to the point that it looked stuck, while it was actually listing directories (many layers, all time enabled, many times).

This change moves the directory collection part to the background, actually allowing the ``buildCacheInfo`` method to return immediately.



