### PR TITLE
Configure compiler to use -parameters flag

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -641,11 +641,12 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.13.0</version>
         <configuration>
           <source>11</source>
           <target>11</target>
           <encoding>UTF-8</encoding>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Using certain Spring Framework functionality without the parameters flag will cause warnings in version 6.0 and errors in 6.1.