### PR TITLE
[Backport 1.23.x] Bump com.google.guava:guava from 27.0-jre to 32.0.0-jre in /geowebcache

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -63,7 +63,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-text.version>1.4</commons-text.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
-    <guava.version>27.0-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>
     <log4j.version>2.17.2</log4j.version>
     <h2.version>1.1.119</h2.version>


### PR DESCRIPTION
Backport #1201
 **Authored by:** @dependabot[bot]