### PR TITLE
GWC WMTS data security improvements

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -307,6 +307,7 @@ public class Demo {
                 .append("ol.css' type='text/css'>\n");
         buf.append(
                 "<script type=\"text/javascript\">\n"
+                        + "//# sourceURL=gwc_page.js\n" // this makes debugging in chrome possible
                         + "function init(){\n"
                         + "function ScaleControl(opt_options) {\n"
                         + "  var options = opt_options || {};\n"

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilter.java
@@ -1,0 +1,46 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author David Blasby, GeoCat, Copyright 2022
+ */
+package org.geowebcache.layer;
+
+import org.geowebcache.filter.security.SecurityDispatcher;
+
+public class SecurityDispatcherTileLayerDispatcherFilter implements TileLayerDispatcherFilter {
+
+    SecurityDispatcher securityDispatcher;
+
+    public SecurityDispatcherTileLayerDispatcherFilter(SecurityDispatcher securityDispatcher) {
+        this.securityDispatcher = securityDispatcher;
+    }
+
+    /**
+     * This uses the GWC SecurityDispatcher#checkSecurity to determine if the user has access to the
+     * layer.
+     *
+     * @param tileLayer
+     * @return true if the user doesn't have access to layer
+     */
+    @Override
+    public boolean exclude(TileLayer tileLayer) {
+        if (securityDispatcher == null) {
+            return false;
+        }
+        try {
+            securityDispatcher.checkSecurity(tileLayer, null, null);
+        } catch (Exception e) {
+            return true; // threw exception - we don't have access
+        }
+        return false;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
@@ -161,13 +161,14 @@ public class TileLayerDispatcher
      *
      * @return all layers, but filtered based on the tileLayerDispatcherFilter.
      */
+    @SuppressWarnings("unchecked")
     public Iterable<TileLayer> getLayerListFiltered() {
         Iterable<TileLayer> result = getLayerList();
         if (tileLayerDispatcherFilter != null) {
             Stream s =
                     StreamSupport.stream(result.spliterator(), false)
                             .filter(x -> !tileLayerDispatcherFilter.exclude(x));
-            result = s::iterator;
+            result = (Iterable<TileLayer>) s::iterator;
         }
         return result;
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcherFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcherFilter.java
@@ -1,0 +1,30 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author David Blasby, GeoCat, Copyright 2022
+ */
+package org.geowebcache.layer;
+
+/**
+ * Filter interface for the TileLayerDispatcher. This allows layers to be excluded from the list of
+ * available layers.
+ */
+public interface TileLayerDispatcherFilter {
+
+    /**
+     * Determine if the layer should be excluded (filtered out).
+     *
+     * @param tileLayer
+     * @return true if this tileLayer should be excluded (filtered out)
+     */
+    boolean exclude(TileLayer tileLayer);
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTest.java
@@ -56,7 +56,8 @@ public abstract class GWCConfigIntegrationTest {
 
         gridSetBroker = testSupport.getGridSetBroker();
         tileLayerDispatcher =
-                new TileLayerDispatcher(gridSetBroker, testSupport.getTileLayerConfigurations());
+                new TileLayerDispatcher(
+                        gridSetBroker, testSupport.getTileLayerConfigurations(), null);
         blobStoreAggregator =
                 new BlobStoreAggregator(
                         Collections.singletonList(testSupport.getBlobStoreConfiguration()),

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilterTest.java
@@ -14,52 +14,57 @@
  */
 package org.geowebcache.layer;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.filter.security.SecurityDispatcher;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 public class SecurityDispatcherTileLayerDispatcherFilterTest {
 
     /**
-     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the SecurityDispatcher.
-     * If the SecurityDispatcher#checkSecurity() doesn't throw, then that TileLayer is NOT filtered ("false").
+     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the
+     * SecurityDispatcher. If the SecurityDispatcher#checkSecurity() doesn't throw, then that
+     * TileLayer is NOT filtered ("false").
      */
     @Test
     public void testFilterIn() throws GeoWebCacheException {
         SecurityDispatcher securityDispatcher = Mockito.mock(SecurityDispatcher.class);
 
-        SecurityDispatcherTileLayerDispatcherFilter filter = new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
-        TileLayer tileLayer =  Mockito.mock(TileLayer.class);
-        //doesn't throw -> filter.exclude() will be false
-        Mockito.doNothing().when(securityDispatcher).checkSecurity(tileLayer,null,null);
+        SecurityDispatcherTileLayerDispatcherFilter filter =
+                new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
+        TileLayer tileLayer = Mockito.mock(TileLayer.class);
+        // doesn't throw -> filter.exclude() will be false
+        Mockito.doNothing().when(securityDispatcher).checkSecurity(tileLayer, null, null);
 
         boolean result = filter.exclude(tileLayer);
 
         assertFalse(result);
-        Mockito.verify(securityDispatcher).checkSecurity(tileLayer,null,null);
+        Mockito.verify(securityDispatcher).checkSecurity(tileLayer, null, null);
     }
 
-
     /**
-     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the SecurityDispatcher.
-     * If the SecurityDispatcher#checkSecurity() throws, then that TileLayer is filtered out ("true").
+     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the
+     * SecurityDispatcher. If the SecurityDispatcher#checkSecurity() throws, then that TileLayer is
+     * filtered out ("true").
      */
     @Test
     public void testFilterOut() throws GeoWebCacheException {
         SecurityDispatcher securityDispatcher = Mockito.mock(SecurityDispatcher.class);
 
-        SecurityDispatcherTileLayerDispatcherFilter filter = new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
-        TileLayer tileLayer =  Mockito.mock(TileLayer.class);
-        //throws -> filter.exclude() will be true
-        Mockito.doThrow(new GeoWebCacheException("")).when(securityDispatcher).checkSecurity(tileLayer,null,null);
+        SecurityDispatcherTileLayerDispatcherFilter filter =
+                new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
+        TileLayer tileLayer = Mockito.mock(TileLayer.class);
+        // throws -> filter.exclude() will be true
+        Mockito.doThrow(new GeoWebCacheException(""))
+                .when(securityDispatcher)
+                .checkSecurity(tileLayer, null, null);
 
         boolean result = filter.exclude(tileLayer);
 
         assertTrue(result);
-        Mockito.verify(securityDispatcher).checkSecurity(tileLayer,null,null);
+        Mockito.verify(securityDispatcher).checkSecurity(tileLayer, null, null);
     }
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilterTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/SecurityDispatcherTileLayerDispatcherFilterTest.java
@@ -1,0 +1,65 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * <p>Copyright 2022
+ */
+package org.geowebcache.layer;
+
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.filter.security.SecurityDispatcher;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SecurityDispatcherTileLayerDispatcherFilterTest {
+
+    /**
+     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the SecurityDispatcher.
+     * If the SecurityDispatcher#checkSecurity() doesn't throw, then that TileLayer is NOT filtered ("false").
+     */
+    @Test
+    public void testFilterIn() throws GeoWebCacheException {
+        SecurityDispatcher securityDispatcher = Mockito.mock(SecurityDispatcher.class);
+
+        SecurityDispatcherTileLayerDispatcherFilter filter = new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
+        TileLayer tileLayer =  Mockito.mock(TileLayer.class);
+        //doesn't throw -> filter.exclude() will be false
+        Mockito.doNothing().when(securityDispatcher).checkSecurity(tileLayer,null,null);
+
+        boolean result = filter.exclude(tileLayer);
+
+        assertFalse(result);
+        Mockito.verify(securityDispatcher).checkSecurity(tileLayer,null,null);
+    }
+
+
+    /**
+     * Tests that the SecurityDispatcherTileLayerDispatcherFilter passes the request off to the SecurityDispatcher.
+     * If the SecurityDispatcher#checkSecurity() throws, then that TileLayer is filtered out ("true").
+     */
+    @Test
+    public void testFilterOut() throws GeoWebCacheException {
+        SecurityDispatcher securityDispatcher = Mockito.mock(SecurityDispatcher.class);
+
+        SecurityDispatcherTileLayerDispatcherFilter filter = new SecurityDispatcherTileLayerDispatcherFilter(securityDispatcher);
+        TileLayer tileLayer =  Mockito.mock(TileLayer.class);
+        //throws -> filter.exclude() will be true
+        Mockito.doThrow(new GeoWebCacheException("")).when(securityDispatcher).checkSecurity(tileLayer,null,null);
+
+        boolean result = filter.exclude(tileLayer);
+
+        assertTrue(result);
+        Mockito.verify(securityDispatcher).checkSecurity(tileLayer,null,null);
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
@@ -262,39 +262,45 @@ public class TileLayerDispatcherTest extends GWCConfigIntegrationTest {
     }
 
     /**
-     * this tests that the GetLayerListFiltered is working correctly.
-     * It should be the results of getLayerList() run through the TileLayerDispatcherFilter.
+     * this tests that the GetLayerListFiltered is working correctly. It should be the results of
+     * getLayerList() run through the TileLayerDispatcherFilter.
      */
     @Test
     public void testGetLayerListFiltered() {
-        // we don't really care about the internals of these layer, just making sure that exclude() is called on them
-        TileLayer tileLayer1 =  Mockito.mock(TileLayer.class);
-        TileLayer tileLayer2 =  Mockito.mock(TileLayer.class);
+        // we don't really care about the internals of these layer, just making sure that exclude()
+        // is called on them
+        TileLayer tileLayer1 = Mockito.mock(TileLayer.class);
+        TileLayer tileLayer2 = Mockito.mock(TileLayer.class);
 
         // setup the tileLayerDispatcherFilter so that
         // tileLayer1 -> excluded
         // tileLayer2 -> NOT excluded
-        TileLayerDispatcherFilter tileLayerDispatcherFilter = Mockito.mock(TileLayerDispatcherFilter.class);
+        TileLayerDispatcherFilter tileLayerDispatcherFilter =
+                Mockito.mock(TileLayerDispatcherFilter.class);
         Mockito.doReturn(true).when(tileLayerDispatcherFilter).exclude(tileLayer1);
         Mockito.doReturn(false).when(tileLayerDispatcherFilter).exclude(tileLayer2);
 
         // we use mokito spy to make testing the getLayerListFiltered() method easy
-        // tileLayerDispatcher will return the list [tileLayer1,tileLayer2] when getLayerList() called
-        TileLayerDispatcher tileLayerDispatcher = new TileLayerDispatcher(null,tileLayerDispatcherFilter);
+        // tileLayerDispatcher will return the list [tileLayer1,tileLayer2] when getLayerList()
+        // called
+        TileLayerDispatcher tileLayerDispatcher =
+                new TileLayerDispatcher(null, tileLayerDispatcherFilter);
         TileLayerDispatcher tileLayerDispatcherSpy = Mockito.spy(tileLayerDispatcher);
-        Mockito.doReturn(Arrays.asList(tileLayer1,tileLayer2)).when(tileLayerDispatcherSpy).getLayerList();
+        Mockito.doReturn(Arrays.asList(tileLayer1, tileLayer2))
+                .when(tileLayerDispatcherSpy)
+                .getLayerList();
 
         // run our actual method
         Iterable<TileLayer> filteredResult = tileLayerDispatcherSpy.getLayerListFiltered();
-        //iterator->list
+        // iterator->list
         List<TileLayer> result = new ArrayList<>();
         filteredResult.forEach(result::add);
 
         // should only have tileLayer2 in the result
-        assertEquals(1,result.size());
+        assertEquals(1, result.size());
         assertEquals(tileLayer2, result.get(0));
 
-        //verify that exclude(tileLayer1) and exclude(tileLayer2) were called
+        // verify that exclude(tileLayer1) and exclude(tileLayer2) were called
         Mockito.verify(tileLayerDispatcherFilter).exclude(tileLayer1);
         Mockito.verify(tileLayerDispatcherFilter).exclude(tileLayer2);
     }

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/TileLayerDispatcherTest.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.GWCConfigIntegrationTest;
@@ -31,6 +34,7 @@ import org.geowebcache.grid.GridSetFactory;
 import org.geowebcache.grid.SRS;
 import org.geowebcache.layer.wms.WMSLayer;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TileLayerDispatcherTest extends GWCConfigIntegrationTest {
 
@@ -255,5 +259,43 @@ public class TileLayerDispatcherTest extends GWCConfigIntegrationTest {
         } catch (IllegalStateException e) {
 
         }
+    }
+
+    /**
+     * this tests that the GetLayerListFiltered is working correctly.
+     * It should be the results of getLayerList() run through the TileLayerDispatcherFilter.
+     */
+    @Test
+    public void testGetLayerListFiltered() {
+        // we don't really care about the internals of these layer, just making sure that exclude() is called on them
+        TileLayer tileLayer1 =  Mockito.mock(TileLayer.class);
+        TileLayer tileLayer2 =  Mockito.mock(TileLayer.class);
+
+        // setup the tileLayerDispatcherFilter so that
+        // tileLayer1 -> excluded
+        // tileLayer2 -> NOT excluded
+        TileLayerDispatcherFilter tileLayerDispatcherFilter = Mockito.mock(TileLayerDispatcherFilter.class);
+        Mockito.doReturn(true).when(tileLayerDispatcherFilter).exclude(tileLayer1);
+        Mockito.doReturn(false).when(tileLayerDispatcherFilter).exclude(tileLayer2);
+
+        // we use mokito spy to make testing the getLayerListFiltered() method easy
+        // tileLayerDispatcher will return the list [tileLayer1,tileLayer2] when getLayerList() called
+        TileLayerDispatcher tileLayerDispatcher = new TileLayerDispatcher(null,tileLayerDispatcherFilter);
+        TileLayerDispatcher tileLayerDispatcherSpy = Mockito.spy(tileLayerDispatcher);
+        Mockito.doReturn(Arrays.asList(tileLayer1,tileLayer2)).when(tileLayerDispatcherSpy).getLayerList();
+
+        // run our actual method
+        Iterable<TileLayer> filteredResult = tileLayerDispatcherSpy.getLayerListFiltered();
+        //iterator->list
+        List<TileLayer> result = new ArrayList<>();
+        filteredResult.forEach(result::add);
+
+        // should only have tileLayer2 in the result
+        assertEquals(1,result.size());
+        assertEquals(tileLayer2, result.get(0));
+
+        //verify that exclude(tileLayer1) and exclude(tileLayer2) were called
+        Mockito.verify(tileLayerDispatcherFilter).exclude(tileLayer1);
+        Mockito.verify(tileLayerDispatcherFilter).exclude(tileLayer2);
     }
 }

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -129,7 +129,7 @@ public class BDBQuotaStoreTest {
                 BaseConfiguration.class);
         GridSetBroker gridSetBroker = new GridSetBroker();
         gridSetBroker.setApplicationContext(context.getMockContext());
-        layerDispatcher = new TileLayerDispatcher(gridSetBroker);
+        layerDispatcher = new TileLayerDispatcher(gridSetBroker, null);
         layerDispatcher.setApplicationContext(context.getMockContext());
 
         tilePageCalculator = new TilePageCalculator(layerDispatcher, storageBroker);

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -133,7 +133,7 @@ public abstract class JDBCQuotaStoreTest {
             xmlConfig.setGridSetBroker(broker);
             extraConfig.setGridSetBroker(broker);
 
-            layerDispatcher = new TileLayerDispatcher(broker);
+            layerDispatcher = new TileLayerDispatcher(broker, null);
 
             layerDispatcher.setApplicationContext(extensions.getMockContext());
 

--- a/geowebcache/gmaps/src/test/java/org/geowebcache/layer/TileLayerDispatcherMock.java
+++ b/geowebcache/gmaps/src/test/java/org/geowebcache/layer/TileLayerDispatcherMock.java
@@ -7,7 +7,7 @@ public class TileLayerDispatcherMock extends TileLayerDispatcher {
     private final TileLayer layer;
 
     public TileLayerDispatcherMock(TileLayer layer) {
-        super(null);
+        super(null, null);
         this.layer = layer;
     }
 

--- a/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLSiteMap.java
+++ b/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLSiteMap.java
@@ -80,7 +80,7 @@ public class KMLSiteMap {
         OutputStream os = tile.servletResp.getOutputStream();
         String urlPrefix = tile.getUrlPrefix();
 
-        Iterable<TileLayer> iter = tLD.getLayerList();
+        Iterable<TileLayer> iter = tLD.getLayerListFiltered();
 
         for (TileLayer tl : iter) {
             if (!tl.isEnabled()) {

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ByteStreamController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ByteStreamController.java
@@ -77,17 +77,24 @@ public class ByteStreamController {
 
     static final Pattern UNSAFE_RESOURCE = Pattern.compile("^/|/\\.\\./|^\\.\\./|\\.class$");
 
+    // "gwc/rest/web/openlayers3/ol.js" -> openlayers3/ol.js
+    // "/rest/web/openlayers3/ol.js" -> openlayers3/ol.js
+    String getFileName(HttpServletRequest request) {
+        String path = request.getPathInfo();
+        if (path.indexOf("/rest/web") != 0) {
+            path = path.substring(path.indexOf("/rest/web"));
+        }
+        return path.substring("/rest/web/".length());
+    }
+
     @RequestMapping(value = "/web/**", method = RequestMethod.GET)
     ResponseEntity<?> doGet(HttpServletRequest request, HttpServletResponse response) {
-
         final String filename;
         try {
-            filename =
-                    URLDecoder.decode(
-                            request.getPathInfo().substring("/rest/web/".length()), "UTF-8");
+            filename = URLDecoder.decode(getFileName(request), "UTF-8");
         } catch (UnsupportedEncodingException e1) {
             throw new IllegalStateException(
-                    "Cound not decode encoding UTF-8", e1); // Should never happen
+                    "Could not decode encoding UTF-8", e1); // Should never happen
         }
 
         // Just to make sure we don't allow access to arbitrary resources

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/bounds/BoundsControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/bounds/BoundsControllerTest.java
@@ -83,7 +83,7 @@ public class BoundsControllerTest {
         LinkedList<TileLayerConfiguration> configList = new LinkedList<>();
         configList.add(xmlConfig);
 
-        tld = new TileLayerDispatcher(gridSetBroker, configList);
+        tld = new TileLayerDispatcher(gridSetBroker, configList, null);
         bc = new BoundsController();
         bc.setTileLayerDispatcher(tld);
         this.mockMvc = MockMvcBuilders.standaloneSetup(bc).build();

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/filter/FilterUpdateControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/filter/FilterUpdateControllerTest.java
@@ -64,7 +64,7 @@ public class FilterUpdateControllerTest {
         LinkedList<TileLayerConfiguration> configList = new LinkedList<>();
         configList.add(xmlConfig);
 
-        tld = new TileLayerDispatcher(gridSetBroker, configList);
+        tld = new TileLayerDispatcher(gridSetBroker, configList, null);
         fc = new FilterUpdateController();
         fc.setTileLayerDispatcher(tld);
         this.mockMvc = MockMvcBuilders.standaloneSetup(fc).build();

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/reload/ReloadTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/reload/ReloadTest.java
@@ -72,7 +72,7 @@ public class ReloadTest {
         GridSetBroker gridSetBroker =
                 new GridSetBroker(MockGridSetConfiguration.withDefaults(gridSet));
 
-        tld = new TileLayerDispatcher(gridSetBroker);
+        tld = new TileLayerDispatcher(gridSetBroker, null);
         reload = new ReloadController();
         reload.setTileLayerDispatcher(tld);
 

--- a/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSDocumentFactory.java
+++ b/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSDocumentFactory.java
@@ -133,7 +133,7 @@ public class TMSDocumentFactory {
             // <ContactElectronicMailAddress>pramsey@refractions.net</ContactElectronicMailAddress>
             // </ContactInformation>
             xml.indentElement("TileMaps");
-            Iterable<TileLayer> iter = tld.getLayerList();
+            Iterable<TileLayer> iter = tld.getLayerListFiltered();
             for (TileLayer layer : iter) {
                 if (!layer.isEnabled() || !layer.isAdvertised()) {
                     continue;

--- a/geowebcache/tms/src/test/java/org/geowebcache/service/tms/TMSServiceTest.java
+++ b/geowebcache/tms/src/test/java/org/geowebcache/service/tms/TMSServiceTest.java
@@ -284,6 +284,7 @@ public class TMSServiceTest {
                 mockTileLayer(
                         tld, gridsetBroker, "mockLayer", gridSetNames, Collections.emptyList());
         when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
 
         Conveyor conv = service.getConveyor(req, resp);
         Assert.assertNotNull(conv);

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
@@ -72,13 +72,19 @@
     </property>
     
   </bean-->
-  
+
+  <bean id="gwcSecurityDispatcherTileLayerDispatcherFilter" class="org.geowebcache.layer.SecurityDispatcherTileLayerDispatcherFilter">
+    <constructor-arg ref="gwcSecurityDispatcher"/>
+  </bean>
+
+
   <!-- For each configuration bean above, add them below to activate -->
   <bean id="gwcTLDispatcher" class="org.geowebcache.layer.TileLayerDispatcher">
     <description>
       TileLayerDispatcher serves up TileLayers from the available Configurations in the application context
     </description>
     <constructor-arg ref="gwcGridSetBroker"/>
+    <constructor-arg ref="gwcSecurityDispatcherTileLayerDispatcherFilter"/>
   </bean>
 
   <bean id="gwcBlobStoreAggregator" class="org.geowebcache.storage.BlobStoreAggregator">

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
@@ -280,7 +280,7 @@ public class WMSGetCapabilities {
 
     private void capabilityRequestGetMap(XMLBuilder xml) throws IOException {
         // Find all the formats we support
-        Iterable<TileLayer> layerIter = tld.getLayerList();
+        Iterable<TileLayer> layerIter = tld.getLayerListFiltered();
 
         HashSet<String> formats = new HashSet<>();
 
@@ -306,7 +306,7 @@ public class WMSGetCapabilities {
     private void capabilityRequestGetFeatureInfo(XMLBuilder xml) throws IOException {
 
         // Find all the info formats we support
-        Iterable<TileLayer> layerIter = tld.getLayerList();
+        Iterable<TileLayer> layerIter = tld.getLayerListFiltered();
 
         HashSet<String> formats = new HashSet<>();
 
@@ -351,7 +351,7 @@ public class WMSGetCapabilities {
 
     private void capabilityVendorSpecific(XMLBuilder xml) throws IOException {
         xml.indentElement("VendorSpecificCapabilities");
-        Iterable<TileLayer> layerIter = tld.getLayerList();
+        Iterable<TileLayer> layerIter = tld.getLayerListFiltered();
         for (TileLayer layer : layerIter) {
             if (!layer.isEnabled() || !layer.isAdvertised()) {
                 continue;
@@ -502,7 +502,7 @@ public class WMSGetCapabilities {
                 true);
         xml.latLonBoundingBox(-180.0, -90.0, 180.0, 90.0);
 
-        Iterable<TileLayer> layerIter = tld.getLayerList();
+        Iterable<TileLayer> layerIter = tld.getLayerListFiltered();
         for (TileLayer layer : layerIter) {
             if (!layer.isEnabled() || !layer.isAdvertised()) {
                 continue;

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
@@ -128,6 +128,8 @@ public class WMSGetCapabilitiesTest {
         unAdvertisedLayer.setAdvertised(false);
 
         expect(tld.getLayerList()).andStubReturn(Arrays.asList(advertisedLayer, unAdvertisedLayer));
+        expect(tld.getLayerListFiltered())
+                .andStubReturn(Arrays.asList(advertisedLayer, unAdvertisedLayer));
 
         replay(tld, servReq, response, servInfo);
 

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
@@ -228,6 +228,7 @@ public class WMSServiceTest {
                 Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
         TileLayer tileLayer = mockTileLayer("mockLayer", gridSetNames);
         when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
 
         ConveyorTile conv = service.getConveyor(req, resp);
         assertNotNull(conv);
@@ -271,6 +272,7 @@ public class WMSServiceTest {
                 Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
         TileLayer tileLayer = mockTileLayer("möcklāyer😎", gridSetNames);
         when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
 
         ConveyorTile conv = service.getConveyor(req, resp);
         assertNotNull(conv);
@@ -496,6 +498,7 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
 
         doThrow(new SecurityException()).when(secDisp).checkSecurity(Mockito.any());
 
@@ -531,6 +534,7 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         MockHttpServletResponse resp = new MockHttpServletResponse();
@@ -577,6 +581,8 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
+
         when(tileLayer.getGridSubsetsForSRS(SRS.getEPSG4326()))
                 .thenReturn(Collections.singletonList(subset));
 
@@ -638,6 +644,8 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
+
         when(tileLayer.getGridSubsetsForSRS(SRS.getEPSG4326()))
                 .thenReturn(Collections.singletonList(subset));
 
@@ -692,6 +700,8 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
+
         when(tileLayer.getGridSubsetsForSRS(SRS.getEPSG4326()))
                 .thenReturn(Collections.singletonList(subset));
         when(tileLayer.getInfoMimeTypes()).thenReturn(Collections.singletonList(XMLMime.gml));
@@ -756,6 +766,8 @@ public class WMSServiceTest {
         TestLayer tileLayer = mock(TestLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
+
         when(tileLayer.getGridSubsetsForSRS(SRS.getEPSG4326()))
                 .thenReturn(Collections.singletonList(subset));
         when(tileLayer.getInfoMimeTypes()).thenReturn(Collections.singletonList(XMLMime.gml));

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
@@ -323,7 +323,7 @@ public class WMSTileFuserTest {
         temp.mkdirs();
         try {
             TileLayerDispatcher dispatcher =
-                    new TileLayerDispatcher(gridSetBroker) {
+                    new TileLayerDispatcher(gridSetBroker, null) {
 
                         @Override
                         public TileLayer getTileLayer(String layerName)

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -429,7 +429,7 @@ public class WMTSGetCapabilities {
 
     private void contents(XMLBuilder xml) throws IOException {
         xml.indentElement("Contents");
-        Iterable<TileLayer> iter = tld.getLayerList();
+        Iterable<TileLayer> iter = tld.getLayerListFiltered();
         Set<GridSet> usedGridsets = new HashSet<>();
         for (TileLayer layer : iter) {
             if (!layer.isEnabled() || !layer.isAdvertised()) {

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
@@ -229,6 +229,7 @@ public class WMTSRestTest {
         when(tileLayerJson.getGridSubset(eq(googleMercator))).thenReturn(subset);
 
         when(tileLayerDispatcher.getLayerList()).thenReturn(Arrays.asList(tileLayerJson));
+        when(tileLayerDispatcher.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayerJson));
     }
 
     public MockHttpServletResponse dispatch(MockHttpServletRequest req) throws Exception {
@@ -458,6 +459,7 @@ public class WMTSRestTest {
         when(tileLayer.getGridSubsets()).thenReturn(subsets.keySet());
 
         when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
 
         when(tileLayer.getTile(any(ConveyorTile.class)))
                 .thenAnswer(

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -131,7 +131,7 @@ public class WMTSServiceTest {
         when(appContext.getBean(BaseConfiguration.class)).thenReturn(config2);
         when(appContext.getBeansOfType(BaseConfiguration.class))
                 .thenReturn(Collections.singletonMap("xmlConfig", config2));
-        TileLayerDispatcher tldx = new TileLayerDispatcher(gridsetBroker);
+        TileLayerDispatcher tldx = new TileLayerDispatcher(gridsetBroker, null);
         tldx.setApplicationContext(appContext);
         tldx.afterPropertiesSet();
         return tldx;
@@ -321,6 +321,7 @@ public class WMTSServiceTest {
                     mockTileLayer("mockLayerUnadv", gridSetNames, Collections.emptyList(), false);
 
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
 
             // add styles
             StringParameterFilter styles = new StringParameterFilter();
@@ -606,6 +607,8 @@ public class WMTSServiceTest {
                 Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
         TileLayer tileLayer = mockTileLayer("mockLayer", gridSetNames, Collections.emptyList());
         when(tld.getLayerList()).thenReturn(Collections.singletonList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singletonList(tileLayer));
+
         Conveyor conv = service.getConveyor(req, resp);
         assertNotNull(conv);
         assertEquals(Conveyor.RequestHandler.SERVICE, conv.reqHandler);
@@ -706,6 +709,8 @@ public class WMTSServiceTest {
             TileLayer tileLayerUn =
                     mockTileLayer("mockLayerUnadv", gridSetNames, Collections.emptyList(), false);
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
+
             GridSubset wgs84Subset = mock(GridSubset.class);
             when(wgs84Subset.getOriginalExtent()).thenReturn(new BoundingBox(-42d, -24d, 40d, 50d));
             GridSubset googleSubset = mock(GridSubset.class);
@@ -784,6 +789,8 @@ public class WMTSServiceTest {
             TileLayer tileLayerUn =
                     mockTileLayer("mockLayerUnadv", gridSetNames, Collections.emptyList(), false);
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer, tileLayerUn));
+
             GridSubset wgs84Subset = mock(GridSubset.class);
             when(wgs84Subset.getOriginalExtent()).thenReturn(new BoundingBox(-42d, -24d, 40d, 50d));
             GridSubset googleSubset = mock(GridSubset.class);
@@ -869,6 +876,7 @@ public class WMTSServiceTest {
                     mockTileLayer(
                             "mockLayer", gridSetNames, Collections.singletonList(styleFilter));
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
         }
 
         Conveyor conv = service.getConveyor(req, resp);
@@ -952,6 +960,7 @@ public class WMTSServiceTest {
                     mockTileLayer(
                             "mockLayer", gridSetNames, Collections.singletonList(styleFilter));
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
         }
 
         Conveyor conv = service.getConveyor(req, resp);
@@ -1035,6 +1044,7 @@ public class WMTSServiceTest {
                     mockTileLayer(
                             "mockLayer", gridSetNames, Collections.singletonList(styleFilter));
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
         }
 
         Conveyor conv = service.getConveyor(req, resp);
@@ -1160,6 +1170,7 @@ public class WMTSServiceTest {
                             gridSetNames,
                             Arrays.asList(styleFilter, elevationDimension, timeDimension));
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
         }
 
         Conveyor conv = service.getConveyor(req, resp);
@@ -1267,6 +1278,7 @@ public class WMTSServiceTest {
                             any()))
                     .thenReturn(Collections.unmodifiableMap(map));
             when(tld.getLayerList()).thenReturn(Arrays.asList(tileLayer));
+            when(tld.getLayerListFiltered()).thenReturn(Arrays.asList(tileLayer));
         }
 
         Conveyor conv = service.getConveyor(req, resp);
@@ -1366,6 +1378,7 @@ public class WMTSServiceTest {
         TileLayer tileLayer = mock(TileLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
         when(tileLayer.getGridSubset("testGridset")).thenReturn(subset);
         when(tileLayer.getInfoMimeTypes()).thenReturn(Collections.singletonList(XMLMime.gml));
         // doThrow(new SecurityException()).when(secDisp).checkSecurity(Mockito.any());
@@ -1446,6 +1459,7 @@ public class WMTSServiceTest {
         TileLayer tileLayer = mock(TileLayer.class);
         when(tld.getTileLayer(layerName)).thenReturn(tileLayer);
         when(tld.getLayerList()).thenReturn(Collections.singleton(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singleton(tileLayer));
         when(tileLayer.getGridSubset("testGridset")).thenReturn(subset);
         when(tileLayer.getInfoMimeTypes()).thenReturn(Collections.singletonList(XMLMime.gml));
         doThrow(new SecurityException()).when(secDisp).checkSecurity(Mockito.any());
@@ -1523,6 +1537,7 @@ public class WMTSServiceTest {
         List<String> gridSetNames = Arrays.asList("EPSG:900913");
         TileLayer tileLayer = mockTileLayerWithJSONSupport("mockLayer", gridSetNames);
         when(tld.getLayerList()).thenReturn(Collections.singletonList(tileLayer));
+        when(tld.getLayerListFiltered()).thenReturn(Collections.singletonList(tileLayer));
 
         Conveyor conv = service.getConveyor(req, resp);
         assertNotNull(conv);


### PR DESCRIPTION

See Geoserver-side PR: https://github.com/geoserver/geoserver/pull/6185
See bug report: https://osgeo-org.atlassian.net/browse/GEOS-10648

When GS global services are off allow GWC to work
When a Layer is non-visible to user, do not show it in the WMTS GetCapabilities
Better handling of workspace-specific requests (instead of global requests).

Changes
1. Smarter normalizeURL (in GeoWebCAcheDispatcher) and getFileName (in ByteStreamController for serving static files) 
2. added JS comment so that Chrome would make it easier to put in breakpoints 
3. Added security check for WMTSGetCapabilites to make sure the user can see the layer before putting it in the document.  This required injecting the SecurityDispatcher.  Updates test cases to inject a null SecurityDispatcher.