### PR TITLE
Fix Azure blobstore error instantiating AzureClient

### DIFF
--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -93,8 +93,13 @@ class AzureClient implements Closeable {
             this.container = serviceURL.createContainerURL(containerName);
             // no way to see if the containerURL already exists, try to create and see if
             // we get a 409 CONFLICT
+            int status;
             try {
-                int status = this.container.getProperties().blockingGet().statusCode();
+                status = this.container.getProperties().blockingGet().statusCode();
+            } catch (com.microsoft.azure.storage.blob.StorageException se) {
+                status = se.statusCode();
+            }
+            try {
                 if (status == HttpStatus.NOT_FOUND.value()) {
                     status = this.container.create(null, null, null).blockingGet().statusCode();
                     if (!HttpStatus.valueOf(status).is2xxSuccessful()


### PR DESCRIPTION
commit 72ce566b "Avoid infinite number of calls to listBlobs when doing prefix removals (e..g, gridset or layer removals)" changed the gwc `AzureClient` check for container existence from an attemp to create it to an attempt to get its properties before creating it.

When the container doesn't exist, the blocking call throws `com.microsoft.azure.storage.blob.StorageException`, which contains the status code.

Wrap that call in a try-catch block and get the status code from the exception.