### PR TITLE
Add site index to main repo

### DIFF
--- a/documentation/en/index.html
+++ b/documentation/en/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  
+  <title>GeoWebCache</title>
+  <link rel="shortcut icon" href="_static/favicon.ico" type="image/x-icon" /> 
+  <link rel="stylesheet" href="_static/blueprint/screen.css" type="text/css" media="screen, projection" />
+  <!--[if IE]>
+  <link rel="stylesheet" href="_static/blueprint/ie.css" type="text/css" media="screen, projection" />
+  <![endif]-->
+  <link rel="stylesheet" href="_static/default.css" type="text/css" />
+
+      <link rel="top" title="GeoWebCache" href="" />
+</head>
+<body class="index">
+  <div id="header" class="selfclear">
+    <div class="wrap selfclear">
+      <div id="logo"><a href="">GeoWebCache</a></div>
+      <ul id="top-nav">
+        <li class="first"><a href="http://geowebcache.org">Homepage</a></li>
+        <li><a href="http://geowebcache.org/docs/current/">Documentation</a></li>
+      </ul>
+    </div><!-- /.wrap -->
+  </div><!-- /#header -->
+  <div id="main">
+    <div class="wrap selfclear">
+      <div id="content">
+
+        <div class="section" id="geowebcache">
+<h1>GeoWebCache</h1>
+
+<p>
+<strong>03 September 2015: <a href="http://sourceforge.net/projects/geowebcache/files/geowebcache/1.6.3/">GeoWebCache 1.6.3</a> released.</strong>
+</p>
+
+<p>
+<strong>21 July 2015: <a href="http://sourceforge.net/projects/geowebcache/files/geowebcache/1.7.2/">GeoWebCache 1.7.2</a> released.</strong>
+</p>
+<p>GWC 1.7.2 <a href="https://github.com/GeoWebCache/geowebcache/releases/tag/1.7.2">downloads</a> will be available from GitHub instead of 
+Sourceforge until the Sourceforge service issues have been resolved.</p>
+
+<p>GeoWebCache is a Java web application used to cache map tiles coming from a variety of sources such as OGC Web Map Service (WMS). It implements various service interfaces (such as WMS-C, WMTS, TMS, Google Maps KML, Virtual Earth) in order to accelerate and optimize map image delivery.  It can also recombine tiles to work with regular WMS clients.</p>
+
+<p>GeoWebCache is licensed under the <a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License (LGPL)</a>.</p>
+
+<p>Please use the links at the right to learn more.</p>
+        </div>
+
+      </div><!-- /#content> -->
+    <div id="sidebar">
+      <div class="section">
+        <h3>Links</h3>
+        <ul class="this-page-menu">
+          <li><a href="https://sourceforge.net/projects/geowebcache/files/geowebcache">Downloads</a></li>
+          <li><a href="http://gridlock.opengeo.org/geowebcache/">Nightly Builds</a></li>
+          <li><a href="http://github.com/GeoWebCache/geowebcache/">Source Code</a></li>
+          <li><a href="http://github.com/GeoWebCache/geowebcache/issues/">Issue Tracking</a></li>
+          <li><a href="http://geowebcache.org/docs/current/">Documentation</a></li>
+          <li><a href="http://geowebcache.org/schema">XML Schemas</a></li>
+          <li><a href="https://lists.sourceforge.net/lists/listinfo/geowebcache-users">Users mailing list</a></li>
+          <li><a href="https://lists.sourceforge.net/lists/listinfo/geowebcache-devel">Developers mailing list</a></li>
+        </ul>
+      </div>
+    </div><!-- /#sidebar -->
+  </div><!-- /.wrap> -->
+</div><!-- /#main -->
+<div id="footer">
+  <div class="wrap">
+    &copy; 2008-2015 GeoWebCache
+  </div><!-- /.wrap> -->
+</div><!-- /#footer -->
+  </body>
+</html>

--- a/documentation/en/index.html
+++ b/documentation/en/index.html
@@ -5,12 +5,12 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   
   <title>GeoWebCache</title>
-  <link rel="shortcut icon" href="_static/favicon.ico" type="image/x-icon" /> 
-  <link rel="stylesheet" href="_static/blueprint/screen.css" type="text/css" media="screen, projection" />
+  <link rel="shortcut icon" href="docs/main/_static/favicon.ico" type="image/x-icon" /> 
+  <link rel="stylesheet" href="docs/main/_static/blueprint/screen.css" type="text/css" media="screen, projection" />
   <!--[if IE]>
-  <link rel="stylesheet" href="_static/blueprint/ie.css" type="text/css" media="screen, projection" />
+  <link rel="stylesheet" href="docs/main/_static/blueprint/ie.css" type="text/css" media="screen, projection" />
   <![endif]-->
