### PR TITLE
Update to Java 11 as the minimum Java version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/checkout@v1
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,14 +6,14 @@ env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
 
 jobs:
-  openjdk8:
-    runs-on: [ubuntu-18.04]
+  openjdk11:
+    runs-on: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Maven repository caching
       uses: actions/cache@v1
       with:
@@ -27,14 +27,14 @@ jobs:
       run: |
         find .m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
 
-  openjdk11:
+  openjdk17:
     runs-on: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationXSchemaTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationXSchemaTest.java
@@ -86,7 +86,7 @@ public class XMLConfigurationXSchemaTest {
         EasyMock.expect(wac.getBeansOfType(XMLConfigurationProvider.class))
                 .andReturn(Collections.singletonMap("provider", provider));
         EasyMock.expect(wac.getBean("provider")).andReturn(provider);
-        final Capture<XStream> xsCap = new Capture<>();
+        final Capture<XStream> xsCap = EasyMock.newCapture();
         EasyMock.expect(provider.getConfiguredXStream(EasyMock.capture(xsCap)))
                 .andStubAnswer(
                         () -> {

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeedTaskTest.java
@@ -36,7 +36,9 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.io.Resource;
@@ -87,27 +89,28 @@ public class SeedTaskTest {
         WMSSourceHelper mockSourceHelper = EasyMock.createMock(WMSSourceHelper.class);
 
         final AtomicInteger wmsRequestsCounter = new AtomicInteger();
-        Capture<WMSMetaTile> wmsRequestsCapturer =
-                new Capture<WMSMetaTile>() {
-                    /** Override because setValue with anyTimes() resets the list of values */
+        Capture<WMSMetaTile> wmsRequestsCapturer = EasyMock.newCapture();
+        Capture<Resource> resourceCapturer = EasyMock.newCapture();
+
+        IAnswer<Void> answer =
+                new IAnswer<Void>() {
                     @Override
-                    public void setValue(WMSMetaTile o) {
+                    public Void answer() throws Throwable {
                         wmsRequestsCounter.incrementAndGet();
-                    }
-                };
-        Capture<Resource> resourceCapturer =
-                new Capture<Resource>() {
-                    @Override
-                    public void setValue(Resource target) {
                         try {
-                            target.transferFrom(
-                                    Channels.newChannel(new ByteArrayInputStream(fakeWMSResponse)));
+                            resourceCapturer
+                                    .getValue()
+                                    .transferFrom(
+                                            Channels.newChannel(
+                                                    new ByteArrayInputStream(fakeWMSResponse)));
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
+                        return null;
                     }
                 };
         mockSourceHelper.makeRequest(capture(wmsRequestsCapturer), capture(resourceCapturer));
+        expectLastCall().andAnswer(answer).anyTimes();
         mockSourceHelper.makeRequest(capture(wmsRequestsCapturer), capture(resourceCapturer));
         mockSourceHelper.makeRequest(capture(wmsRequestsCapturer), capture(resourceCapturer));
         mockSourceHelper.setConcurrency(32);
@@ -267,12 +270,7 @@ public class SeedTaskTest {
         // create an image to be returned by the mock WMSSourceHelper
         // / final byte[] fakeWMSResponse = createFakeSourceImage(tl);
         // WMSSourceHelper that on makeRequest() returns always the saqme fake image
-        WMSSourceHelper mockSourceHelper =
-                new MockWMSSourceHelper(); // EasyMock.createMock(WMSSourceHelper.class);
-        // expect(mockSourceHelper.makeRequest((WMSMetaTile)
-        // anyObject())).andReturn(fakeWMSResponse)
-        // .anyTimes();
-        // replay(mockSourceHelper);
+        WMSSourceHelper mockSourceHelper = new MockWMSSourceHelper();
         tl.setSourceHelper(mockSourceHelper);
 
         final String gridSetId = tl.getGridSubsets().iterator().next();
@@ -284,15 +282,9 @@ public class SeedTaskTest {
          * the TileObject the seeder requests it to store for further test validation
          */
         final StorageBroker mockStorageBroker = EasyMock.createMock(StorageBroker.class);
-        Capture<TileObject> storedObjects =
-                new Capture<TileObject>() {
-                    /** Override because setValue with anyTimes() resets the list of values */
-                    @Override
-                    public void setValue(TileObject o) {
-                        super.getValues().add(o);
-                    }
-                };
+        Capture<TileObject> storedObjects = EasyMock.newCapture(CaptureType.ALL);
         expect(mockStorageBroker.put(capture(storedObjects))).andReturn(true).anyTimes();
+
         expect(mockStorageBroker.get(anyObject())).andReturn(false).anyTimes();
         replay(mockStorageBroker);
 

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/AbstractBlobStoreTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testStoreTile() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache =
                 TileObject.createCompleteTileObject(
@@ -131,7 +131,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testStoreTilesInMultipleLayers() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache1 =
                 TileObject.createCompleteTileObject(
@@ -213,7 +213,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testDeleteTile() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache =
                 TileObject.createCompleteTileObject(
@@ -230,7 +230,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                 TileObject.createQueryTileObject(
                         "testLayer", new long[] {0L, 0L, 0L}, "testGridSet", "image/png", null);
 
-        Capture<Long> sizeCapture = new Capture<>();
+        Capture<Long> sizeCapture = EasyMock.newCapture();
         if (events) {
             listener.tileStored(
                     eq("testLayer"),
@@ -274,7 +274,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testUpdateTile() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache1 =
                 TileObject.createCompleteTileObject(
@@ -297,7 +297,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                 TileObject.createQueryTileObject(
                         "testLayer", new long[] {0L, 0L, 0L}, "testGridSet", "image/png", null);
 
-        Capture<Long> sizeCapture = new Capture<>();
+        Capture<Long> sizeCapture = EasyMock.newCapture();
         if (events) {
             listener.tileStored(
                     eq("testLayer"),
@@ -348,7 +348,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testGridsets() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache1 =
                 TileObject.createCompleteTileObject(
@@ -387,8 +387,8 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                 TileObject.createQueryTileObject(
                         "testLayer", new long[] {0L, 0L, 0L}, "testGridSet2", "image/png", null);
 
-        Capture<Long> sizeCapture1 = new Capture<>();
-        Capture<Long> sizeCapture2 = new Capture<>();
+        Capture<Long> sizeCapture1 = EasyMock.newCapture();
+        Capture<Long> sizeCapture2 = EasyMock.newCapture();
         if (events) {
             listener.tileStored(
                     eq("testLayer"),
@@ -471,7 +471,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testDeleteGridset() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         TileObject toCache1 =
                 TileObject.createCompleteTileObject(
@@ -590,7 +590,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testParameters() throws Exception {
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         Map<String, String> params1 = Collections.singletonMap("testKey", "testValue1");
         Map<String, String> params2 = Collections.singletonMap("testKey", "testValue2");
@@ -632,10 +632,10 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                 TileObject.createQueryTileObject(
                         "testLayer", new long[] {0L, 0L, 0L}, "testGridSet", "image/png", params2);
 
-        Capture<Long> sizeCapture1 = new Capture<>();
-        Capture<Long> sizeCapture2 = new Capture<>();
-        Capture<String> pidCapture1 = new Capture<>();
-        Capture<String> pidCapture2 = new Capture<>();
+        Capture<Long> sizeCapture1 = EasyMock.newCapture();
+        Capture<Long> sizeCapture2 = EasyMock.newCapture();
+        Capture<String> pidCapture1 = EasyMock.newCapture();
+        Capture<String> pidCapture2 = EasyMock.newCapture();
         if (events) {
             listener.tileStored(
                     eq("testLayer"),
@@ -855,7 +855,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                         "image/png",
                         params2,
                         new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         final long size1 = toCache1.getBlobSize();
         final long size2 = toCache2.getBlobSize();
@@ -972,7 +972,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testPurgeOrphans() throws Exception {
-        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        TileLayer layer = EasyMock.createNiceMock("layer", TileLayer.class);
         EasyMock.expect(layer.getName()).andStubReturn("testLayer");
         StringParameterFilter testFilter = new StringParameterFilter();
         testFilter.setDefaultValue("DEFAULT");
@@ -1001,7 +1001,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
                         "image/png",
                         params2,
                         new ByteArrayResource("7,8,9,10 test".getBytes(StandardCharsets.UTF_8)));
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
         final long size1 = toCache1.getBlobSize();
         final long size2 = toCache2.getBlobSize();
@@ -1136,7 +1136,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testPurgeOrphansWithDefault() throws Exception {
-        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        TileLayer layer = EasyMock.createNiceMock("layer", TileLayer.class);
         final String layerName = "testLayer";
         final String paramKey = "testKey";
 
@@ -1154,7 +1154,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
         String paramID2 = ParametersUtils.getId(params2);
         final String gridset = "testGridSet";
         final String format = "image/png";
-        BlobStoreListener listener = EasyMock.createMock(BlobStoreListener.class);
+        BlobStoreListener listener = EasyMock.createNiceMock(BlobStoreListener.class);
         store.addListener(listener);
 
         if (events) {
@@ -1210,7 +1210,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testDeleteRangeSingleLevel() throws StorageException {
-        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        TileLayer layer = EasyMock.createNiceMock("layer", TileLayer.class);
         final String layerName = "testLayer";
         EasyMock.expect(layer.getName()).andStubReturn(layerName);
         GridSet gridSet = new DefaultGridsets(true, false).worldEpsg4326();
@@ -1242,7 +1242,7 @@ public abstract class AbstractBlobStoreTest<TestClass extends BlobStore> {
 
     @Test
     public void testDeleteRangeMultiLevel() throws StorageException {
-        TileLayer layer = EasyMock.createMock("layer", TileLayer.class);
+        TileLayer layer = EasyMock.createNiceMock("layer", TileLayer.class);
         final String layerName = "testLayer";
         EasyMock.expect(layer.getName()).andStubReturn(layerName);
         GridSet gridSet = new DefaultGridsets(true, false).worldEpsg4326();

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.diskquota;
 
+import static org.easymock.EasyMock.newCapture;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -94,7 +95,7 @@ public class BDBQuotaStoreTest {
                 .anyTimes();
         EasyMock.replay(cacheDirFinder);
 
-        Capture<String> layerNameCap = new Capture<>();
+        Capture<String> layerNameCap = newCapture();
         storageBroker = EasyMock.createMock(StorageBroker.class);
         EasyMock.expect(storageBroker.getCachedParameterIds(EasyMock.capture(layerNameCap)))
                 .andStubAnswer(

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.diskquota.jdbc;
 
+import static org.easymock.EasyMock.newCapture;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -142,7 +143,7 @@ public abstract class JDBCQuotaStoreTest {
             extraConfig.afterPropertiesSet();
             layerDispatcher.afterPropertiesSet();
 
-            Capture<String> layerNameCap = new Capture<>();
+            Capture<String> layerNameCap = newCapture();
             storageBroker = EasyMock.createMock(StorageBroker.class);
             EasyMock.expect(storageBroker.getCachedParameterIds(EasyMock.capture(layerNameCap)))
                     .andStubAnswer(

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -93,7 +93,7 @@
     <lint>deprecation,unchecked</lint>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jclouds.version>2.3.0</jclouds.version>
-    <mockito.version>3.8.0</mockito.version>
+    <mockito.version>3.12.4</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -289,13 +289,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymockclassextension</artifactId>
-        <version>3.2</version>
+        <version>5.0.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -576,10 +570,10 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -610,7 +604,7 @@
             <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
-          <argLine>${maven.test.jvmargs} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=warn</argLine>
+          <argLine>${maven.test.jvmargs} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=warn --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED</argLine>
           <!-- prevent ForkedBooter focus steal on macOS -->
         </configuration>
       </plugin>
@@ -752,7 +746,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
+          <source>11</source>
           <version>false</version>
           <noqualifier>all</noqualifier>
           <maxmemory>256M</maxmemory>
@@ -846,11 +840,9 @@
       </build>
     </profile>
 
-    <!-- for those using JDK 11 -->
     <profile>
       <id>errorprone</id>
       <activation>
-        <jdk>(1.8,)</jdk>
         <property>
           <name>qa</name>
         </property>
@@ -881,42 +873,6 @@
       </build>
     </profile>
 
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-    <profile>
-      <id>errorprone8</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <property>
-          <name>qa</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
-            <configuration>
-              <fork>true</fork>
-              <compilerArgs combine.children="append">
-                <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:${project.build.directory}/generated-sources/.* ${errorProneFlags}</arg>
-                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
-                <arg>-Xlint:${lint}</arg>
-                <arg>-Werror</arg>
-              </compilerArgs>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>${errorProne.version}</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>spotbugs</id>
       <activation>
@@ -929,7 +885,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>3.1.10</version>
+            <version>4.0.0</version>
             <executions>
               <execution>
                 <goals>

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesConfigurationTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesConfigurationTest.java
@@ -18,6 +18,7 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.Matchers.is;
@@ -69,7 +70,7 @@ public class GetCapabilitiesConfigurationTest {
         req = createNiceMock(WMSRequest.class);
         gcOpType = createNiceMock(OperationType.class);
         globalConfig = createNiceMock(DefaultingConfiguration.class);
-        layerCapture = new Capture<>(CaptureType.LAST);
+        layerCapture = newCapture(CaptureType.LAST);
         broker = new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, false)));
 
         expect(server.getCapabilities()).andStubReturn(cap);


### PR DESCRIPTION
Mostly swicthes to Java 11 as the minimum. As part of that, an upgrade to latest EasyMock was required, which in turn stumbled into some behavioral changes, so some tests had to be modified to follow (mocks are not nice by default anymore when it comes to expectations, captures do not allow subclassing anymore). 