### PR TITLE
[GWC-1261] Upgrade commons-text from 1.4 to 1.12.0

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -61,7 +61,7 @@
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-collections.version>4.4</commons-collections.version>
     <commons-codec.version>1.10</commons-codec.version>
-    <commons-text.version>1.4</commons-text.version>
+    <commons-text.version>1.12.0</commons-text.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <guava.version>33.2.0-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>


### PR DESCRIPTION
https://github.com/GeoWebCache/geowebcache/issues/1261
This PR is just a regular dependency upgrade.