### PR TITLE
[GWC-1169] Upgrade OWASP Encoder from 1.1 to 1.2.3

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -220,7 +220,7 @@
     <dependency>
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
-      <version>1.1</version>
+      <version>1.2.3</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
https://github.com/GeoWebCache/geowebcache/issues/1169
This PR upgrades the OWASP Encoder dependency from 1.1 to 1.2.3.