### PR TITLE
Upgrade hamcrest from 1.3 to 3.0

### DIFF
--- a/geowebcache/arcgiscache/pom.xml
+++ b/geowebcache/arcgiscache/pom.xml
@@ -28,18 +28,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/azureblob/pom.xml
+++ b/geowebcache/azureblob/pom.xml
@@ -31,11 +31,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -49,11 +44,6 @@
       <groupId>org.geowebcache</groupId>
       <artifactId>gwc-core</artifactId>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -181,21 +181,6 @@
     </dependency>
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-integration</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/filter/parameters/ParametersUtilsTest.java
@@ -16,8 +16,8 @@ package org.geowebcache.filter.parameters;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyString;
 
 import java.util.Collections;
 import java.util.Map;
@@ -35,7 +35,7 @@ public class ParametersUtilsTest {
     @Test
     public void testEmptyToKVP() {
         String result = ParametersUtils.getKvp(Collections.emptyMap());
-        assertThat(result, isEmptyString());
+        assertThat(result, emptyString());
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/TruncateBboxRequestTest.java
@@ -28,12 +28,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.mime.ImageMime;
 import org.geowebcache.storage.StorageBroker;
-import org.hamcrest.integration.EasyMock2Adapter;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
 import org.junit.Test;
 
 public class TruncateBboxRequestTest {
@@ -47,7 +49,7 @@ public class TruncateBboxRequestTest {
             int maxZ,
             BoundingBox bounds,
             Map<String, String> parameters) {
-        EasyMock2Adapter.adapt(
+        Matcher<Object> matcher =
                 allOf(
                         hasProperty("layerName", equalTo(layerName)),
                         hasProperty("gridSetId", equalTo(gridSet)),
@@ -58,7 +60,20 @@ public class TruncateBboxRequestTest {
                         hasProperty("filterUpdate", any(Boolean.class)),
                         hasProperty("threadCount", any(Integer.class)),
                         hasProperty("bounds", equalTo(bounds)),
-                        hasProperty("type", any(GWCTask.TYPE.class))));
+                        hasProperty("type", any(GWCTask.TYPE.class)));
+        EasyMock.reportMatcher(
+                new IArgumentMatcher() {
+
+                    @Override
+                    public boolean matches(Object argument) {
+                        return matcher.matches(argument);
+                    }
+
+                    @Override
+                    public void appendTo(StringBuffer buffer) {
+                        matcher.describeTo(new StringDescription(buffer));
+                    }
+                });
         return null;
     }
 

--- a/geowebcache/diskquota/bdb/pom.xml
+++ b/geowebcache/diskquota/bdb/pom.xml
@@ -26,11 +26,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
@@ -44,11 +39,6 @@
       <groupId>org.geowebcache</groupId>
       <artifactId>gwc-core</artifactId>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/diskquota/jdbc/pom.xml
+++ b/geowebcache/diskquota/jdbc/pom.xml
@@ -37,11 +37,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
@@ -56,11 +51,6 @@
       <artifactId>gwc-core</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/mbtiles/pom.xml
+++ b/geowebcache/mbtiles/pom.xml
@@ -34,18 +34,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -64,6 +64,7 @@
     <commons-text.version>1.12.0</commons-text.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <guava.version>33.2.1-jre</guava.version>
+    <hamcrest.version>3.0</hamcrest.version>
     <jsr305.version>3.0.1</jsr305.version>
     <log4j.version>2.17.2</log4j.version>
     <h2.version>1.1.119</h2.version>
@@ -273,17 +274,29 @@
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>hamcrest-core</artifactId>
+            <groupId>org.hamcrest</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-integration</artifactId>
-        <version>1.3</version>
+        <artifactId>hamcrest-core</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -469,6 +482,20 @@
 
     </dependencies>
   </dependencyManagement>
+
+  <!-- common test dependencies -->
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>

--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -36,11 +36,6 @@
 
     <!-- test dependencies  -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geowebcache</groupId>
       <artifactId>gwc-core</artifactId>
       <version>${project.version}</version>
@@ -55,11 +50,6 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/s3storage/pom.xml
+++ b/geowebcache/s3storage/pom.xml
@@ -33,11 +33,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -51,11 +46,6 @@
       <groupId>org.geowebcache</groupId>
       <artifactId>gwc-core</artifactId>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -44,16 +44,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -119,11 +119,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
@@ -131,11 +126,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/wms/pom.xml
+++ b/geowebcache/wms/pom.xml
@@ -48,11 +48,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -65,11 +60,6 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/geowebcache/wmts/pom.xml
+++ b/geowebcache/wmts/pom.xml
@@ -27,11 +27,6 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-legacy</artifactId>
       <scope>test</scope>
@@ -46,17 +41,6 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-integration</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
This is a test dependency upgrade.

This PR adds the hamcrest 3.0 dependency to the root pom.xml and removes all hamcrest-core, hamcrest-library and hamcrest-integration dependencies. The version is set to 3.0 for hamcrest-core and hamcrest-library in case there is another transitive dependency on it (these are empty jar files). hamcrest-integration has no version beyond 1.3.

Some code changes were required for deprecated or removed API.