### PR TITLE
Restore 1.21-SNAPSHOT

### DIFF
--- a/documentation/en/user/source/conf.py
+++ b/documentation/en/user/source/conf.py
@@ -47,7 +47,7 @@ copyright = u'OpenGeo, License: Creative Commons 3.0 - Attribution Share Alike'
 # The short X.Y version.
 version = '1.21'
 # The full version, including alpha/beta/rc tags.
-release = '1.21.x'
+release = '1.21.1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/geowebcache/arcgiscache/pom.xml
+++ b/geowebcache/arcgiscache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/azureblob/pom.xml
+++ b/geowebcache/azureblob/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
 

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/diskquota/bdb/pom.xml
+++ b/geowebcache/diskquota/bdb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>gwc-diskquota</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <artifactId>gwc-diskquota-bdb</artifactId>

--- a/geowebcache/diskquota/core/pom.xml
+++ b/geowebcache/diskquota/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>gwc-diskquota</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/diskquota/jdbc/pom.xml
+++ b/geowebcache/diskquota/jdbc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>gwc-diskquota</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/diskquota/pom.xml
+++ b/geowebcache/diskquota/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/distributed/pom.xml
+++ b/geowebcache/distributed/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/gmaps/pom.xml
+++ b/geowebcache/gmaps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/kml/pom.xml
+++ b/geowebcache/kml/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/mbtiles/pom.xml
+++ b/geowebcache/mbtiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.geowebcache</groupId>
   <artifactId>geowebcache</artifactId>
-  <version>1.21.1</version>
+  <version>1.21-SNAPSHOT</version>
   <packaging>pom</packaging>
   <!-- GWC VERSION -->
   <name>geowebcache</name>
@@ -51,7 +51,7 @@
   </distributionManagement>
 
   <properties>
-    <gt.version>27-SNAPSHOT</gt.version>
+    <gt.version>27.1</gt.version>
     <jts.version>1.18.2</jts.version>
     <jaiext.version>1.1.24</jaiext.version>
     <spring.version>5.2.20.RELEASE</spring.version>
@@ -663,7 +663,7 @@
             <descriptor>release/war.xml</descriptor>
             <descriptor>release/doc.xml</descriptor>
           </descriptors>
-          <finalName>geowebcache-1.21-SNAPSHOT</finalName>
+          <finalName>geowebcache-1.21.1</finalName>
           <outputDirectory>${project.build.directory}/release</outputDirectory>
         </configuration>
       </plugin>

--- a/geowebcache/release/doc.xml
+++ b/geowebcache/release/doc.xml
@@ -7,7 +7,7 @@
 	<fileSets>
 		<fileSet>
 			<directory>../documentation/en/user/build/html</directory>
-			<outputDirectory>geowebcache-<!-- GWC VERSION -->1.21-SNAPSHOT<!-- /GWC VERSION -->/doc</outputDirectory>
+			<outputDirectory>geowebcache-<!-- GWC VERSION -->1.21.1<!-- /GWC VERSION -->/doc</outputDirectory>
 			<includes>
 				<include>**/*</include>
 			</includes>

--- a/geowebcache/release/src.xml
+++ b/geowebcache/release/src.xml
@@ -7,7 +7,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}</directory>
-      <outputDirectory>geowebcache-<!-- GWC VERSION -->1.21-SNAPSHOT<!-- /GWC VERSION -->/</outputDirectory>
+      <outputDirectory>geowebcache-<!-- GWC VERSION -->1.21.1<!-- /GWC VERSION -->/</outputDirectory>
       <useDefaultExcludes>true</useDefaultExcludes>
       <excludes>
         <exclude>**/${project.build.directory}/**</exclude>

--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/s3storage/pom.xml
+++ b/geowebcache/s3storage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
 

--- a/geowebcache/tms/pom.xml
+++ b/geowebcache/tms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/ve/pom.xml
+++ b/geowebcache/ve/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/wms/pom.xml
+++ b/geowebcache/wms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>

--- a/geowebcache/wmts/pom.xml
+++ b/geowebcache/wmts/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geowebcache</groupId>
     <artifactId>geowebcache</artifactId>
-    <version>1.21.1</version>
+    <version>1.21-SNAPSHOT</version>
     <!-- GWC VERSION -->
   </parent>
   <groupId>org.geowebcache</groupId>


### PR DESCRIPTION
The most recent release appears to have gotten the revert commit incorrect - I am sure it was operator error (and I was the person doing the release).

This PR combines reverting:

* https://github.com/GeoWebCache/geowebcache/commit/ec1d83f89f15f70367b7f7cb6fbba1678257f9ad - changing pom.xml version numbers
* https://github.com/GeoWebCache/geowebcache/commit/71d5827b2ad9c97fe1353e74d99cd8922262f7ac - changing some version numbers in docs and pom.xml

  Since this commit was a revert of https://github.com/GeoWebCache/geowebcache/commit/a1a2452df6f1cd06cba0f80d402e1375d106690a the net effect should be to restore docs and pom.xml to their 1.21-SNAPSHOT values

