### PR TITLE
Fix a typo in logging file

### DIFF
--- a/geowebcache/web/src/main/resources/log4j2-rollingfile.xml
+++ b/geowebcache/web/src/main/resources/log4j2-rollingfile.xml
@@ -3,7 +3,7 @@
     <CustomLevels>
       <CustomLevel name="CONFIG" intLevel="450" />
       <CustomLevel name="FINEST" intLevel="700" />
-    </CustomLevels>>
+    </CustomLevels>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%date{dd MMM HH:mm:ss} (%t) %-6level [%logger{2}] - %msg%n%throwable"/>

--- a/geowebcache/web/src/main/resources/log4j2-rollingfile.xml
+++ b/geowebcache/web/src/main/resources/log4j2-rollingfile.xml
@@ -44,3 +44,4 @@
         </Root>
     </Loggers>
 </Configuration>
+


### PR DESCRIPTION
This removes a bad character which is causing logging not working using the content as logging configuration