### PR TITLE
Update old geowebcache.org links to geowebcache.osgeo.org

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,4 +1,4 @@
-GeoWebCache 1.27.0(2025-03-18)
+GeoWebCache 1.27.0 (2025-03-18)
 ------------------------------
 
 Stable release
@@ -1297,13 +1297,13 @@ This release comes with a number of bug fixes and improvements (check the full l
 - Added an "enabled" property to the layer configuration XML schema, so that it's possible to keep a layer from being listed in the capabilities document or accessed through any of the provided service interfaces, but still being able of seeding it either through the web or the REST interfaces.
 - New embedded, high performance storage mechanism for Disk Quota statistics based on the Berkeley DB JE no-SQL database engine.
 - Possibility to define a GWC_DISKQUOTA_DISABLED=true environment variable to disable the usage of the disk quota module. Useful for load balanced deployments for the same reasons you need to disable the meta-store. This is a work around until "clustering" is supported for the disk quota storage.
-- Improved DiskQuota documentation <http://geowebcache.org/docs/current/configuration/diskquotas.html>
-- REST API to configure the global disk quota settings <http://geowebcache.org/docs/current/rest/diskquota.html>
+- Improved DiskQuota documentation <https://geowebcache.osgeo.org/docs/current/configuration/diskquotas.html>
+- REST API to configure the global disk quota settings <https://geowebcache.osgeo.org/docs/current/rest/diskquota.html>
 - Implemented a CQL_FILTER parameter extension for the Google Maps service interface
 - Fixed the computation of estimated and remaining seeding time and number of tiles to process reported by the web interface
 - Improved the stability of the system by avoiding the unnecessary load of existing tiles into memory when re-seeding
 - Seeding and truncating with parameter filters (i.e. for multiple styles or other WMS parameters)
-- Failure tolerance control for seeding:  <http://geowebcache.org/docs/current/production/index.html#seeding-and-truncating-the-cache>
+- Failure tolerance control for seeding:  <https://geowebcache.osgeo.org/docs/current/production/index.html#seeding-and-truncating-the-cache>
 
 
 GeoWebCache 1.2.4 (2011-01-24)
@@ -1324,4 +1324,4 @@ In this release, besides numerous bug fixes, you'll find three new exciting feat
 
 
 [1] <https://github.com/GeoWebCache/geowebcache>
-[2] <http://geowebcache.org/docs/current>
+[2] <https://geowebcache.osgeo.org/docs/current>

--- a/documentation/en/theme/_templates/layout.html
+++ b/documentation/en/theme/_templates/layout.html
@@ -161,7 +161,7 @@
     <div class="wrap selfclear">
       <div id="logo"><a href="{{ pathto('index') }}">{{ shorttitle }}</a></div>
       <ul id="top-nav">
-        <li class="first"><a href="http://geowebcache.org">Homepage</a></li>
+        <li class="first"><a href="https://geowebcache.osgeo.org">Homepage</a></li>
         <li><a href="{{ pathto('index') }}">Documentation</a></li>
       </ul>
       

--- a/documentation/en/user/source/installation/geowebcache.rst
+++ b/documentation/en/user/source/installation/geowebcache.rst
@@ -5,7 +5,7 @@ Installing GeoWebCache
 
 Once the :ref:`Java Servlet environment <prerequisites>` is in place, installing GeoWebCache is simple. 
 
-The latest Web ARchive (WAR) file can be downloaded from `geowebcache.org <http://geowebcache.org>`_.  
+The latest Web ARchive (WAR) file can be downloaded from `GeoWebCache.osgeo.org <https://geowebcache.osgeo.org>`_.  
 
 Unpack the zip file and make sure to read the software :ref:`license`.
 

--- a/documentation/en/user/source/introduction/community.rst
+++ b/documentation/en/user/source/introduction/community.rst
@@ -8,7 +8,7 @@ GeoWebCache is an open source project and thus it relies on its community of use
 Homepage
 --------
 
-The GeoWebCache homepage is `<http://geowebcache.org>`_.  This page has the latest information about GeoWebCache, as well as links to documentation, downloads, developer information, issue tracking, and other up-to-the-minute information.
+The GeoWebCache homepage is `<https://geowebcache.osgeo.org>`_.  This page has the latest information about GeoWebCache, as well as links to documentation, downloads, developer information, issue tracking, and other up-to-the-minute information.
 
 .. _mailinglists:
 

--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -109,7 +109,7 @@ These environment variables can be established by any of the following ways, in 
 Resource Allocation
 -------------------
 
-Also see http://geowebcache.org/trac/wiki/resources for tools that can be used to estimate how much storage you need and how long seeding will take
+Also see <del>http://geowebcache.org/trac/wiki/resources</del> for tools that can be used to estimate how much storage you need and how long seeding will take
 
 
 Clustering

--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -109,7 +109,7 @@ These environment variables can be established by any of the following ways, in 
 Resource Allocation
 -------------------
 
-Also see https://github.com/GeoWebCache/geowebcache/wiki/Estimating-the-number-of-tiles-and-size-on-disk for tools that can be used to estimate how much storage you need and how long seeding will take
+Also see https://github.com/GeoWebCache/geowebcache/wiki/Estimating-the-number-of-tiles-and-size-on-disk for table that can be used to estimate how much storage you need and how long seeding will take
 
 
 Clustering

--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -109,7 +109,7 @@ These environment variables can be established by any of the following ways, in 
 Resource Allocation
 -------------------
 
-Also see <del>http://geowebcache.org/trac/wiki/resources</del> for tools that can be used to estimate how much storage you need and how long seeding will take
+Also see https://github.com/GeoWebCache/geowebcache/wiki/Estimating-the-number-of-tiles-and-size-on-disk for tools that can be used to estimate how much storage you need and how long seeding will take
 
 
 Clustering

--- a/geowebcache/arcgiscache/pom.xml
+++ b/geowebcache/arcgiscache/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-arcgiscache</artifactId>
   <packaging>jar</packaging>
   <name>ArcGIS Server tile cache support</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/layer/ArcGISCacheLayerTest.java
+++ b/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/layer/ArcGISCacheLayerTest.java
@@ -41,7 +41,7 @@ public class ArcGISCacheLayerTest {
         // PLEASE DO NOT update the ArcGISCacheLayer GridSetBroker mocking below without first
         // confirming any new ArcGISCacheLayer GridSet configuration logic is build tested to work
         // with an actual ArcGISCacheLayer configuration test using the GWC tiling scheme steps:
-        // https://www.geowebcache.org/docs/latest/configuration/layers/arcgistilingschemes.html
+        // https://geowebcache.osgeo.org/docs/current/configuration/layers/arcgistilingschemes.html
 
         final File configDir = temp.getRoot();
         ArcGISCacheLayer layer = new ArcGISCacheLayer("fakeLayerId");

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-core</artifactId>
   <packaging>jar</packaging>
   <name>gwc-core</name>
-  <url>https://www.geowebcache.org</url>
+  <url>https://www.geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -467,7 +467,8 @@ public class GeoWebCacheDispatcher extends AbstractController {
                 + "<body>\n"
                 + ServletUtils.gwcHtmlLogoLink(baseUrl));
         str.append("<h3>Welcome to GeoWebCache version " + version + ", build " + commitId + "</h3>\n");
-        str.append("<p><a href=\"https://geowebcache.osgeo.org\">GeoWebCache</a> is an advanced tile cache for WMS servers. ");
+        str.append(
+                "<p><a href=\"https://geowebcache.osgeo.org\">GeoWebCache</a> is an advanced tile cache for WMS servers. ");
         str.append(
                 "It supports a large variety of protocols and formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</p>");
         str.append("<h3>Automatically Generated Demos:</h3>\n");

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -467,7 +467,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
                 + "<body>\n"
                 + ServletUtils.gwcHtmlLogoLink(baseUrl));
         str.append("<h3>Welcome to GeoWebCache version " + version + ", build " + commitId + "</h3>\n");
