### PR TITLE
Set disk quota store isolation to serializable

### DIFF
--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStore.java
@@ -126,6 +126,7 @@ public class JDBCQuotaStore implements QuotaStore {
         DataSourceTransactionManager dsTransactionManager =
                 new DataSourceTransactionManager(dataSource);
         this.tt = new TransactionTemplate(dsTransactionManager);
+        this.tt.setIsolationLevel(TransactionTemplate.ISOLATION_SERIALIZABLE);
         this.jt = new SimpleJdbcTemplate(dsTransactionManager.getDataSource());
     }
 


### PR DESCRIPTION
The default isolation level (read committed) allows for phantom reads and non repeatable reads, which is probably the  reason why the disk quota totals sometimes diverge from reality. Since the updates are asynch, it should not cause major bottlenecks (hopefully).