-  <link rel="stylesheet" href="_static/default.css" type="text/css" />
+  <link rel="stylesheet" href="docs/main/_static/default.css" type="text/css" />
 
       <link rel="top" title="GeoWebCache" href="" />
 </head>
@@ -19,8 +19,8 @@
     <div class="wrap selfclear">
       <div id="logo"><a href="">GeoWebCache</a></div>
       <ul id="top-nav">
-        <li class="first"><a href="http://geowebcache.org">Homepage</a></li>
-        <li><a href="http://geowebcache.org/docs/current/">Documentation</a></li>
+        <li class="first"><a href="https://geowebcache.osgeo.org">Homepage</a></li>
+        <li><a href="https://geowebcache.osgeo.org/docs/current/">Documentation</a></li>
       </ul>
     </div><!-- /.wrap -->
   </div><!-- /#header -->
@@ -30,16 +30,6 @@
 
         <div class="section" id="geowebcache">
 <h1>GeoWebCache</h1>
-
-<p>
-<strong>03 September 2015: <a href="http://sourceforge.net/projects/geowebcache/files/geowebcache/1.6.3/">GeoWebCache 1.6.3</a> released.</strong>
-</p>
-
-<p>
-<strong>21 July 2015: <a href="http://sourceforge.net/projects/geowebcache/files/geowebcache/1.7.2/">GeoWebCache 1.7.2</a> released.</strong>
-</p>
-<p>GWC 1.7.2 <a href="https://github.com/GeoWebCache/geowebcache/releases/tag/1.7.2">downloads</a> will be available from GitHub instead of 
-Sourceforge until the Sourceforge service issues have been resolved.</p>
 
 <p>GeoWebCache is a Java web application used to cache map tiles coming from a variety of sources such as OGC Web Map Service (WMS). It implements various service interfaces (such as WMS-C, WMTS, TMS, Google Maps KML, Virtual Earth) in order to accelerate and optimize map image delivery.  It can also recombine tiles to work with regular WMS clients.</p>
 
@@ -54,11 +44,10 @@ Sourceforge until the Sourceforge service issues have been resolved.</p>
         <h3>Links</h3>
         <ul class="this-page-menu">
           <li><a href="https://sourceforge.net/projects/geowebcache/files/geowebcache">Downloads</a></li>
-          <li><a href="http://gridlock.opengeo.org/geowebcache/">Nightly Builds</a></li>
-          <li><a href="http://github.com/GeoWebCache/geowebcache/">Source Code</a></li>
-          <li><a href="http://github.com/GeoWebCache/geowebcache/issues/">Issue Tracking</a></li>
-          <li><a href="http://geowebcache.org/docs/current/">Documentation</a></li>
-          <li><a href="http://geowebcache.org/schema">XML Schemas</a></li>
+          <li><a href="https://build.geoserver.org/view/geowebcache/">Nightly Builds</a></li>
+          <li><a href="https://github.com/GeoWebCache/geowebcache/">Source Code</a></li>
+          <li><a href="https://github.com/GeoWebCache/geowebcache/issues/">Issue Tracking</a></li>
+          <li><a href="https://geowebcache.osgeo.org/docs/current/">Documentation</a></li>
           <li><a href="https://lists.sourceforge.net/lists/listinfo/geowebcache-users">Users mailing list</a></li>
           <li><a href="https://lists.sourceforge.net/lists/listinfo/geowebcache-devel">Developers mailing list</a></li>
         </ul>
@@ -68,7 +57,7 @@ Sourceforge until the Sourceforge service issues have been resolved.</p>
 </div><!-- /#main -->
 <div id="footer">
   <div class="wrap">
-    &copy; 2008-2015 GeoWebCache
+    &copy; 2008-2023 GeoWebCache
   </div><!-- /.wrap> -->
 </div><!-- /#footer -->
   </body>


### PR DESCRIPTION
Fixes #1126

Adds index.html to documentation root, so that [geowebcache-main-live-docs](https://build.geoserver.org/view/geowebcache/job/geowebcache-main-live-docs/) can keep the homepage up-to-date
The doc build has been updated accordingly, so once this is merged, it should automatically push the new homepage (this does mean that if any docs get changed before this is merged, the docbuild will fail, although that's easy enough to fix).

I have made the following modifications to the homepage:

- Updated all links to the new geowebcache.osgeo.org domain
- Update stylesheet links to reference the main docs stylesheet
- Dropped the news section, since it wasn't getting updated
- (Temporarily) Dropped the schemas link. Once schemas are getting uploaded to the new site, this should be re-added. See also: #716, #760, #1134
- Updated the copyright date

I've split the import of index.html and the above changes into separate commits, so we can maintain some version history.
I expect some adjustments may be required after the first deploy - there's a few things I can't test until that happens.

Once we have confirmed this is working, https://github.com/GeoWebCache/geowebcache.github.io should probably be archived or deleted, since it is out-of-date, and not being updated.

