### PR TITLE
Fix S3 blobstore geowebcache parameterization issue

### DIFF
--- a/documentation/en/user/source/configuration/storage.rst
+++ b/documentation/en/user/source/configuration/storage.rst
@@ -229,6 +229,12 @@ Properties:
 * **proxyPassword**: Optional. The proxy password to use when connecting through a proxy.
 * **useGzip**: Optional, default: ``true``. Whether gzip compression should be used when transferring tiles to/from S3.
 
+**Note**: It is possible to set above properties from environment variable as long as they are of string type. In the example below, The awsAccessKey is set from environment variable named AWS_ACCESS_KEY
+
+.. code-block:: xml
+
+      <awsAccessKey>${AWS_ACCESS_KEY}</awsAccessKey>
+
 Additional Information:
 ```````````````````````
 

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
@@ -347,23 +347,22 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
         S3BlobStoreInfo blobStore = SerializationUtils.clone(this);
 
         if (allowEnvParametrization && gwcEnvironment != null) {
-            blobStore.setName((String) gwcEnvironment.resolveValue(getName()));
-            blobStore.setEnabled((Boolean) gwcEnvironment.resolveValue(isEnabled()));
-            blobStore.setDefault((Boolean) gwcEnvironment.resolveValue(isDefault()));
-            blobStore.setAccess((Access) gwcEnvironment.resolveValue(getAccess()));
-            blobStore.setPrefix((String) gwcEnvironment.resolveValue(getPrefix()));
-            blobStore.setUseHTTPS((Boolean) gwcEnvironment.resolveValue(isUseHTTPS()));
-            blobStore.setUseGzip((Boolean) gwcEnvironment.resolveValue(isUseGzip()));
-
+            blobStore.setName(getName());
+            blobStore.setEnabled(isEnabled());
+            blobStore.setDefault(isDefault());
+            blobStore.setAccess(getAccess());
+            blobStore.setPrefix(getPrefix());
+            blobStore.setUseHTTPS(isUseHTTPS());
+            blobStore.setUseGzip(isUseGzip());
+            blobStore.setMaxConnections(getMaxConnections());
+            blobStore.setProxyPort(getProxyPort());
             blobStore.setBucket((String) gwcEnvironment.resolveValue(getBucket()));
             blobStore.setAwsAccessKey((String) gwcEnvironment.resolveValue(getAwsAccessKey()));
             blobStore.setAwsSecretKey((String) gwcEnvironment.resolveValue(getAwsSecretKey()));
-            blobStore.setMaxConnections((Integer) gwcEnvironment.resolveValue(getMaxConnections()));
             blobStore.setProxyDomain((String) gwcEnvironment.resolveValue(getProxyDomain()));
             blobStore.setProxyWorkstation(
                     (String) gwcEnvironment.resolveValue(getProxyWorkstation()));
             blobStore.setProxyHost((String) gwcEnvironment.resolveValue(getProxyHost()));
-            blobStore.setProxyPort((Integer) gwcEnvironment.resolveValue(getProxyPort()));
             blobStore.setProxyUsername((String) gwcEnvironment.resolveValue(getProxyUsername()));
             blobStore.setProxyPassword((String) gwcEnvironment.resolveValue(getProxyPassword()));
             blobStore.setEndpoint((String) gwcEnvironment.resolveValue(getEndpoint()));

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
@@ -347,13 +347,13 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
         S3BlobStoreInfo blobStore = SerializationUtils.clone(this);
 
         if (allowEnvParametrization && gwcEnvironment != null) {
-            blobStore.setName(getName());
-            blobStore.setEnabled(isEnabled());
-            blobStore.setDefault(isDefault());
-            blobStore.setAccess(getAccess());
-            blobStore.setPrefix(getPrefix());
-            blobStore.setUseHTTPS(isUseHTTPS());
-            blobStore.setUseGzip(isUseGzip());
+            blobStore.setName((String) gwcEnvironment.resolveValue(getName()));
+            blobStore.setEnabled((Boolean) gwcEnvironment.resolveValue(isEnabled()));
+            blobStore.setDefault((Boolean) gwcEnvironment.resolveValue(isDefault()));
+            blobStore.setAccess((Access) gwcEnvironment.resolveValue(getAccess()));
+            blobStore.setPrefix((String) gwcEnvironment.resolveValue(getPrefix()));
+            blobStore.setUseHTTPS((Boolean) gwcEnvironment.resolveValue(isUseHTTPS()));
+            blobStore.setUseGzip((Boolean) gwcEnvironment.resolveValue(isUseGzip()));
 
             blobStore.setBucket((String) gwcEnvironment.resolveValue(getBucket()));
             blobStore.setAwsAccessKey((String) gwcEnvironment.resolveValue(getAwsAccessKey()));

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
@@ -29,7 +29,10 @@ import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.SerializationUtils;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.config.BlobStoreInfo;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.locks.LockProvider;
@@ -334,7 +337,38 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
         checkState(
                 isEnabled(),
                 "Can't call S3BlobStoreConfig.createInstance() is blob store is not enabled");
-        return new S3BlobStore(this, layers, lockProvider);
+        final GeoWebCacheEnvironment gwcEnvironment =
+                GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
+        return new S3BlobStore(this.clone(gwcEnvironment, true), layers, lockProvider);
+    }
+
+    public S3BlobStoreInfo clone(
+            GeoWebCacheEnvironment gwcEnvironment, Boolean allowEnvParametrization) {
+        S3BlobStoreInfo blobStore = SerializationUtils.clone(this);
+
+        if (allowEnvParametrization && gwcEnvironment != null) {
+            blobStore.setName(getName());
+            blobStore.setEnabled(isEnabled());
+            blobStore.setDefault(isDefault());
+            blobStore.setAccess(getAccess());
+            blobStore.setPrefix(getPrefix());
+            blobStore.setUseHTTPS(isUseHTTPS());
+            blobStore.setUseGzip(isUseGzip());
+
+            blobStore.setBucket((String) gwcEnvironment.resolveValue(getBucket()));
+            blobStore.setAwsAccessKey((String) gwcEnvironment.resolveValue(getAwsAccessKey()));
+            blobStore.setAwsSecretKey((String) gwcEnvironment.resolveValue(getAwsSecretKey()));
+            blobStore.setMaxConnections((Integer) gwcEnvironment.resolveValue(getMaxConnections()));
+            blobStore.setProxyDomain((String) gwcEnvironment.resolveValue(getProxyDomain()));
+            blobStore.setProxyWorkstation(
+                    (String) gwcEnvironment.resolveValue(getProxyWorkstation()));
+            blobStore.setProxyHost((String) gwcEnvironment.resolveValue(getProxyHost()));
+            blobStore.setProxyPort((Integer) gwcEnvironment.resolveValue(getProxyPort()));
+            blobStore.setProxyUsername((String) gwcEnvironment.resolveValue(getProxyUsername()));
+            blobStore.setProxyPassword((String) gwcEnvironment.resolveValue(getProxyPassword()));
+            blobStore.setEndpoint((String) gwcEnvironment.resolveValue(getEndpoint()));
+        }
+        return blobStore;
     }
 
     @Override

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/config/S3BlobStoreConfigStoreLoadTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/config/S3BlobStoreConfigStoreLoadTest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayerDispatcher;
@@ -81,6 +83,31 @@ public class S3BlobStoreConfigStoreLoadTest {
 
         saveConfig(store1, store2);
         validateAndLoadSavedConfig();
+    }
+
+    @Test
+    public void testParameterizedS3BlobStore() {
+        Assume.assumeTrue(tempFolder.isConfigured());
+
+        GeoWebCacheEnvironment genv = new GeoWebCacheEnvironment();
+        genv.setProps(testConfigLoader.getProperties());
+
+        S3BlobStoreInfo store = new S3BlobStoreInfo("999");
+        store.setDefault(true);
+        store.setEnabled(true);
+        store.setBucket("${bucket}");
+        store.setAwsAccessKey("${accessKey}");
+        store.setAwsSecretKey("${secretKey}");
+
+        S3BlobStoreInfo storedData = store.clone(genv, true);
+        assertEquals(
+                testConfigLoader.getProperties().getProperty("bucket"), storedData.getBucket());
+        assertEquals(
+                testConfigLoader.getProperties().getProperty("accessKey"),
+                storedData.getAwsAccessKey());
+        assertEquals(
+                testConfigLoader.getProperties().getProperty("secretKey"),
+                storedData.getAwsSecretKey());
     }
 
     private void saveConfig(S3BlobStoreInfo store1, S3BlobStoreInfo store2) throws IOException {


### PR DESCRIPTION
This PR fixes the S3 Blobstore parameterization issue. 
For example, if we set the bucket name to ${S3_BUCKET} and pass it as an env variable, we get an error suggesting that its not possible to specify bucket name containing '$'