### PR TITLE
Allow building with QA on Java 17+

### DIFF
--- a/geowebcache/.mvn/jvm.config
+++ b/geowebcache/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -40,7 +40,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Proxy;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import org.geowebcache.storage.StorageException;
+import org.geowebcache.util.URLs;
 import org.springframework.http.HttpStatus;
 
 class AzureClient implements Closeable {
@@ -86,7 +86,7 @@ class AzureClient implements Closeable {
             PipelineOptions options = new PipelineOptions().withClient(client);
             ServiceURL serviceURL =
                     new ServiceURL(
-                            new URL(getServiceURL(configuration)),
+                            URLs.of(getServiceURL(configuration)),
                             StorageURL.createPipeline(creds, options));
 
             String containerName = configuration.getContainer();

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -88,6 +88,7 @@ import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.storage.UnsuitableStorageException;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.geowebcache.util.ExceptionUtils;
+import org.geowebcache.util.URLs;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -266,10 +267,10 @@ public class XMLConfiguration
             URL proxyUrl = null;
             try {
                 if (getGwcConfig().getProxyUrl() != null) {
-                    proxyUrl = new URL(getGwcConfig().getProxyUrl());
+                    proxyUrl = URLs.of(getGwcConfig().getProxyUrl());
                     log.fine("Using proxy " + proxyUrl.getHost() + ":" + proxyUrl.getPort());
                 } else if (wl.getProxyUrl() != null) {
-                    proxyUrl = new URL(wl.getProxyUrl());
+                    proxyUrl = URLs.of(wl.getProxyUrl());
                     log.fine("Using proxy " + proxyUrl.getHost() + ":" + proxyUrl.getPort());
                 }
             } catch (MalformedURLException e) {

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLOldGrid.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLOldGrid.java
@@ -22,6 +22,7 @@ import org.geowebcache.grid.GridSetFactory;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.grid.GridSubsetFactory;
 import org.geowebcache.grid.SRS;
+import org.geowebcache.util.SuppressFBWarnings;
 
 /**
  * This class exists mainly to parse the old XML objects using XStream
@@ -29,6 +30,11 @@ import org.geowebcache.grid.SRS;
  * <p>The problem is that it cannot use the GridSetBroker, so we end up with one GridSet per layer
  * anyway.
  */
+@SuppressFBWarnings({
+    "NP_UNWRITTEN_FIELD",
+    "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+    "UWF_NULL_FIELD"
+}) // field assignment done by XStream
 public class XMLOldGrid implements Serializable {
 
     private static final long serialVersionUID = 1413422643636728997L;

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/request/WMSRasterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/request/WMSRasterFilter.java
@@ -34,6 +34,7 @@ import org.geowebcache.layer.wms.WMSHttpHelper;
 import org.geowebcache.layer.wms.WMSLayer;
 import org.geowebcache.mime.ImageMime;
 import org.geowebcache.util.ServletUtils;
+import org.geowebcache.util.URLs;
 
 public class WMSRasterFilter extends RasterFilter {
 
@@ -110,7 +111,7 @@ public class WMSRasterFilter extends RasterFilter {
                         + ") , "
                         + urlStr);
 
-        URL wmsUrl = new URL(urlStr);
+        URL wmsUrl = URLs.of(urlStr);
 
         if (backendTimeout == null) {
             backendTimeout = 120;

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
@@ -113,7 +113,7 @@ public class TileLayerDispatcher
         }
         throw new GeoWebCacheException(
                 "Thread "
-                        + Thread.currentThread().getId()
+                        + Thread.currentThread().getName()
                         + " Unknown layer "
                         + layerName
                         + ". Check the logfiles,"

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -46,6 +46,7 @@ import org.geowebcache.service.ServiceException;
 import org.geowebcache.util.GWCVars;
 import org.geowebcache.util.HttpClientBuilder;
 import org.geowebcache.util.ServletUtils;
+import org.geowebcache.util.URLs;
 import org.springframework.util.Assert;
 
 /** This class is a wrapper for HTTP interaction with WMS backend */
@@ -115,7 +116,7 @@ public class WMSHttpHelper extends WMSSourceHelper {
             String requestUrl = layer.nextWmsURL();
 
             try {
-                wmsBackendUrl = new URL(requestUrl);
+                wmsBackendUrl = URLs.of(requestUrl);
             } catch (MalformedURLException maue) {
                 throw new GeoWebCacheException(
                         "Malformed URL: " + requestUrl + " " + maue.getMessage());

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
@@ -54,6 +54,7 @@ import org.geowebcache.mime.FormatModifier;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.mime.XMLMime;
 import org.geowebcache.util.GWCVars;
+import org.geowebcache.util.URLs;
 
 /** A tile layer backed by a WMS server */
 public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
@@ -803,9 +804,9 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
         try {
             URL url;
             if (serverStr.contains("?")) {
-                url = new URL(serverStr + "&" + queryStr);
+                url = URLs.of(serverStr + "&" + queryStr);
             } else {
-                url = new URL(serverStr + queryStr);
+                url = URLs.of(serverStr + queryStr);
             }
 
             WMSSourceHelper helper = getSourceHelper();

--- a/geowebcache/core/src/main/java/org/geowebcache/locks/NIOLockProvider.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/locks/NIOLockProvider.java
@@ -115,7 +115,7 @@ public class NIOLockProvider implements LockProvider {
                             "Lock "
                                     + lockKey
                                     + " acquired by thread "
-                                    + Thread.currentThread().getId()
+                                    + Thread.currentThread().getName()
                                     + " on file "
                                     + file);
                 }
@@ -151,7 +151,7 @@ public class NIOLockProvider implements LockProvider {
                                                     + " for releasing lock is unkonwn, it means "
                                                     + "this lock was never acquired, or was released twice. "
                                                     + "Current thread is: "
-                                                    + Thread.currentThread().getId()
+                                                    + Thread.currentThread().getName()
                                                     + ". "
                                                     + "Are you running two GWC instances in the same JVM using NIO locks? "
                                                     + "This case is not supported and will generate exactly this error message");
@@ -170,7 +170,7 @@ public class NIOLockProvider implements LockProvider {
                                                     + " on file "
                                                     + lockFile
                                                     + " released by thread "
-                                                    + Thread.currentThread().getId());
+                                                    + Thread.currentThread().getName());
                                 }
                             } catch (IOException e) {
                                 throw new GeoWebCacheException(

--- a/geowebcache/core/src/main/java/org/geowebcache/proxy/ProxyDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/proxy/ProxyDispatcher.java
@@ -22,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.util.URLs;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
 
@@ -62,7 +63,7 @@ public class ProxyDispatcher extends AbstractController {
         }
         String decodedUrl = URLDecoder.decode(urlStr, charEnc);
 
-        URL url = new URL(decodedUrl);
+        URL url = URLs.of(decodedUrl);
         HttpURLConnection wmsBackendCon = (HttpURLConnection) url.openConnection();
 
         if (wmsBackendCon.getContentEncoding() != null) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
@@ -103,7 +103,7 @@ public class BlobStoreAggregator {
                         () ->
                                 new GeoWebCacheException(
                                         "Thread "
-                                                + Thread.currentThread().getId()
+                                                + Thread.currentThread().getName()
                                                 + " Unknown blob store "
                                                 + blobStoreName
                                                 + ". Check the logfiles,"

--- a/geowebcache/core/src/main/java/org/geowebcache/util/URLs.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/URLs.java
@@ -1,0 +1,54 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Gabriel Roldan, Camptocamp, Copyright 2023
+ */
+package org.geowebcache.util;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/** Utilities for manipulating and converting to and from {@link URL}s. */
+public class URLs {
+
+    private URLs() {
+        // private constructor signaling this is a pure-utility class
+    }
+
+    /**
+     * Creates a {@code URL} object from the {@code String} representation.
+     *
+     * <p>Prefer this method to {@code new URL(String)}, which is <a
+     * href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#constructor-deprecation">deprecated
+     * in Java 21</a>.
+     *
+     * <p>Note a {@link URISyntaxException} will be rethrown as {@link MalformedURLException} to
+     * preserve the behavior of code that used to call {@code new URL(String)} and expected either a
+     * {@code MalformedURLException} or its super type {@code java.io.IOException}.
+     *
+     * @param url a URL string to build a {@link URL} from
+     * @return the URL built from the argument
+     * @throws MalformedURLException if {code}url{code} is not a valid {@link URI} nor a valid
+     *     {@link URL} as per {@link URI#toURL()}
+     */
+    public static URL of(String url) throws MalformedURLException {
+        try {
+            return new URI(url).toURL();
+        } catch (URISyntaxException orig) {
+            MalformedURLException e = new MalformedURLException(orig.getMessage());
+            e.initCause(orig);
+            throw e;
+        }
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
@@ -50,6 +50,7 @@ public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlob
     private void putLayerMetadataConcurrently(
             final int srcStoreKey, final FileBlobStore srcStore, int numberOfThreads)
             throws InterruptedException {
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
         for (int i = 0; i < numberOfThreads; i++) {
@@ -75,6 +76,7 @@ public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlob
 
     private void executeStoresConcurrently(int numberOfStores, int numberOfThreads)
             throws InterruptedException {
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService service = Executors.newFixedThreadPool(numberOfStores);
         CountDownLatch latch = new CountDownLatch(numberOfStores);
         for (int i = 0; i < numberOfStores; i++) {
@@ -106,6 +108,7 @@ public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlob
     public void testConcurrentMetadataWithPointInKey() throws InterruptedException {
         assertThat(store.getLayerMetadata("testLayer", "test.Key"), nullValue());
         int numberOfThreads = 2;
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
         for (int i = 0; i < numberOfThreads; i++) {

--- a/geowebcache/core/src/test/java/org/geowebcache/config/ConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/ConfigurationTest.java
@@ -345,6 +345,7 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
                 defaultCount + 10,
                 getInfoNames(config).size());
         // get a thread pool
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService pool =
                 Executors.newFixedThreadPool(
                         16, (Runnable r) -> new Thread(r, "Info Concurrency Test for ADD"));
@@ -389,6 +390,7 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
                 defaultCount + 100,
                 getInfoNames(config).size());
         // get a thread pool
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService pool =
                 Executors.newFixedThreadPool(
                         16, (Runnable r) -> new Thread(r, "Info Concurrency Test for DELETE"));
@@ -431,6 +433,7 @@ public abstract class ConfigurationTest<I extends Info, C extends BaseConfigurat
                 defaultCount + 100,
                 getInfoNames(config).size());
         // get a thread pool
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService pool =
                 Executors.newFixedThreadPool(
                         16, (Runnable r) -> new Thread(r, "Info Concurrency Test for MODIFY"));

--- a/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
@@ -27,6 +27,7 @@ import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.wms.WMSHttpHelper;
 import org.geowebcache.layer.wms.WMSLayer;
+import org.geowebcache.util.URLs;
 import org.junit.Test;
 
 public class DefaultingConfigurationTest {
@@ -111,9 +112,9 @@ public class DefaultingConfigurationTest {
                     URL proxyUrl = null;
                     try {
                         if (getGwcConfig().getProxyUrl() != null) {
-                            proxyUrl = new URL(getGwcConfig().getProxyUrl());
+                            proxyUrl = URLs.of(getGwcConfig().getProxyUrl());
                         } else if (wl.getProxyUrl() != null) {
-                            proxyUrl = new URL(wl.getProxyUrl());
+                            proxyUrl = URLs.of(wl.getProxyUrl());
                         }
                     } catch (MalformedURLException e) {
                     }

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
@@ -601,6 +601,7 @@ public class WMSLayerTest extends TileLayerTest {
         long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
 
         // six concurrent requests max
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService requests = Executors.newFixedThreadPool(6);
         ExecutorCompletionService<ConveyorTile> completer =
                 new ExecutorCompletionService<>(requests);

--- a/geowebcache/core/src/test/java/org/geowebcache/storage/TileRangeIteratorTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/storage/TileRangeIteratorTest.java
@@ -215,6 +215,7 @@ public class TileRangeIteratorTest {
             final int[] metaTilingFactors)
             throws Exception {
 
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         final ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
 
         final TileRange tileRange;

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
@@ -16,7 +16,6 @@ package org.geowebcache.diskquota.storage;
 
 import java.math.BigInteger;
 import java.text.NumberFormat;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import org.geowebcache.grid.GridSubset;
@@ -84,7 +83,7 @@ class PagePyramid {
 
         @Override
         public String toString() {
-            NumberFormat nf = NumberFormat.getInstance(new Locale("es"));
+            NumberFormat nf = NumberFormat.getInstance();
             nf.setGroupingUsed(true);
 
             return "Pages: "

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.logging.Logger;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.config.DefaultGridsets;
@@ -76,7 +75,7 @@ public class PagePyramidTest {
     }
 
     private void printPyramid(int zoomStart, int zoomStop, PagePyramid pp) {
-        NumberFormat nf = NumberFormat.getInstance(new Locale("es"));
+        NumberFormat nf = NumberFormat.getInstance();
         nf.setGroupingUsed(true);
 
         long totalPages = 0;

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
@@ -37,6 +37,7 @@ import org.geowebcache.seed.TileBreeder;
 import org.geowebcache.storage.DiscontinuousTileRange;
 import org.geowebcache.storage.RasterMask;
 import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.util.URLs;
 
 /**
  * A task to run a GeoRSS feed poll and launch the seeding process
@@ -128,7 +129,7 @@ class GeoRSSPollTask implements Runnable {
         final String previousUpdatedEntry = storageBroker.getLayerMetadata(layerName, LAST_UPDATED);
 
         final String gridSetId = pollDef.getGridSetId();
-        final URL feedUrl = new URL(templateFeedUrl(pollDef.getFeedUrl(), previousUpdatedEntry));
+        URL feedUrl = URLs.of(templateFeedUrl(pollDef.getFeedUrl(), previousUpdatedEntry));
         final String httpUsername = pollDef.getHttpUsername();
         final String httpPassword = pollDef.getHttpUsername();
 

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -892,7 +892,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.7.3.4</version>
+            <version>4.8.2.0</version>
             <executions>
               <execution>
                 <goals>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -86,7 +86,7 @@
     <jackson.databind.version>2.15.2</jackson.databind.version>
     <jetty.version>9.4.33.v20201020</jetty.version>
     <errorProneFlags></errorProneFlags>
-    <errorProne.version>2.18.0</errorProne.version>
+    <errorProne.version>2.24.1</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
     <pmd.version>6.55.0</pmd.version>
     <checkstyle.skip>false</checkstyle.skip>

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqliteConnectionManagerTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqliteConnectionManagerTest.java
@@ -161,6 +161,7 @@ public final class SqliteConnectionManagerTest extends TestSupport {
             int threadsNumber, int workersNumber, long poolSize, File... files) throws Exception {
         SqliteConnectionManager connectionManager = new SqliteConnectionManager(poolSize, 10);
         connectionManagersToClean.add(connectionManager);
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService executor = Executors.newFixedThreadPool(threadsNumber);
         Random random = new Random();
         List<Future<Tuple<File, String>>> results = new ArrayList<>();

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqlitlePerf.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqlitlePerf.java
@@ -80,6 +80,7 @@ final class SqlitlePerf {
         }
         FileUtils.copyFile(seedFile, databaseFile);
         // submitting the select tasks
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
         long startTime = System.currentTimeMillis();
         try (Connection connection =
@@ -124,6 +125,7 @@ final class SqlitlePerf {
         }
         FileUtils.copyFile(seedFile, databaseFile);
         // submitting the select tasks
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
         SqliteConnectionManager connectionManager = new SqliteConnectionManager(10, 2000);
         long startTime = System.currentTimeMillis();
@@ -179,6 +181,7 @@ final class SqlitlePerf {
         }
         FileUtils.copyFile(seedFile, databaseFile);
         // submitting the select tasks
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
         long startTime = System.currentTimeMillis();
         // mbtiles store configuration
@@ -240,6 +243,7 @@ final class SqlitlePerf {
             LOGGER.info(String.format("Start reading from directory'%s'.", seedDirectory));
         }
         // submitting the read tasks
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
         long startTime = System.currentTimeMillis();
         // instantiate the file blobstore

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -696,6 +696,7 @@ public class SwiftBlobStoreTest {
     @Ignore // unreliable test timing
     public void deleteWhenUploadExists() throws Exception {
         BlockingQueue<Runnable> taskQueue = spy(new LinkedBlockingQueue<>(1000));
+        @SuppressWarnings("PMD.CloseResource") // implements AutoCloseable in Java 21
         ThreadPoolExecutor executor =
                 spy(
                         new ThreadPoolExecutor(

--- a/geowebcache/wms/src/main/java/org/geowebcache/config/wms/GetCapabilitiesConfiguration.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/config/wms/GetCapabilitiesConfiguration.java
@@ -16,7 +16,6 @@ package org.geowebcache.config.wms;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,6 +69,7 @@ import org.geowebcache.layer.meta.LayerMetaInformation;
 import org.geowebcache.layer.meta.MetadataURL;
 import org.geowebcache.layer.wms.WMSHttpHelper;
 import org.geowebcache.layer.wms.WMSLayer;
+import org.geowebcache.util.URLs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -521,7 +521,7 @@ public class GetCapabilitiesConfiguration implements TileLayerConfiguration, Gri
     WebMapServer getWMS() throws IOException, ServiceException {
         Map<String, Object> hints = new HashMap<>();
         hints.put(XMLHandlerHints.ENTITY_RESOLVER, PreventLocalEntityResolver.INSTANCE);
-        return new WebMapServer(new URL(url), HTTPClientFinder.createClient(), hints);
+        return new WebMapServer(URLs.of(url), HTTPClientFinder.createClient(), hints);
     }
 
     private String parseVersion(String url) {

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesConfigurationTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesConfigurationTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.Sets;
-import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -49,6 +48,7 @@ import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.wms.WMSLayer;
+import org.geowebcache.util.URLs;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +78,7 @@ public class GetCapabilitiesConfigurationTest {
         expect(req.getGetCapabilities()).andStubReturn(gcOpType);
         expect(gcOpType.getGet())
                 .andStubReturn(
-                        new URL(
+                        URLs.of(
                                 "http://test/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities"));
         expect(cap.getVersion()).andStubReturn("1.1.1");
     }
@@ -215,7 +215,7 @@ public class GetCapabilitiesConfigurationTest {
         expect(req.getGetCapabilities()).andStubReturn(gcOpType);
         expect(gcOpType.getGet())
                 .andStubReturn(
-                        new URL(
+                        URLs.of(
                                 "http://test/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities"));
 
         expect(cap.getVersion()).andStubReturn("1.1.1");

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesGridSetConfigurationConformanceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesGridSetConfigurationConformanceTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.base.Objects;
-import java.net.URL;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,6 +40,7 @@ import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
+import org.geowebcache.util.URLs;
 import org.hamcrest.CustomMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Assume;
@@ -97,7 +97,7 @@ public class GetCapabilitiesGridSetConfigurationConformanceTest extends GridSetC
         expect(req.getGetCapabilities()).andStubReturn(gcOpType);
         expect(gcOpType.getGet())
                 .andStubReturn(
-                        new URL(
+                        URLs.of(
                                 "http://test/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities"));
         expect(cap.getVersion()).andStubReturn("1.1.1");
         EasyMock.replay(server, cap, req, gcOpType, globalConfig);

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesLayerConfigurationConformanceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesLayerConfigurationConformanceTest.java
@@ -19,7 +19,6 @@ import static org.easymock.EasyMock.expect;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +37,7 @@ import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubsetFactory;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.wms.WMSLayer;
+import org.geowebcache.util.URLs;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
@@ -120,7 +120,7 @@ public class GetCapabilitiesLayerConfigurationConformanceTest extends LayerConfi
         expect(req.getGetCapabilities()).andStubReturn(gcOpType);
         expect(gcOpType.getGet())
                 .andStubReturn(
-                        new URL(
+                        URLs.of(
                                 "http://test/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities"));
         expect(cap.getVersion()).andStubReturn("1.1.1");
         EasyMock.replay(server, cap, req, gcOpType, globalConfig);

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -85,6 +85,7 @@ import org.geowebcache.service.OWSException;
 import org.geowebcache.stats.RuntimeStats;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.util.NullURLMangler;
+import org.geowebcache.util.URLs;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -358,7 +359,7 @@ public class WMTSServiceTest {
             // add some layer metadata
             MetadataURL metadataURL =
                     new MetadataURL(
-                            "some-type", "some-format", new URL("http://localhost:8080/some-url"));
+                            "some-type", "some-format", URLs.of("http://localhost:8080/some-url"));
             when(tileLayer.getMetadataURLs()).thenReturn(Collections.singletonList(metadataURL));
         }
 


### PR DESCRIPTION
Running `mvn ... -Dqa` with Java 17/21 breaks errorprone, as in:

```
[INFO] --- compiler:3.8.0:compile (default-compile) @ gwc-core ---
[INFO] Compiling 201 source files to /home/groldan/git/geowebcache/geowebcache/core/target/classes
An exception has occurred in the compiler (17.0.8). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.IllegalAccessError: class com.google.errorprone.BaseErrorProneJavaCompiler (in unnamed module @0x3d3e9163) cannot access class com.sun.tools.javac.api.BasicJavacTask (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.api to unnamed module @0x3d3e9163
        at com.google.errorprone.BaseErrorProneJavaCompiler.addTaskListener(BaseErrorProneJavaCompiler.java:95)
...
````

Fixed with:

* Update errorProne.version: `2.18.0` -> `2.24.1`
* Add `geowebcache/.mvn/jvm.config` with the required `--add-exports` for the `maven-compiler-plugin` as explained at https://errorprone.info/docs/installation#jdk-16.

---

## Fixes to build with Java 21:

* `Thread.getId()` is deprecated. Since it's only used for reporting  errors, use `Thread.getName()` instead
* `new URL(String)` is deprecated. Use `new URI(String).toURL()`  instead, throwing `MalformedURLException` to preserve the old  behavior in methods that throw `IOException`. This is centralized in the new utility class/method `org.geowebcache.util.URLs.of(String url)`
* `ExecutorService` implements `AutoCloseable` in Java 21, add  `@SuppressWarnings("PMD.CloseResource")` in the test classes that use it
* Add `@SuppressFBWarnings` for new rules related to POJO fields unset/null, when they're assigned using reflection by XStream
