### PR TITLE
Improvements, async delete, upload interrupt support for Swift blobstores

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -87,7 +87,7 @@
     <qa>false</qa>
     <lint>deprecation,unchecked</lint>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jclouds.version>2.2.0</jclouds.version>
+    <jclouds.version>2.3.0</jclouds.version>
     <mockito.version>3.8.0</mockito.version>
   </properties>
 

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/IBlobStoreListenerNotifier.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/IBlobStoreListenerNotifier.java
@@ -1,0 +1,19 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthew Northcott, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+interface IBlobStoreListenerNotifier {
+    void notifyListeners();
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreInfo.java
@@ -17,6 +17,8 @@ package org.geowebcache.swift;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -45,19 +47,19 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
 
     private static final long serialVersionUID = 9072751143836460389L;
 
+    private static final String provider = "openstack-swift";
+
+    private static final String keystoneDomainName = "Default";
+
     private String container;
 
     private String prefix;
-
-    private String provider;
 
     private String region;
 
     private String keystoneVersion;
 
     private String keystoneScope;
-
-    private String keystoneDomainName;
 
     private String identity;
 
@@ -129,14 +131,10 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
         overrides.put(Constants.PROPERTY_MAX_CONNECTIONS_PER_CONTEXT, 32);
         overrides.put(Constants.PROPERTY_MAX_RETRIES, 0);
 
-        String provider = this.provider;
-        String identity = this.identity;
-        String credential = this.password;
-
         SwiftApi context =
                 ContextBuilder.newBuilder(provider)
                         .endpoint(endpoint)
-                        .credentials(identity, credential)
+                        .credentials(identity, password)
                         .overrides(overrides)
                         .buildApi(SwiftApi.class);
 
@@ -158,14 +156,10 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
         overrides.put(KeystoneProperties.SCOPE, keystoneScope);
         overrides.put(KeystoneProperties.PROJECT_DOMAIN_NAME, keystoneDomainName);
 
-        String provider = this.provider;
-        String identity = this.identity;
-        String credential = this.password;
-
         ContextBuilder builder =
                 ContextBuilder.newBuilder(provider)
                         .endpoint(endpoint)
-                        .credentials(identity, credential)
+                        .credentials(identity, password)
                         .overrides(overrides);
 
         return builder.build(RegionScopedBlobStoreContext.class);
@@ -180,5 +174,21 @@ public class SwiftBlobStoreInfo extends BlobStoreInfo {
         } else {
             return String.format("bucket: %s prefix: %s", bucket, prefix);
         }
+    }
+
+    public boolean isValid() {
+        final List<String> fields =
+                Arrays.asList(
+                        new String[] {
+                            endpoint,
+                            identity,
+                            password,
+                            region,
+                            container,
+                            keystoneVersion,
+                            keystoneScope
+                        });
+
+        return !(fields.contains(null) || fields.contains(""));
     }
 }

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftDeleteTask.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftDeleteTask.java
@@ -1,0 +1,81 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthew Northcott, Catalyst IT Ltd NZ, Copyright 2020
+ */
+package org.geowebcache.swift;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedSwiftBlobStore;
+
+class SwiftDeleteTask implements Runnable {
+    static final Log log = LogFactory.getLog(SwiftDeleteTask.class);
+    static final String logStr = "%s, %s, %dms";
+
+    private static final int RETRIES = 5;
+
+    private final RegionScopedSwiftBlobStore blobStore;
+    private final String path;
+    private final String container;
+    private final IBlobStoreListenerNotifier notifier;
+
+    SwiftDeleteTask(
+            RegionScopedSwiftBlobStore blobStore,
+            String path,
+            String container,
+            IBlobStoreListenerNotifier notifier) {
+        this.blobStore = blobStore;
+        this.path = path;
+        this.container = container;
+        this.notifier = notifier;
+    }
+
+    @Override
+    public void run() {
+        final ListContainerOptions options = new ListContainerOptions().prefix(path).recursive();
+
+        int delayMs = 1000;
+        boolean deleted = false;
+
+        // Attempt to delete path and increase timeout exponentially with each consective failure
+        for (int retry = 0; retry < RETRIES && !deleted; retry++) {
+            blobStore.clearContainer(container, options);
+
+            // Wait before checking if deletion was successful
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                log.debug(e.getMessage());
+            }
+            delayMs *= 2; // Exponential backoff
+
+            // NOTE: this is messy but it seems to work.
+            // there might be a more effecient way of doing this.
+            deleted = blobStore.list(container, options).isEmpty();
+        }
+
+        if (deleted) {
+            log.info(String.format("Deleted Swift tile cache at %s/%s", container, path));
+
+            if (notifier != null) {
+                notifier.notifyListeners();
+            }
+        } else {
+            log.error(
+                    String.format(
+                            "Failed to delete Swift tile cache at %s/%s after %d retries.",
+                            container, path, RETRIES));
+        }
+    }
+}

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftUploadTask.java
@@ -25,7 +25,7 @@ import org.jclouds.io.Payload;
 import org.jclouds.openstack.swift.v1.domain.SwiftObject;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 
-public class SwiftUploadTask implements Runnable {
+class SwiftUploadTask implements Runnable {
     static final Log log = LogFactory.getLog(SwiftUploadTask.class);
     static final String logStr = "%s, %s, %dms";
 
@@ -34,7 +34,7 @@ public class SwiftUploadTask implements Runnable {
     private final ObjectApi objectApi;
     private final BlobStoreListenerList listeners;
 
-    public SwiftUploadTask(
+    SwiftUploadTask(
             String key, SwiftTile tile, BlobStoreListenerList listeners, ObjectApi objectApi) {
         this.key = key;
         this.tile = tile;
@@ -70,6 +70,11 @@ public class SwiftUploadTask implements Runnable {
         }
     }
 
+    public String getKey() {
+        return key;
+    }
+
+    @Override
     public void run() {
         log.debug("Processing " + key);
 
@@ -92,8 +97,7 @@ public class SwiftUploadTask implements Runnable {
             }
             tile.notifyListeners(listeners);
         } catch (HttpResponseException e) {
-            log.warn(e.getMessage());
-            throw e;
+            log.warn(String.format("Swift tile upload failed: %s", e.getMessage()));
         } catch (IOException e) {
             // pass
         }


### PR DESCRIPTION
This PR introduces a number of fixes/improvements, asynchronous tile deletion, and upload interrupt support for Swift blobstores.

Change summary:
* jclouds update to 2.3.0
* Adapt existing upload queue to serve as a more generic task queue
* Queue tile deletions as tasks to the task queue when tile caching is disabled for a layer
* Interrupt and cancel any existing upload tasks when tile caching is disabled for the associated layer
* General code improvements
* Additional tests to cover changes