### PR TITLE
[GWC-1233] Refactor inline JavaScript in the Seed Controller

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/ServletUtils.java
@@ -354,12 +354,22 @@ public class ServletUtils {
     }
 
     public static String gwcHtmlHeader(String relBasePath, String pageTitle) {
+        return gwcHtmlHeader(relBasePath, pageTitle, null);
+    }
+
+    public static String gwcHtmlHeader(String relBasePath, String pageTitle, String jsFile) {
         StringBuilder builder = new StringBuilder();
         builder.append("<head>\n");
         builder.append("<title>").append(pageTitle).append("</title>\n");
         builder.append("<link rel=\"stylesheet\" href=\"")
                 .append(relBasePath)
                 .append("rest/web/gwc.css\" type=\"text/css\"/>\n");
+        if (jsFile != null) {
+            builder.append("<script src=\"")
+                    .append(relBasePath)
+                    .append(jsFile)
+                    .append("\"></script>\n");
+        }
         builder.append("</head>\n");
         return builder.toString();
     }

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
@@ -650,7 +650,7 @@ public class FormService {
     private void makeHeader(StringBuilder doc) {
         doc.append(
                 "<html>\n"
-                        + ServletUtils.gwcHtmlHeader("../../", "GWC Seed Form")
+                        + ServletUtils.gwcHtmlHeader("../../", "GWC Seed Form", "rest/web/seed.js")
                         + "<body>\n"
                         + ServletUtils.gwcHtmlLogoLink("../../"));
     }
@@ -824,7 +824,7 @@ public class FormService {
                 .append(escapeHtml4(layerName))
                 .append("\" method=\"post\">\n");
         doc.append("List ");
-        doc.append("<select name=\"list\" onchange=\"this.form.submit();\">\n");
+        doc.append("<select name=\"list\">\n");
         doc.append("<option value=\"layer\"")
                 .append(listAll ? "" : " selected")
                 .append(">this Layer tasks</option>\n");

--- a/geowebcache/rest/src/main/resources/org/geowebcache/rest/webresources/seed.js
+++ b/geowebcache/rest/src/main/resources/org/geowebcache/rest/webresources/seed.js
@@ -1,0 +1,6 @@
+
+window.onload = function() {
+    document.getElementById('list').list.onchange = function() {
+        document.getElementById('list').submit();
+    };
+};

--- a/geowebcache/rest/src/test/java/org/geowebcache/rest/service/FormServiceTest.java
+++ b/geowebcache/rest/src/test/java/org/geowebcache/rest/service/FormServiceTest.java
@@ -18,12 +18,12 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -98,6 +98,24 @@ public class FormServiceTest {
         assertThat(body, containsString(escapedString));
         assertThat(body, not(containsString(unescapedRegex)));
         assertThat(body, containsString(escapedRegex));
+    }
+
+    @Test
+    public void testRemovedInlineJavaScript() throws Exception {
+        TileLayer tl = EasyMock.createMock("tl", TileLayer.class);
+        expect(breeder.findTileLayer("testLayer")).andReturn(tl);
+        expect(tl.getName()).andStubReturn("testLayer");
+        expect(breeder.getRunningAndPendingTasks()).andReturn(Collections.emptyIterator()).times(2);
+        expect(tl.getGridSubsets()).andReturn(Collections.emptySet()).times(4);
+        expect(tl.getMimeTypes()).andReturn(Collections.emptyList());
+        expect(tl.getParameterFilters()).andReturn(Collections.emptyList());
+        replay(tl, breeder);
+        ResponseEntity<?> response = service.handleGet(null, "testLayer");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        String body = (String) response.getBody();
+        assertThat(body, containsString("<script src=\"../../rest/web/seed.js\"></script>"));
+        assertThat(body, not(containsString(" onchange=")));
     }
 
     @Test


### PR DESCRIPTION
This PR moves the inline JavaScript in the Seed Controller into an external file. See https://github.com/GeoWebCache/geowebcache/issues/1233 for more information. This PR is related to Content-Security-Policy work for GeoServer 2.26.0 and should **NOT** be backported.