### PR TITLE
Disable azure job, credentials are not working any longer

### DIFF
--- a/.github/workflows/azure-integration.yml
+++ b/.github/workflows/azure-integration.yml
@@ -48,10 +48,10 @@ jobs:
     #if: github.repository == 'geowebcache/geowebcache'
     runs-on: ubuntu-latest
     needs: azurite
-    if: |
-      always() &&
-      !contains(needs.*.result, 'cancelled') &&
-      !contains(needs.*.result, 'failure')
+    if: false # | Restore when credentials are back working
+    #  always() &&
+    #  !contains(needs.*.result, 'cancelled') &&
+    #  !contains(needs.*.result, 'failure')
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v3


### PR DESCRIPTION
Job has been failing in all recent PRs, likely due to a credentials issue:

```
Error:  Tests run: 14, Failures: 0, Errors: 14, Skipped: 0, Time elapsed: 0.837 s <<< FAILURE! -- in org.geowebcache.azure.tests.online.OnlineAzureBlobStoreIntegrationIT
Error:  org.geowebcache.azure.tests.online.OnlineAzureBlobStoreIntegrationIT.testCreatesStoreMetadataOnStart -- Time elapsed: 0.725 s <<< ERROR!
org.geowebcache.storage.StorageException: Failed to setup Azure connection and container
	at org.geowebcache.azure.AzureClient.<init>(AzureClient.java:71)
	at org.geowebcache.azure.tests.online.TemporaryAzureFolder.before(TemporaryAzureFolder.java:59)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: java.lang.IllegalArgumentException: 'name' cannot be empty.
	at com.azure.core.credential.AzureNamedKeyCredential.validateInputParameters(AzureNamedKeyCredential.java:93)
	at com.azure.core.credential.AzureNamedKeyCredential.<init>(AzureNamedKeyCredential.java:61)
	at org.geowebcache.azure.AzureClient.getCredentials(AzureClient.java:109)
	at org.geowebcache.azure.AzureClient.createBlobServiceClient(AzureClient.java:92)
	at org.geowebcache.azure.AzureClient.<init>(AzureClient.java:64)
	... 22 more
```

The change does not remove the build, but disables it so that it gets skipped:

![image](https://github.com/user-attachments/assets/337b53fe-4d21-4479-9ab7-0623a8471322)
