### PR TITLE
[GWC-1329] Upgrade log4j to 2.24.1 and slf4j to 2.0.16

### DIFF
--- a/geowebcache/azureblob/pom.xml
+++ b/geowebcache/azureblob/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -66,7 +66,7 @@
     <guava.version>33.2.1-jre</guava.version>
     <hamcrest.version>3.0</hamcrest.version>
     <jsr305.version>3.0.1</jsr305.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.24.1</log4j.version>
     <h2.version>1.1.119</h2.version>
     <hsql.version>2.7.1</hsql.version>
     <postgresql.version>42.7.3</postgresql.version>
@@ -213,13 +213,13 @@
       <!-- bridge slf4j to log4j -->
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>2.0.16</version>
       </dependency>
 
       <!-- bridge commons-logging to log4j -->

--- a/geowebcache/s3storage/pom.xml
+++ b/geowebcache/s3storage/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR upgrades the log4j and slf4j dependencies to their current versions and is related to GeoServer's Wicket 9 upgrade.

See https://osgeo-org.atlassian.net/browse/GEOS-11590 for more information.