-        str.append("<p><a href=\"http://geowebcache.org\">GeoWebCache</a> is an advanced tile cache for WMS servers.");
+        str.append("<p><a href=\"https://geowebcache.osgeo.org\">GeoWebCache</a> is an advanced tile cache for WMS servers. ");
         str.append(
                 "It supports a large variety of protocols and formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</p>");
         str.append("<h3>Automatically Generated Demos:</h3>\n");
@@ -477,12 +477,12 @@ public class GeoWebCacheDispatcher extends AbstractController {
         str.append("<ul><li><a href=\""
                 + baseUrl
                 + "service/wmts?REQUEST=getcapabilities\">WMTS 1.0.0 GetCapabilities document</a></li>");
+        str.append("<li><a href=\"" + baseUrl + "service/tms/1.0.0\">TMS 1.0.0 document</a></li>");
         str.append(
                 "<li><a href=\""
                         + baseUrl
                         + "service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true\">WMS 1.1.1 GetCapabilities document</a></li>");
-        str.append("<li><a href=\"" + baseUrl + "service/tms/1.0.0\">TMS 1.0.0 document</a></li>");
-        str.append("<li>Note that the latter will only work with clients that are ");
+        str.append("<li>Note that the latter (WMS) will only work with clients that are ");
         str.append("<a href=\"http://wiki.osgeo.org/wiki/WMS_Tiling_Client_Recommendation\">WMS-C capable</a>.</li>\n");
         str.append("<li>Omitting tiled=true from the URL will omit the TileSet elements.</li></ul>\n");
         if (runtimeStats != null) {

--- a/geowebcache/diskquota/bdb/pom.xml
+++ b/geowebcache/diskquota/bdb/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>gwc-diskquota-bdb</artifactId>
   <packaging>jar</packaging>
   <name>Disk Quota management module - BerkeleyDB backend</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/diskquota/core/pom.xml
+++ b/geowebcache/diskquota/core/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-diskquota-core</artifactId>
   <packaging>jar</packaging>
   <name>Disk Quota management module - core service</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/diskquota/jdbc/pom.xml
+++ b/geowebcache/diskquota/jdbc/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>gwc-diskquota-jdbc</artifactId>
   <packaging>jar</packaging>
   <name>Disk Quota management module - JDBC backends</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/diskquota/pom.xml
+++ b/geowebcache/diskquota/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-diskquota</artifactId>
   <packaging>pom</packaging>
   <name>Disk Quota management module</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <modules>
     <module>core</module>

--- a/geowebcache/distributed/pom.xml
+++ b/geowebcache/distributed/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>gwc-distributed</artifactId>
   <packaging>jar</packaging>
   <name>gwc-distributed</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-georss</artifactId>
   <packaging>jar</packaging>
   <name>gwc-georss</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/gmaps/pom.xml
+++ b/geowebcache/gmaps/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-gmaps</artifactId>
   <packaging>jar</packaging>
   <name>gwc-gmaps</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/kml/pom.xml
+++ b/geowebcache/kml/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-kml</artifactId>
   <packaging>jar</packaging>
   <name>gwc-kml</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/mbtiles/pom.xml
+++ b/geowebcache/mbtiles/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-mbtiles</artifactId>
   <packaging>jar</packaging>
   <name>MBTiles cache support</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
   <!-- GWC VERSION -->
   <name>geowebcache</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <modules>
     <module>core</module>

--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-rest</artifactId>
   <packaging>jar</packaging>
   <name>gwc-rest</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ReloadController.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/controller/ReloadController.java
@@ -110,7 +110,7 @@ public class ReloadController implements ApplicationContextAware {
                     + e.getMessage()
                     + "\n<br>"
                     + " If you believe this is a bug, please submit a ticket at "
-                    + "<a href=\"http://geowebcache.org\">GeoWebCache.org</a>"
+                    + "<a href=\"https://geowebcache.osgeo.org\">GeoWebCache.osgeo.org</a>"
                     + "</p>");
         }
 

--- a/geowebcache/s3storage/pom.xml
+++ b/geowebcache/s3storage/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-aws-s3</artifactId>
   <packaging>jar</packaging>
   <name>AWS S3 Storage</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/swiftblob/pom.xml
+++ b/geowebcache/swiftblob/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>gwc-swift</artifactId>
   <packaging>jar</packaging>
   <name>Swift Storage</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/tms/pom.xml
+++ b/geowebcache/tms/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-tms</artifactId>
   <packaging>jar</packaging>
   <name>gwc-tms</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/ve/pom.xml
+++ b/geowebcache/ve/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-ve</artifactId>
   <packaging>jar</packaging>
   <name>gwc-ve</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-web</artifactId>
   <packaging>jar</packaging>
   <name>Web module</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/wms/pom.xml
+++ b/geowebcache/wms/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-wms</artifactId>
   <packaging>jar</packaging>
   <name>gwc-wms</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>

--- a/geowebcache/wmts/pom.xml
+++ b/geowebcache/wmts/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>gwc-wmts</artifactId>
   <packaging>jar</packaging>
   <name>gwc-wmts</name>
-  <url>http://geowebcache.org</url>
+  <url>https://geowebcache.osgeo.org</url>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Except for schema URLs e.g. http://geowebcache.org/schema/1.9.0/geowebcache.xsd

Fixes: https://github.com/GeoWebCache/geowebcache/issues/1325

Also reorder GetCapabilities links in http://localhost:8080/geoserver/gwc/home, so that **latter** refers to the correct (WMS) GetCapabilities (and not TMS):

![image](https://github.com/user-attachments/assets/d9262633-cb4b-4f5c-8ccc-fbde9f58c113)
