### PR TITLE
Update ImageIO-EXT to 1.4.8 and JAI-EXT to 1.1.25

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -53,7 +53,7 @@
   <properties>
     <gt.version>31-SNAPSHOT</gt.version>
     <jts.version>1.19.0</jts.version>
-    <jaiext.version>1.1.24</jaiext.version>
+    <jaiext.version>1.1.25</jaiext.version>
     <spring.version>5.3.25</spring.version>
     <spring.security.version>5.7.6</spring.security.version>
     <xstream.version>1.4.20</xstream.version>
@@ -75,7 +75,7 @@
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs></maven.test.jvmargs>
-    <imageio-ext.version>1.4.7</imageio-ext.version>
+    <imageio-ext.version>1.4.8</imageio-ext.version>
     <hazelcast.version>5.3.1</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
     <spotless.action>apply</spotless.action>


### PR DESCRIPTION
To be merged along with:
- https://github.com/geoserver/geoserver/pull/7223
- https://github.com/geotools/geotools/pull/4529