### PR TITLE
[GWC-1242] Upgrade commons-io from 2.12.0 to 2.16.1

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -57,7 +57,7 @@
     <spring.version>5.3.34</spring.version>
     <spring.security.version>5.7.12</spring.security.version>
     <xstream.version>1.4.20</xstream.version>
-    <commons-io.version>2.12.0</commons-io.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-collections.version>4.2</commons-collections.version>
     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION
https://github.com/GeoWebCache/geowebcache/issues/1242
This PR is just a regular dependency upgrade.