### PR TITLE
[GWC-1290] Upgrade commons-codec from 1.17.0 to 1.17.1

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -60,7 +60,7 @@
     <commons-io.version>2.16.1</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-collections.version>4.4</commons-collections.version>
-    <commons-codec.version>1.17.0</commons-codec.version>
+    <commons-codec.version>1.17.1</commons-codec.version>
     <commons-text.version>1.12.0</commons-text.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <guava.version>33.2.0-jre</guava.version>


### PR DESCRIPTION
https://github.com/GeoWebCache/geowebcache/issues/1290
This is just a regular dependency upgrade.