### PR TITLE
Support numeric grid names in vector tiles preview

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.filter.parameters.FloatParameterFilter;
@@ -342,6 +343,12 @@ public class Demo {
                 Arrays.stream(gridSubset.getGridNames())
                         .map(s -> String.format("\"%s\"", s))
                         .collect(Collectors.joining(", ", "[", "]")));
+        makeHiddenInput(
+                buf,
+                "gridNamesNumeric",
+                String.valueOf(
+                        Arrays.stream(gridSubset.getGridNames())
+                                .allMatch(n -> StringUtils.isNumeric(n))));
         makeHiddenInput(buf, "format", formatStr);
         makeHiddenInput(buf, "layerName", layerName);
         makeHiddenInput(buf, "SRS", gridSubset.getSRS().toString());

--- a/geowebcache/core/src/main/resources/org/geowebcache/rest/webresources/demo.js
+++ b/geowebcache/core/src/main/resources/org/geowebcache/rest/webresources/demo.js
@@ -55,6 +55,7 @@ window.onload = function() {
     }
 
     var gridsetName = getValue('gridsetName');
+    var gridNamesNumeric = getValue('gridNamesNumeric') === 'true' ? true : false ;
     var gridNames = JSON.parse(getValue('gridNames'));
     var baseUrl = '../service/wmts';
     var style = '';
@@ -75,7 +76,7 @@ window.onload = function() {
             'VERSION': '1.0.0',
             'LAYER': layerName,
             'STYLE': style,
-            'TILEMATRIX': gridsetName + ':{z}',
+            'TILEMATRIX': gridNamesNumeric ? '{z}' : gridsetName + ':{z}',
             'TILEMATRIXSET': gridsetName,
             'FORMAT': format,
             'TILECOL': '{x}',


### PR DESCRIPTION
The current vector tiles preview assumes the grid names are in the form "gridsetName:Z". But the ones coming from OGC the Tile Matrix Set specification use just numbers instead. Support that style too.

Ideally we should just use the actual names, but the vector tiles support in OL3 seems to really want a Z placeholder somewhere to work.