### PR TITLE
[Backport 1.24.x] Avoid infinite number of calls to listBlobs when doing prefix removals (e..g, gridset or layer removals)

### DIFF
--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureBlobStore.java
@@ -67,7 +67,7 @@ public class AzureBlobStore implements BlobStore {
     private final TMSKeyBuilder keyBuilder;
     private final BlobStoreListenerList listeners = new BlobStoreListenerList();
     private final AzureClient client;
-    private DeleteManager deleteManager;
+    DeleteManager deleteManager;
 
     private volatile boolean shutDown = false;
 
@@ -200,7 +200,7 @@ public class AzureBlobStore implements BlobStore {
     @Override
     public boolean delete(TileRange tileRange) throws StorageException {
         // see if there is anything to delete in that range by computing a prefix
-        final String coordsPrefix = keyBuilder.coordinatesPrefix(tileRange, true);
+        final String coordsPrefix = keyBuilder.coordinatesPrefix(tileRange, false);
         if (client.listBlobs(coordsPrefix, 1).isEmpty()) {
             return false;
         }

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -94,14 +94,17 @@ class AzureClient implements Closeable {
             // no way to see if the containerURL already exists, try to create and see if
             // we get a 409 CONFLICT
             try {
-                int status = this.container.create(null, null, null).blockingGet().statusCode();
-                if (!HttpStatus.valueOf(status).is2xxSuccessful()
-                        && status != HttpStatus.CONFLICT.value()) {
-                    throw new StorageException(
-                            "Failed to create container "
-                                    + containerName
-                                    + ", REST API returned a "
-                                    + status);
+                int status = this.container.getProperties().blockingGet().statusCode();
+                if (status == HttpStatus.NOT_FOUND.value()) {
+                    status = this.container.create(null, null, null).blockingGet().statusCode();
+                    if (!HttpStatus.valueOf(status).is2xxSuccessful()
+                            && status != HttpStatus.CONFLICT.value()) {
+                        throw new StorageException(
+                                "Failed to create container "
+                                        + containerName
+                                        + ", REST API returned a "
+                                        + status);
+                    }
                 }
             } catch (RestException e) {
                 if (e.response().statusCode() != HttpStatus.CONFLICT.value()) {

--- a/geowebcache/core/src/main/java/org/geowebcache/util/TMSKeyBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/util/TMSKeyBuilder.java
@@ -39,6 +39,7 @@ public final class TMSKeyBuilder {
     public static final String LAYER_METADATA_OBJECT_NAME = "metadata.properties";
     public static final String PARAMETERS_METADATA_OBJECT_PREFIX = "parameters-";
     public static final String PARAMETERS_METADATA_OBJECT_SUFFIX = ".properties";
+    public static final String PENDING_DELETES = "_pending_deletes.properties";
 
     private String prefix;
 
@@ -220,7 +221,8 @@ public final class TMSKeyBuilder {
     }
 
     public String pendingDeletes() {
-        return String.format("%s/%s", prefix, "_pending_deletes.properties");
+        if (!Strings.isNullOrEmpty(prefix)) return String.format("%s/%s", prefix, PENDING_DELETES);
+        else return PENDING_DELETES;
     }
 
     private static String join(boolean closing, Object... elements) {


### PR DESCRIPTION
Backport #1232
 **Authored by:** @aaime