### PR TITLE
[GEOT-7287] GeoTools API Change refactoring org.opengis to org.geotools.api

### DIFF
--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeometryRasterMaskBuilder.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeometryRasterMaskBuilder.java
@@ -23,21 +23,21 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.api.geometry.MismatchedDimensionException;
+import org.geotools.api.referencing.datum.PixelInCell;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.NoninvertibleTransformException;
+import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.coverage.grid.GridEnvelope2D;
-import org.geotools.geometry.Envelope2D;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.LiteShape;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.operation.builder.GridToEnvelopeMapper;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opengis.geometry.MismatchedDimensionException;
-import org.opengis.referencing.datum.PixelInCell;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.NoninvertibleTransformException;
-import org.opengis.referencing.operation.TransformException;
 
 /**
  * An object that builds a mask of tiles affected by geometries
@@ -222,7 +222,7 @@ public class GeometryRasterMaskBuilder {
         // Convert the JTS envelope and get the transform
         //
         // //
-        final Envelope2D genvelope = new Envelope2D();
+        final ReferencedEnvelope genvelope = new ReferencedEnvelope();
         {
             // genvelope.setCoordinateReferenceSystem(layerCrs);
             double x = coverageBounds.getMinX();

--- a/geowebcache/mbtiles/src/main/java/org/geowebcache/mbtiles/layer/MBTilesInfo.java
+++ b/geowebcache/mbtiles/src/main/java/org/geowebcache/mbtiles/layer/MBTilesInfo.java
@@ -24,6 +24,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.api.geometry.Bounds;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.mbtiles.MBTilesFile;
 import org.geotools.mbtiles.MBTilesMetadata;
@@ -32,10 +36,6 @@ import org.geotools.util.logging.Logging;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.layer.meta.TileJSON;
 import org.geowebcache.layer.meta.VectorLayerMetadata;
-import org.opengis.geometry.Envelope;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.TransformException;
 
 /** Info Object storing basic MBTiles Cached info */
 public class MBTilesInfo {
@@ -96,7 +96,7 @@ public class MBTilesInfo {
         minZoom = metadata.getMinZoom();
         maxZoom = metadata.getMaxZoom();
 
-        Envelope env = metadata.getBounds();
+        Bounds env = metadata.getBounds();
         ReferencedEnvelope envelope = null;
         if (env != null) {
             try {
@@ -122,7 +122,7 @@ public class MBTilesInfo {
         bounds = getBBoxFromEnvelope(envelope);
     }
 
-    private BoundingBox getBBoxFromEnvelope(Envelope envelope) {
+    private BoundingBox getBBoxFromEnvelope(Bounds envelope) {
         BoundingBox bbox = null;
         if (envelope != null) {
             bbox =


### PR DESCRIPTION
This changes covers GeoTools 30-SNAPSHOT API Change from ``org.opengis`` to ``org.geotools.api`` and resulting refactoring of the library.

This PR depends on https://github.com/geotools/geotools/pull/4367 and the availability of 30-SNAPSHOT.

See https://github.com/GeoWebCache/geowebcache/issues/1151