### PR TITLE
Geowebcache add hsql to disk quota make h2 optional

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <!-- logging -->

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
@@ -302,7 +302,10 @@ public class MetastoreRemover {
             // grab the connection
             return DriverManager.getConnection(jdbcString, username, password);
         } catch (ClassNotFoundException e) {
-            log.log(Level.WARNING, "Could not find the metastore driver, skipping migration");
+            Level logLevel = Level.WARNING;
+            if (getVariable(DefaultStorageFinder.GWC_METASTORE_DRIVER_CLASS, null) == null)
+                logLevel = Level.FINE;
+            log.log(logLevel, "Could not find the metastore driver, skipping migration", e);
             return null;
         } catch (SQLException e) {
             log.log(

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/MetastoreRemover.java
@@ -300,7 +300,7 @@ public class MetastoreRemover {
             // grab the connection
             return DriverManager.getConnection(jdbcString, username, password);
         } catch (ClassNotFoundException e) {
-            log.log(Level.WARNING, "Could not find the metastore driver, skipping migration", e);
+            log.log(Level.WARNING, "Could not find the metastore driver, skipping migration");
             return null;
         } catch (SQLException e) {
             log.log(

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
@@ -59,7 +59,7 @@ public class QuotaStoreProvider
     public void reloadQuotaStore() throws IOException, ConfigurationException {
         DiskQuotaConfig config = loader.loadConfig();
         // migrate existing H2 DB selection to HSQL DB
-        if(config.getQuotaStore().equals("H2")) {
+        if (config.getQuotaStore().equals("H2")) {
             config.setQuotaStore("HSQL");
             loader.saveConfig(config);
         }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
@@ -53,16 +53,21 @@ public class QuotaStoreProvider
 
     @Override
     public void afterPropertiesSet() throws Exception {
+        replaceH2WithHsql();
         reloadQuotaStore();
+    }
+
+    private void replaceH2WithHsql() throws IOException, ConfigurationException {
+        // migrate existing H2 DB selection to HSQL DB
+        DiskQuotaConfig config = loader.loadConfig();
+        if (config.getQuotaStore() != null && config.getQuotaStore().equals("H2")) {
+            config.setQuotaStore("HSQL");
+            loader.saveConfig(config);
+        }
     }
 
     public void reloadQuotaStore() throws IOException, ConfigurationException {
         DiskQuotaConfig config = loader.loadConfig();
-        // migrate existing H2 DB selection to HSQL DB
-        if (config.getQuotaStore().equals("H2")) {
-            config.setQuotaStore("HSQL");
-            loader.saveConfig(config);
-        }
         String quotaStoreName = config.getQuotaStore();
         if (quotaStoreName == null) {
             // the default quota store, for backwards compatibility

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java
@@ -55,6 +55,11 @@ public class QuotaStoreProvider
 
     public void reloadQuotaStore() throws IOException, ConfigurationException {
         DiskQuotaConfig config = loader.loadConfig();
+        // migrate existing H2 DB selection to HSQL DB
+        if(config.getQuotaStore().equals("H2")) {
+            config.setQuotaStore("HSQL");
+            loader.saveConfig(config);
+        }
         String quotaStoreName = config.getQuotaStore();
         if (quotaStoreName == null) {
             // the default quota store, for backwards compatibility

--- a/geowebcache/diskquota/jdbc/pom.xml
+++ b/geowebcache/diskquota/jdbc/pom.xml
@@ -28,6 +28,11 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
@@ -1,0 +1,157 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geowebcache.diskquota.jdbc;
+
+import java.util.Arrays;
+
+/**
+ * HSQL dialect for the quota store
+ *
+ * @author Can Mehteroglu - GeoSolutions
+ */
+public class HSQLDialect extends SQLDialect {
+    public HSQLDialect() {
+
+        TABLE_CREATION_MAP.put(
+                "TILESET",
+                Arrays.asList( //
+                        "CREATE TABLE ${schema}TILESET (\n"
+                                + //
+                                "  KEY VARCHAR("
+                                + TILESET_KEY_SIZE
+                                + ") PRIMARY KEY,\n"
+                                + //
+                                "  LAYER_NAME VARCHAR("
+                                + LAYER_NAME_SIZE
+                                + "),\n"
+                                + //
+                                "  GRIDSET_ID VARCHAR("
+                                + GRIDSET_ID_SIZE
+                                + "),\n"
+                                + //
+                                "  BLOB_FORMAT VARCHAR("
+                                + BLOB_FORMAT_SIZE
+                                + "),\n"
+                                + //
+                                "  PARAMETERS_ID VARCHAR("
+                                + PARAMETERS_ID_SIZE
+                                + "),\n"
+                                + //
+                                "  BYTES NUMERIC("
+                                + BYTES_SIZE
+                                + ") DEFAULT 0 NOT NULL\n"
+                                + //
+                                ")", //
+                        "CREATE INDEX TILESET_LAYER ON ${schema}TILESET(LAYER_NAME)" //
+                        ));
+
+        TABLE_CREATION_MAP.put(
+                "TILEPAGE",
+                Arrays.asList(
+                        "CREATE TABLE ${schema}TILEPAGE (\n"
+                                + //
+                                " KEY VARCHAR("
+                                + TILEPAGE_KEY_SIZE
+                                + ") PRIMARY KEY,\n"
+                                + //
+                                " TILESET_ID VARCHAR("
+                                + TILESET_KEY_SIZE
+                                + ") REFERENCES ${schema}TILESET(KEY) ON DELETE CASCADE,\n"
+                                + //
+                                " PAGE_Z SMALLINT,\n"
+                                + //
+                                " PAGE_X INTEGER,\n"
+                                + //
+                                " PAGE_Y INTEGER,\n"
+                                + //
+                                " CREATION_TIME_MINUTES INTEGER,\n"
+                                + //
+                                " FREQUENCY_OF_USE FLOAT,\n"
+                                + //
+                                " LAST_ACCESS_TIME_MINUTES INTEGER,\n"
+                                + //
+                                " FILL_FACTOR FLOAT,\n"
+                                + //
+                                " NUM_HITS NUMERIC("
+                                + NUM_HITS_SIZE
+                                + ")\n"
+                                + //
+                                ")", //
+                        "CREATE INDEX TILEPAGE_TILESET ON ${schema}TILEPAGE(TILESET_ID, FILL_FACTOR)",
+                        "CREATE INDEX TILEPAGE_FREQUENCY ON ${schema}TILEPAGE(FREQUENCY_OF_USE DESC)",
+                        "CREATE INDEX TILEPAGE_LAST_ACCESS ON ${schema}TILEPAGE(LAST_ACCESS_TIME_MINUTES DESC)"));
+    }
+
+    @Override
+    public String getCreateTileSetQuery(
+            String schema,
+            String keyParam,
+            String layerNameParam,
+            String gridSetIdParam,
+            String blobFormatParam,
+            String paramIdParam) {
+        StringBuilder sb = new StringBuilder("INSERT INTO ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILESET SELECT :").append(keyParam);
+        sb.append(", :").append(layerNameParam);
+        sb.append(", :").append(gridSetIdParam);
+        sb.append(", :").append(blobFormatParam);
+        sb.append(", :").append(paramIdParam);
+        sb.append(", 0 ");
+
+        // add this to try avoiding race conditions with other
+        // GWC instances doing parallel insertions
+        addEmtpyTableReference(sb);
+        sb.append(" FROM (VALUES(1)) AS dummy WHERE NOT EXISTS(SELECT 1 FROM ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILESET WHERE KEY = :").append(keyParam).append(")");
+
+        return sb.toString();
+    }
+
+    @Override
+    public String contionalTilePageInsertStatement(
+            String schema,
+            String keyParam,
+            String tileSetIdParam,
+            String zParam,
+            String xParam,
+            String yParam,
+            String creationParam,
+            String frequencyParam,
+            String lastAccessParam,
+            String fillFactorParam,
+            String numHitsParam) {
+        StringBuilder sb = new StringBuilder("INSERT INTO ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILEPAGE SELECT :").append(keyParam).append(", ");
+        sb.append(":").append(tileSetIdParam).append(", ");
+        sb.append(":").append(zParam).append(", ");
+        sb.append(":").append(xParam).append(", ");
+        sb.append(":").append(yParam).append(", ");
+        sb.append(":").append(creationParam).append(", ");
+        sb.append(":").append(frequencyParam).append(", ");
+        sb.append(":").append(lastAccessParam).append(", ");
+        sb.append(":").append(fillFactorParam).append(", ");
+        sb.append(":").append(numHitsParam).append(" ");
+
+        // add this to try avoiding race conditions with other
+        // GWC instances doing parallel insertions
+        addEmtpyTableReference(sb);
+        sb.append(" FROM (VALUES(1)) AS dummy WHERE NOT EXISTS(SELECT 1 FROM ");
+        if (schema != null) {
+            sb.append(schema).append(".");
+        }
+        sb.append("TILEPAGE WHERE KEY = :").append(keyParam).append(")");
+
+        return sb.toString();
+    }
+}

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
@@ -27,7 +27,7 @@ public class HSQLDialect extends SQLDialect {
         TABLE_CREATION_MAP.put(
                 "TILESET",
                 Arrays.asList( //
-                        "CREATE TABLE ${schema}TILESET (\n"
+                        "CREATE CACHED TABLE ${schema}TILESET (\n"
                                 + //
                                 "  KEY VARCHAR("
                                 + TILESET_KEY_SIZE
@@ -60,7 +60,7 @@ public class HSQLDialect extends SQLDialect {
         TABLE_CREATION_MAP.put(
                 "TILEPAGE",
                 Arrays.asList(
-                        "CREATE TABLE ${schema}TILEPAGE (\n"
+                        "CREATE CACHED TABLE ${schema}TILEPAGE (\n"
                                 + //
                                 " KEY VARCHAR("
                                 + TILEPAGE_KEY_SIZE

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/HSQLDialect.java
@@ -1,6 +1,16 @@
-/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Can Mehteroglu - GeoSolutions Copyright 2023
  */
 package org.geowebcache.diskquota.jdbc;
 

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
@@ -77,11 +77,14 @@ public class JDBCConfiguration implements Serializable {
             throws ConfigurationException {
         if (conf.getDialect() == null) {
             throw new ConfigurationException(
-                    "A dialect must be provided, possible values are H2, Oracle, PostgresSQL");
+                    "A dialect must be provided, possible values are H2, HSQL, Oracle, PostgresSQL");
         }
 
         ConnectionPoolConfiguration cp = conf.getConnectionPool();
-        if (conf.getJNDISource() == null && cp == null && !"H2".equals(conf.getDialect())) {
+        if (conf.getJNDISource() == null
+                && cp == null
+                && !"H2".equals(conf.getDialect())
+                && !"HSQL".equals(conf.getDialect())) {
             throw new ConfigurationException(
                     "No data source provided, either configure JNDISource or connectionPool");
         }

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -313,7 +313,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
         dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
         String database = new File(storeDirectory, "diskquota").getAbsolutePath();
-        dataSource.setUrl("jdbc:hsqldb:" + database + ";shutdown=true");
+        dataSource.setUrl("jdbc:hsqldb:file:" + database + ";shutdown=true");
         dataSource.setUsername("sa");
         dataSource.setPoolPreparedStatements(true);
         dataSource.setAccessToUnderlyingConnectionAllowed(true);

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -68,7 +68,9 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
     @Override
     public List<String> getSupportedStoreNames() {
-        var supportedStores = new ArrayList<>(List.of(HSQL_STORE, JDBC_STORE));
+        List<String> supportedStores = new ArrayList<String>();
+        supportedStores.add(HSQL_STORE);
+        supportedStores.add(JDBC_STORE);
         try {
             // check if H2 driver is in the classpath
             Class.forName("org.h2.Driver");

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -16,6 +16,7 @@ package org.geowebcache.diskquota.jdbc;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -40,7 +41,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 /**
- * Builds the quota store for the JDBC family (either H2 or JDBC)
+ * Builds the quota store for the JDBC family (either H2, HSQL or JDBC)
  *
  * @author Andrea Aime - GeoSolutions
  */
@@ -51,6 +52,8 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
     private static final String CONFIGURATION_FILE_NAME = "geowebcache-diskquota-jdbc.xml";
 
     public static final String H2_STORE = "H2";
+
+    public static final String HSQL_STORE = "HSQL";
 
     public static final String JDBC_STORE = "JDBC";
 
@@ -65,7 +68,15 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
     }
 
     public List<String> getSupportedStoreNames() {
-        return Arrays.asList(H2_STORE, JDBC_STORE);
+        var supportedStores = Arrays.asList(HSQL_STORE, JDBC_STORE);
+        try {
+            // check if H2 driver is in the classpath
+            Class.forName("org.h2.Driver");
+            supportedStores.add(H2_STORE);
+        } catch (Exception e) {
+            // don't add h2 when h2 driver is not there
+        }
+        return supportedStores;
     }
 
     public QuotaStore getQuotaStore(ApplicationContext ctx, String quotaStoreName)
@@ -78,6 +89,8 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
         if (H2_STORE.equals(quotaStoreName)) {
             return initializeH2Store(cacheDirFinder, tilePageCalculator);
+        } else if (HSQL_STORE.equals(quotaStoreName)) {
+            return initializeHSQLStore(cacheDirFinder, tilePageCalculator);
         } else if (JDBC_STORE.equals(quotaStoreName)) {
             return getJDBCStore(cacheDirFinder, tilePageCalculator);
         }
@@ -249,6 +262,23 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
         return store;
     }
 
+    private QuotaStore initializeHSQLStore(
+            DefaultStorageFinder cacheDirFinder, TilePageCalculator tilePageCalculator)
+            throws ConfigurationException {
+        // get a default data source located in the cache directory
+        DataSource ds = getHSQLDataSource(cacheDirFinder);
+
+        // build up the store
+        JDBCQuotaStore store = new JDBCQuotaStore(cacheDirFinder, tilePageCalculator);
+        store.setDataSource(ds);
+        store.setDialect(new HSQLDialect());
+
+        // initialize it
+        store.initialize();
+
+        return store;
+    }
+
     /** Prepares a simple data source for the embedded H2 */
     private DataSource getH2DataSource(DefaultStorageFinder cacheDirFinder)
             throws ConfigurationException {
@@ -260,6 +290,27 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
         dataSource.setDriverClassName("org.h2.Driver");
         String database = new File(storeDirectory, "diskquota").getAbsolutePath();
         dataSource.setUrl("jdbc:h2:" + database);
+        dataSource.setUsername("sa");
+        dataSource.setPoolPreparedStatements(true);
+        dataSource.setAccessToUnderlyingConnectionAllowed(true);
+        dataSource.setMinIdle(1);
+        dataSource.setMaxActive(-1); // boundless
+        dataSource.setMaxWait(5000);
+        return dataSource;
+    }
+
+    /** Prepares a simple data source for the embedded HSQL */
+    private DataSource getHSQLDataSource(DefaultStorageFinder cacheDirFinder)
+            throws ConfigurationException {
+        File storeDirectory =
+                new File(cacheDirFinder.getDefaultPath(), "diskquota_page_store_hsql");
+        storeDirectory.mkdirs();
+
+        BasicDataSource dataSource = new BasicDataSource();
+
+        dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+        String database = new File(storeDirectory, "diskquota").getAbsolutePath();
+        dataSource.setUrl("jdbc:hsqldb:" + database);
         dataSource.setUsername("sa");
         dataSource.setPoolPreparedStatements(true);
         dataSource.setAccessToUnderlyingConnectionAllowed(true);

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -68,7 +68,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
     @Override
     public List<String> getSupportedStoreNames() {
-        List<String> supportedStores = new ArrayList<String>();
+        List<String> supportedStores = new ArrayList<>();
         supportedStores.add(HSQL_STORE);
         supportedStores.add(JDBC_STORE);
         try {

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -18,7 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,7 +68,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
     @Override
     public List<String> getSupportedStoreNames() {
-        var supportedStores = Arrays.asList(HSQL_STORE, JDBC_STORE);
+        var supportedStores = new ArrayList<>(List.of(HSQL_STORE, JDBC_STORE));
         try {
             // check if H2 driver is in the classpath
             Class.forName("org.h2.Driver");

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -313,7 +313,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
         dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
         String database = new File(storeDirectory, "diskquota").getAbsolutePath();
-        dataSource.setUrl("jdbc:hsqldb:" + database);
+        dataSource.setUrl("jdbc:hsqldb:" + database + ";shutdown=true");
         dataSource.setUsername("sa");
         dataSource.setPoolPreparedStatements(true);
         dataSource.setAccessToUnderlyingConnectionAllowed(true);

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -16,7 +16,6 @@ package org.geowebcache.diskquota.jdbc;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -56,6 +56,10 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
     public static final String JDBC_STORE = "JDBC";
 
+    // this will be set to true only for integration tests
+    // not recommended for production usage
+    public static boolean ENABLE_HSQL_AUTO_SHUTDOWN = false;
+
     private ApplicationContext appContext;
 
     private ConfigurationResourceProvider defaultResourceProvider;
@@ -76,7 +80,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
             Class.forName("org.h2.Driver");
             supportedStores.add(H2_STORE);
         } catch (Exception e) {
-            // don't add h2 when h2 driver is not there
+            // don't add h2 when its driver is not there
         }
         return supportedStores;
     }
@@ -313,7 +317,10 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
 
         dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
         String database = new File(storeDirectory, "diskquota").getAbsolutePath();
-        dataSource.setUrl("jdbc:hsqldb:file:" + database + ";shutdown=true");
+        dataSource.setUrl(
+                "jdbc:hsqldb:file:"
+                        + database
+                        + (ENABLE_HSQL_AUTO_SHUTDOWN ? ";shutdown=true" : ""));
         dataSource.setUsername("sa");
         dataSource.setPoolPreparedStatements(true);
         dataSource.setAccessToUnderlyingConnectionAllowed(true);

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 
 public class HSQLQuotaStoreTest extends JDBCQuotaStoreTest {
 
+    @Override
     protected SQLDialect getDialect() {
         return new HSQLDialect();
     }

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
@@ -17,7 +17,7 @@ public class HSQLQuotaStoreTest extends JDBCQuotaStoreTest {
             protected Properties createOfflineFixture() {
                 Properties fixture = new Properties();
                 fixture.put("driver", "org.hsqldb.jdbcDriver");
-                fixture.put("url", "jdbc:hsqldb:file:./target/quota-hsql;shutdown=true");
+                fixture.put("url", "jdbc:hsqldb:file:./target/quota-hsql");
                 fixture.put("username", "sa");
                 fixture.put("password", "");
                 return fixture;

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
@@ -17,7 +17,7 @@ public class HSQLQuotaStoreTest extends JDBCQuotaStoreTest {
             protected Properties createOfflineFixture() {
                 Properties fixture = new Properties();
                 fixture.put("driver", "org.hsqldb.jdbcDriver");
-                fixture.put("url", "jdbc:hsqldb:./target/quota-hsql;shutdown=true");
+                fixture.put("url", "jdbc:hsqldb:file:./target/quota-hsql;shutdown=true");
                 fixture.put("username", "sa");
                 fixture.put("password", "");
                 return fixture;

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
@@ -1,0 +1,31 @@
+package org.geowebcache.diskquota.jdbc;
+
+import java.util.Properties;
+
+public class HSQLQuotaStoreTest extends JDBCQuotaStoreTest {
+
+    protected SQLDialect getDialect() {
+        return new HSQLDialect();
+    }
+
+    @Override
+    protected JDBCFixtureRule makeFixtureRule() {
+        return new JDBCFixtureRule(getFixtureId()) {
+
+            @Override
+            protected Properties createOfflineFixture() {
+                Properties fixture = new Properties();
+                fixture.put("driver", "org.hsqldb.jdbcDriver");
+                fixture.put("url", "jdbc:hsqldb:./target/quota-hsql");
+                fixture.put("username", "sa");
+                fixture.put("password", "");
+                return fixture;
+            }
+        };
+    }
+
+    @Override
+    protected String getFixtureId() {
+        return "hsql";
+    }
+}

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/HSQLQuotaStoreTest.java
@@ -17,7 +17,7 @@ public class HSQLQuotaStoreTest extends JDBCQuotaStoreTest {
             protected Properties createOfflineFixture() {
                 Properties fixture = new Properties();
                 fixture.put("driver", "org.hsqldb.jdbcDriver");
-                fixture.put("url", "jdbc:hsqldb:./target/quota-hsql");
+                fixture.put("url", "jdbc:hsqldb:./target/quota-hsql;shutdown=true");
                 fixture.put("username", "sa");
                 fixture.put("password", "");
                 return fixture;

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -67,6 +67,7 @@
     <jsr305.version>3.0.1</jsr305.version>
     <log4j.version>2.17.2</log4j.version>
     <h2.version>1.1.119</h2.version>
+    <hsql.version>2.7.1</hsql.version>
     <postgresql.version>42.4.3</postgresql.version>
     <oracle.version></oracle.version>
     <java.awt.headless>true</java.awt.headless>
@@ -414,6 +415,12 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hsqldb</groupId>
+        <artifactId>hsqldb</artifactId>
+        <version>${hsql.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Adds hsql db support to gwc.
Makes h2 optional and removes it from the war file.
Automatically replaces existing h2 configuration with hsql.

Note : when testing the changes running standalone gwc, -DGEOWEBCACHE_CONFIG_DIR must be set.