### PR TITLE
[GWC-1101] Upgrade Spring Core to 5.3.23

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
@@ -814,11 +814,13 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
             HttpEntity entity = httpResponse.getEntity();
             try (InputStream is = entity.getContent()) {
                 HttpServletResponse response = tile.servletResp;
-                Header contentEncoding = entity.getContentEncoding();
-                response.setCharacterEncoding(contentEncoding.getValue());
                 org.apache.http.Header contentType = httpResponse.getFirstHeader("Content-Type");
                 if (contentType != null) {
                     response.setContentType(contentType.getValue());
+                    Header contentEncoding = entity.getContentEncoding();
+                    if (!MimeType.isBinary(contentType.getValue())) {
+                        response.setCharacterEncoding(contentEncoding.getValue());
+                    }
                 }
 
                 int read = 0;

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java
@@ -16,6 +16,8 @@ package org.geowebcache.mime;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -70,6 +72,9 @@ public class ApplicationMime extends MimeType {
     static Set<ApplicationMime> ALL =
             ImmutableSet.of(bil16, bil32, json, topojson, geojson, utfgrid, mapboxVector);
 
+    private static final List<String> BINARY_FORMATS =
+            Arrays.asList(bil16.mimeType, bil32.mimeType, mapboxVector.mimeType, utfgrid.mimeType);
+
     private static Map<String, ApplicationMime> BY_FORMAT =
             Maps.uniqueIndex(ALL, mimeType -> mimeType.getFormat());
 
@@ -108,5 +113,10 @@ public class ApplicationMime extends MimeType {
     @Override
     public boolean isVector() {
         return vector;
+    }
+
+    @Override
+    protected boolean isBinary() {
+        return BINARY_FORMATS.contains(this.getMimeType());
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -232,6 +232,11 @@ public class ImageMime extends MimeType {
         return supportsAlphaChannel;
     }
 
+    @Override
+    protected boolean isBinary() {
+        return true;
+    }
+
     public ImageWriter getImageWriter(RenderedImage image) {
         Iterator<ImageWriter> it = javax.imageio.ImageIO.getImageWritersByFormatName(internalName);
         ImageWriter writer = it.next();

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/MimeType.java
@@ -45,6 +45,22 @@ public class MimeType {
         this.supportsTiling = supportsTiling;
     }
 
+    /**
+     * Checks if mime type is a binary type
+     *
+     * @param value mime type
+     * @return true if mime type is binary
+     * @throws MimeException if mime type is not supported
+     */
+    public static boolean isBinary(String value) throws MimeException {
+        MimeType mt = MimeType.createFromFormat(value);
+        return mt.isBinary();
+    }
+
+    protected boolean isBinary() {
+        return false;
+    }
+
     /** The MIME identifier string for this format. */
     public String getMimeType() {
         return mimeType;

--- a/geowebcache/core/src/test/java/org/geowebcache/mime/MimeTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/mime/MimeTest.java
@@ -1,0 +1,19 @@
+package org.geowebcache.mime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class MimeTest {
+    // Test that static binary check matches the instance method
+    @Test
+    public void testIsBinary() throws Exception {
+        assertTrue(MimeType.isBinary(ImageMime.png.mimeType));
+        assertFalse(MimeType.isBinary(XMLMime.gml.mimeType));
+        for (MimeType mt : ApplicationMime.ALL) {
+            assertEquals(mt.isBinary(), MimeType.isBinary(mt.mimeType));
+        }
+    }
+}

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -54,8 +54,8 @@
     <gt.version>29-SNAPSHOT</gt.version>
     <jts.version>1.19.0</jts.version>
     <jaiext.version>1.1.24</jaiext.version>
-    <spring.version>5.2.20.RELEASE</spring.version>
-    <spring.security.version>5.1.13.RELEASE</spring.security.version>
+    <spring.version>5.3.25</spring.version>
+    <spring.security.version>5.7.6</spring.security.version>
     <xstream.version>1.4.11.1</xstream.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/statistics/MemoryCacheControllerTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/statistics/MemoryCacheControllerTest.java
@@ -49,6 +49,9 @@ public class MemoryCacheControllerTest {
     MemoryCacheController mcc;
 
     @Before
+    @SuppressWarnings(
+            "deprecation") // setUseSuffixPatternMatch is deprecated because Spring wants to
+    // discourage extensions in paths
     public void setup() throws GeoWebCacheException {
         GridSetBroker gridSetBroker =
                 new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, false)));
@@ -57,7 +60,7 @@ public class MemoryCacheControllerTest {
         xmlConfig.afterPropertiesSet();
 
         mcc = new MemoryCacheController(null);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(mcc).build();
+        this.mockMvc = MockMvcBuilders.standaloneSetup(mcc).setUseSuffixPatternMatch(true).build();
     }
 
     @Test
@@ -73,7 +76,7 @@ public class MemoryCacheControllerTest {
         mbs.setCacheProvider(cache);
 
         this.mockMvc
-                .perform(get("/rest/statistics.xml").contextPath(""))
+                .perform(get("/rest/statistics").accept("application/xml").contextPath(""))
                 .andExpect(status().is2xxSuccessful());
     }
 
@@ -90,7 +93,7 @@ public class MemoryCacheControllerTest {
         mbs.setCacheProvider(cache);
 
         this.mockMvc
-                .perform(get("/rest/statistics.json").contextPath(""))
+                .perform(get("/rest/statistics").accept("application/json").contextPath(""))
                 .andExpect(status().is2xxSuccessful());
     }
 

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-rest-context.xml
@@ -7,7 +7,15 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
     http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.0.xsd">
 
-  <mvc:annotation-driven>
+  <bean id="antPathMatcher" class="org.springframework.util.AntPathMatcher" />
+  <bean id="contentNegotiationManager"
+        class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
+    <property name="favorPathExtension" value="true" />
+    <property name="favorParameter" value="false"/>
+    <property name="ignoreAcceptHeader" value="true" />
+  </bean>
+  <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
+    <mvc:path-matching suffix-pattern="true" path-matcher="antPathMatcher"/>
     <mvc:message-converters>
       <bean id="gwcConverter" class="org.geowebcache.rest.converter.GWCConverter">
         <constructor-arg ref="gwcAppCtx" />

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -748,7 +748,6 @@ public class WMSTileFuser {
 
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType(this.outputFormat.getMimeType());
-            response.setCharacterEncoding("UTF-8");
 
             @SuppressWarnings("PMD.CloseResource") // managed by servlet container
             ServletOutputStream os = response.getOutputStream();

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSRestTest.java
@@ -116,7 +116,7 @@ public class WMTSRestTest {
         MockHttpServletResponse resp = dispatch(req);
 
         assertEquals(200, resp.getStatus());
-        assertEquals("text/xml", resp.getContentType());
+        assertEquals("text/xml;charset=UTF-8", resp.getContentType());
         final Document doc = XMLUnit.buildTestDocument(resp.getContentAsString());
         assertXpathExists("//wmts:Contents/wmts:Layer", doc);
         assertXpathExists("//wmts:Contents/wmts:Layer[ows:Identifier='mockLayer']", doc);


### PR DESCRIPTION
[GWC-1101] Upgrade Spring Core to 5.3.23

restored tests

cleanup

more test fixes

mimetype is binary check for content type

Update geowebcache/core/src/main/java/org/geowebcache/mime/ApplicationMime.java

Co-authored-by: Andrea Aime <andrea.aime@gmail.com>

constant renaming