### PR TITLE
[GWC-1266] Upgrade jackson from 2.15.2 to 2.17.1

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -82,8 +82,8 @@
     <spotless.apply.skip>false</spotless.apply.skip>
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${spotless.apply.skip}</pom.fmt.skip>
-    <jackson.version>2.15.2</jackson.version>
-    <jackson.databind.version>2.15.2</jackson.databind.version>
+    <jackson.version>2.17.1</jackson.version>
+    <jackson.databind.version>${jackson.version}</jackson.databind.version>
     <jetty.version>9.4.33.v20201020</jetty.version>
     <errorProneFlags></errorProneFlags>
     <errorProne.version>2.24.1</errorProne.version>


### PR DESCRIPTION
https://github.com/GeoWebCache/geowebcache/issues/1266
This PR is just a regular dependency upgrade.