### PR TITLE
Preemptively send authentication credentials in WMSHttpHelper

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -30,11 +30,14 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthenticationException;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.message.BasicNameValuePair;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.GeoWebCacheException;
@@ -337,6 +340,16 @@ public class WMSHttpHelper extends WMSSourceHelper {
                 }
             }
             method = new HttpGet(urlString);
+        }
+
+        if (httpUsername != null) {
+            try {
+                UsernamePasswordCredentials creds =
+                        new UsernamePasswordCredentials(httpUsername, httpPassword);
+                method.addHeader(new BasicScheme().authenticate(creds, method, null));
+            } catch (AuthenticationException e) {
+                throw new AssertionError("BasicScheme threw: " + e.getMessage());
+            }
         }
 
         // fire!


### PR DESCRIPTION
While trying to cache a WMS layer from another GeoServer instance that requires authentication, I noticed that GeoWebCache didn't manage to perform any successful requests to that upstream GeoServer.

While digging into that issue, I noticed that httpcomponents will only send credentials when challenged by the server.
Since that GeoServer had publicly available layers, it would just respond with 404 instead of 401, so `WMSHttpHelper` wouldn't try it again with credentials.

Before moving from commons-httpclient to httpcomponents in 8beede1, `WMSHttpHelper` was sending authentication credentials preemptively. This behaviour changed after the move.

In fact, httpcomponents doesn't seem to have any mechanism to force preemptive authentication except for explicitly setting the Authorization header. So that's exactly what this PR does.

Just as a side note, `BasicScheme.authenticate` doesn't actually ever throw `AuthenticationException`, that's why it's re-thrown as an `AssertionError` here.
