### PR TITLE
WMS full does not correctly rescale when requested resolution is between tile values

### DIFF
--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/BufferedImageWrapper.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/BufferedImageWrapper.java
@@ -69,6 +69,10 @@ class BufferedImageWrapper {
         return canvas;
     }
 
+    public void updateCanvas(BufferedImage canvas) {
+        this.canvas = canvas;
+    }
+
     public Graphics2D getGraphics() {
         if (gfx == null) {
             gfx = (Graphics2D) getCanvas().getGraphics();

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -702,9 +702,9 @@ public class WMSTileFuser {
                 || canvasSize[1] != reqHeight) {
             BufferedImage preTransform = bufferedImageWrapper.getCanvas();
 
-            BufferedImage canvas = new BufferedImage(reqWidth, reqHeight, preTransform.getType());
+            BufferedImage rescaled = new BufferedImage(reqWidth, reqHeight, preTransform.getType());
 
-            Graphics2D gfx = canvas.createGraphics();
+            Graphics2D gfx = rescaled.createGraphics();
 
             AffineTransform affineTrans =
                     AffineTransform.getScaleInstance(
@@ -725,6 +725,10 @@ public class WMSTileFuser {
             gfx.addRenderingHints(hintsTemp);
             gfx.drawRenderedImage(preTransform, affineTrans);
             gfx.dispose();
+
+            // replace the preview image with the scaled down version
+            // (otherwise the write part will use the image at tile resolution)
+            bufferedImageWrapper.updateCanvas(rescaled);
         }
     }
 

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.DefaultGridsets;
@@ -364,7 +367,13 @@ public class WMSTileFuserTest {
                 tileFuser.writeResponse(
                         response, new RuntimeStats(1, Arrays.asList(1), Arrays.asList("desc")));
 
-                assertTrue(response.getContentAsString().length() > 0);
+                // check the result is a valid PNG
+                assertEquals("image/png", response.getContentType());
+                BufferedImage image =
+                        ImageIO.read(new ByteArrayInputStream(response.getContentAsByteArray()));
+                // and it's the expected size
+                assertEquals(width, image.getWidth());
+                assertEquals(height, image.getHeight());
             }
         } finally {
             temp.delete();


### PR DESCRIPTION
The rescale is performed, but the result is thrown away.