### PR TITLE
Review startup warning, info and config logging levels

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -146,7 +146,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
             this.servletPrefix = servletPrefix;
         }
 
-        LOG.info("Invoked setServletPrefix(" + servletPrefix + ")");
+        LOG.config("Invoked setServletPrefix(" + servletPrefix + ")");
     }
     /**
      * GeoServer and other solutions that embedded this dispatcher will prepend a path, this is used
@@ -348,7 +348,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
      * destroy="destroy">...</bean>
      */
     public void destroy() {
-        LOG.info("GeoWebCacheDispatcher.destroy() was invoked, shutting down.");
+        LOG.fine("GeoWebCacheDispatcher.destroy() was invoked, shutting down.");
     }
 
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -26,7 +26,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -759,15 +758,9 @@ public class XMLConfiguration
                 validate(rootNode);
                 log.config("TileLayerConfiguration file validated fine.");
             } catch (SAXException e) {
-                String msg = "*** GWC configuration validation error: " + e.getMessage();
-                char[] c = new char[4 + msg.length()];
-                Arrays.fill(c, '*');
-                String warndecoration = new String(c).substring(0, 80);
-                log.warning(warndecoration);
-                log.warning(msg);
+                log.warning("GWC configuration validation error: " + e.getMessage());
                 log.warning(
-                        "*** Will try to use configuration anyway. Please check the order of declared elements against the schema.");
-                log.warning(warndecoration);
+                        "Will try to use configuration anyway. Please check the order of declared elements against the schema.");
             } catch (IOException e) {
                 throw new RuntimeException(e.getMessage(), e);
             }

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
@@ -203,7 +203,7 @@ public class BlobStoreAggregator {
         int blobStoreCount = config.getBlobStoreCount();
 
         if (blobStoreCount <= 0) {
-            log.info(
+            log.config(
                     "BlobStoreConfiguration "
                             + config.getIdentifier()
                             + " contained no blob store infos.");

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageBroker.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageBroker.java
@@ -87,7 +87,7 @@ public class DefaultStorageBroker implements StorageBroker {
     }
 
     public void destroy() {
-        log.info("Destroying StorageBroker");
+        log.fine("Destroying StorageBroker");
     }
 
     public String getLayerMetadata(final String layerName, final String key) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageFinder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/DefaultStorageFinder.java
@@ -130,9 +130,9 @@ public class DefaultStorageFinder {
             if (tmpDir != null) {
                 File temp = new File(tmpDir, "geowebcache");
                 logMsg =
-                        "Reverting to java.io.tmpdir "
-                                + this.defaultPrefix
-                                + " for storage. "
+                        "Reverting to java.io.tmpdir '"
+                                + temp.getAbsolutePath()
+                                + "' for storage. "
                                 + "Please set "
                                 + GWC_CACHE_DIR
                                 + ".";
@@ -159,15 +159,6 @@ public class DefaultStorageFinder {
 
             logMsg = msgPrefix + ", using it as the default prefix.";
         }
-
-        String warnStr = "*** " + logMsg + " ***";
-        StringBuilder stars = new StringBuilder();
-        for (int i = 0; i < warnStr.length(); i++) {
-            stars.append("*");
-        }
-
-        log.info(stars.toString());
-        log.info(warnStr);
-        log.info(stars.toString());
+        log.config(logMsg);
     }
 }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaMonitor.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/DiskQuotaMonitor.java
@@ -277,7 +277,7 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
         Assert.isTrue(diskQuotaEnabled, "shutDown called but DiskQuotaMonitor is disabled!");
         Assert.isTrue(timeOutSecs > 0, "timeOut for shutdown must be > 0: " + timeOutSecs);
         try {
-            log.info("Disk quota monitor shutting down...");
+            log.fine("Disk quota monitor shutting down...");
             if (this.cacheInfoBuilder != null) {
                 this.cacheInfoBuilder.shutDown();
             }
@@ -286,10 +286,10 @@ public class DiskQuotaMonitor implements InitializingBean, DisposableBean {
                 this.cleanUpExecutorService.shutdownNow();
             }
 
-            log.info("Shutting down quota usage monitor...");
+            log.fine("Shutting down quota usage monitor...");
             quotaUsageMonitor.shutDownNow();
 
-            log.info("Shutting down quota statistics gathering monitor...");
+            log.fine("Shutting down quota statistics gathering monitor...");
             usageStatsMonitor.shutDownNow();
 
             quotaUsageMonitor.awaitTermination(timeOutSecs * 1000, TimeUnit.MILLISECONDS);

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesConsumer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedQuotaUpdatesConsumer.java
@@ -201,7 +201,7 @@ public class QueuedQuotaUpdatesConsumer implements Callable<Long> {
                  */
                 checkAggregatedTimeouts();
             } catch (InterruptedException e) {
-                log.info("Shutting down quota update background task due to InterruptedException");
+                log.fine("Shutting down quota update background task due to InterruptedException");
                 Thread.currentThread().interrupt();
                 break;
                 // it doesn't matter

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QueuedUsageStatsConsumer.java
@@ -128,7 +128,7 @@ public class QueuedUsageStatsConsumer implements Callable<Long> {
                     performAggregatedUpdate(requestedTile);
                 }
             } catch (InterruptedException e) {
-                log.info("Shutting down quota update background task due to interrupted exception");
+                log.fine("Shutting down quota update background task due to interrupted exception");
                 Thread.currentThread().interrupt();
                 break;
                 // it doesn't matter

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaUpdatesMonitor.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaUpdatesMonitor.java
@@ -76,7 +76,7 @@ public class QuotaUpdatesMonitor extends AbstractMonitor {
 
     @Override
     protected void shutDown(final boolean cancel) {
-        log.info("Shutting down quota usage monitor...");
+        log.fine("Shutting down quota usage monitor...");
         try {
             storageBroker.removeBlobStoreListener(quotaDiffsProducer);
         } catch (RuntimeException e) {

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPoller.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPoller.java
@@ -66,11 +66,10 @@ public class GeoRSSPoller {
 
         schedulingPollExecutorService.submit(
                 () -> {
-                    LOGGER.info("Initializing GeoRSS poller in a background job...");
-
                     findEnabledPolls();
 
                     if (pollCount() > 0) {
+                        LOGGER.fine("Initializing GeoRSS poller in a background job...");
 
                         final TimeUnit seconds = TimeUnit.SECONDS;
                         for (PollDef poll : scheduledPolls) {
@@ -78,7 +77,7 @@ public class GeoRSSPoller {
                             GeoRSSFeedDefinition pollDef = poll.getPollDef();
                             long period = pollDef.getPollInterval();
 
-                            LOGGER.info(
+                            LOGGER.config(
                                     "Scheduling layer "
                                             + poll.getLayer().getName()
                                             + " to poll the GeoRSS feed "
@@ -91,14 +90,14 @@ public class GeoRSSPoller {
 
                             scheduledTasks.add(command);
                         }
-                        LOGGER.info(
+                        LOGGER.fine(
                                 "Will wait "
                                         + startUpDelaySecs
                                         + " seconds before launching the "
                                         + pollCount()
                                         + " GeoRSS polls found");
                     } else {
-                        LOGGER.info("No enabled GeoRSS feeds found, poller will not run.");
+                        LOGGER.fine("No enabled GeoRSS feeds found, poller will not run.");
                     }
                 });
     }
@@ -157,7 +156,7 @@ public class GeoRSSPoller {
 
     /** Destroy method for Spring */
     public void destroy() {
-        LOGGER.info("destroy() invoked");
+        LOGGER.fine("destroy() invoked");
         if (schedulingPollExecutorService != null) {
             schedulingPollExecutorService.shutdown();
         }

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
@@ -493,18 +493,18 @@ public class WMSService extends Service {
         }
         // Log if fullWMS is enabled
         if (this.fullWMS) {
-            log.info("Will recombine tiles for non-tiling clients.");
+            log.config("Will recombine tiles for non-tiling clients.");
         } else {
-            log.info("Will NOT recombine tiles for non-tiling clients.");
+            log.config("Will NOT recombine tiles for non-tiling clients.");
         }
     }
 
     public void setProxyRequests(String trueFalse) {
         this.proxyRequests = Boolean.parseBoolean(trueFalse);
         if (this.proxyRequests) {
-            log.info("Will proxy requests to backend that are not getmap or getcapabilities.");
+            log.config("Will proxy requests to backend that are not getmap or getcapabilities.");
         } else {
-            log.info("Will NOT proxy non-getMap requests to backend.");
+            log.config("Will NOT proxy non-getMap requests to backend.");
         }
     }
 


### PR DESCRIPTION
The startup, and especially the shutdown, are very chatty. 

- Take advantage of CONFIG log levels, some configuration still logged as INFO
- Cut back on shutdown messages, many message intended for developers (about destory() and threads) are reduced to fine logging level