### PR TITLE
[Backport 1.23.x] Bump org.postgresql:postgresql from 42.4.3 to 42.7.2 in /geowebcache

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -68,7 +68,7 @@
     <log4j.version>2.17.2</log4j.version>
     <h2.version>1.1.119</h2.version>
     <hsql.version>2.7.1</hsql.version>
-    <postgresql.version>42.4.3</postgresql.version>
+    <postgresql.version>42.7.2</postgresql.version>
     <oracle.version></oracle.version>
     <java.awt.headless>true</java.awt.headless>
     <jalopy.phase>disabled</jalopy.phase>


### PR DESCRIPTION
Backport #1221
 **Authored by:** @dependabot[bot]