### PR TITLE
Upgrade git-commit-id-plugin to 4.9.0 and set useNativeGit to not fail on git worktrees

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -637,7 +637,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.5</version>
+        <version>4.9.10</version>
         <executions>
           <execution>
             <goals>
@@ -646,6 +646,7 @@
           </execution>
         </executions>
         <configuration>
+          <useNativeGit>true</useNativeGit>
           <prefix>build</prefix>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <skipPoms>false</skipPoms>


### PR DESCRIPTION
`jgit` does not support git worktrees. Setting the config option `<useNativeGit>true</useNativeGit>` makes it not fail.