### PR TITLE
Update TextMime.java

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/mime/TextMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/TextMime.java
@@ -52,7 +52,7 @@ public class TextMime extends MimeType {
                 return txtXml;
             } else if (formatStr.startsWith("text/css")) {
                 return txtCss;
-            } else if (formatStr.startsWith("text/javscript")) {
+            } else if (formatStr.startsWith("text/javascript")) {
                 return txtJs;
             }
         }


### PR DESCRIPTION
Correction of typo causing constant log outputs "Unsupported format request: text/javascript" while running in environment with Geoserver (currently 2.24.0)