### PR TITLE
[Backport 1.24.x] Bump org.springframework.security:spring-security-config from 5.7.10 to 5.7.11 in /geowebcache

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -55,7 +55,7 @@
     <jts.version>1.19.0</jts.version>
     <jaiext.version>1.1.24</jaiext.version>
     <spring.version>5.3.25</spring.version>
-    <spring.security.version>5.7.10</spring.security.version>
+    <spring.security.version>5.7.11</spring.security.version>
     <xstream.version>1.4.20</xstream.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>


### PR DESCRIPTION
Backport #1217
 **Authored by:** @dependabot[bot]