### PR TITLE
[GWC-1198] Upgrade Hazelcast from 5.3.1 to 5.3.6

### DIFF
--- a/geowebcache/distributed/pom.xml
+++ b/geowebcache/distributed/pom.xml
@@ -30,6 +30,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+      <version>${gt.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastLoader.java
+++ b/geowebcache/distributed/src/main/java/org/geowebcache/storage/blobstore/memory/distributed/HazelcastLoader.java
@@ -29,6 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.springframework.beans.factory.InitializingBean;
 
 /**
@@ -53,6 +54,18 @@ public class HazelcastLoader implements InitializingBean {
 
     /** Hazelcast instance to pass to the {@link HazelcastCacheProvider} class */
     private HazelcastInstance instance;
+
+    // Disable Hazelcast's XXE protection if the XML libraries don't support JAXP 1.5
+    static {
+        if (System.getProperty("hazelcast.ignoreXxeProtectionFailures") == null) {
+            try {
+                XMLUtils.checkSupportForJAXP15Properties();
+            } catch (IllegalStateException e) {
+                LOGGER.warning("Disabling Hazelcast XXE protection because " + e.getMessage());
+                System.setProperty("hazelcast.ignoreXxeProtectionFailures", "true");
+            }
+        }
+    }
 
     @Override
     public void afterPropertiesSet() throws Exception {

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -76,7 +76,7 @@
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs></maven.test.jvmargs>
     <imageio-ext.version>1.4.9</imageio-ext.version>
-    <hazelcast.version>5.3.1</hazelcast.version>
+    <hazelcast.version>5.3.6</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
     <spotless.action>apply</spotless.action>
     <spotless.apply.skip>false</spotless.apply.skip>


### PR DESCRIPTION
This PR includes a dependency upgrade that contains security fixes and updates the modules using Hazelcast to work correctly after the last Hazelcast upgrade.

This PR must be backported to 1.24.x to fix an error caused by the last Hazelcast upgrade.

This PR is dependent on the GeoTools PR: https://github.com/geotools/geotools/pull/4579