### PR TITLE
Remove stax:stax and stax:stax-api dependencies, they're part of the default Java library

### DIFF
--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -32,15 +32,6 @@
       <version>${gt.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>stax</groupId>
-      <artifactId>stax-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>stax</groupId>
-      <artifactId>stax</artifactId>
-    </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -373,19 +373,6 @@
       </dependency>
 
       <dependency>
-        <groupId>stax</groupId>
-        <artifactId>stax-api</artifactId>
-        <version>1.0.1</version>
-      </dependency>
-
-      <dependency>
-        <!-- StAX is the reference implementation of the StAX API -->
-        <groupId>stax</groupId>
-        <artifactId>stax</artifactId>
-        <version>1.2.0</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>


### PR DESCRIPTION
The StAX API is part of the JRE default library since Java 1.6.