### PR TITLE
[GWC-1344] Hide version info on GWC home page

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -452,21 +452,24 @@ public class GeoWebCacheDispatcher extends AbstractController {
         }
 
         StringBuilder str = new StringBuilder();
-
-        String version = GeoWebCache.getVersion();
-        String commitId = GeoWebCache.getBuildRevision();
-        if (version == null) {
-            version = "{NO VERSION INFO IN MANIFEST}";
-        }
-        if (commitId == null) {
-            commitId = "{NO BUILD INFO IN MANIFEST}";
-        }
-
         str.append("<html>\n"
                 + ServletUtils.gwcHtmlHeader(baseUrl, "GWC Home")
                 + "<body>\n"
                 + ServletUtils.gwcHtmlLogoLink(baseUrl));
-        str.append("<h3>Welcome to GeoWebCache version " + version + ", build " + commitId + "</h3>\n");
+        str.append("<h3>Welcome to GeoWebCache");
+        boolean isAdmin = this.securityDispatcher.isAdmin();
+        if (isAdmin) {
+            String version = GeoWebCache.getVersion();
+            String commitId = GeoWebCache.getBuildRevision();
+            if (version == null) {
+                version = "{NO VERSION INFO IN MANIFEST}";
+            }
+            if (commitId == null) {
+                commitId = "{NO BUILD INFO IN MANIFEST}";
+            }
+            str.append(" version ").append(version).append(", build ").append(commitId);
+        }
+        str.append("</h3>\n");
         str.append(
                 "<p><a href=\"https://geowebcache.osgeo.org\">GeoWebCache</a> is an advanced tile cache for WMS servers. ");
         str.append(
@@ -486,17 +489,18 @@ public class GeoWebCacheDispatcher extends AbstractController {
         str.append("<li>Note that the latter (WMS) will only work with clients that are ");
         str.append("<a href=\"http://wiki.osgeo.org/wiki/WMS_Tiling_Client_Recommendation\">WMS-C capable</a>.</li>\n");
         str.append("<li>Omitting tiled=true from the URL will omit the TileSet elements.</li></ul>\n");
-        if (runtimeStats != null) {
-            str.append("<h3>Runtime Statistics</h3>\n");
-            str.append(runtimeStats.getHTMLStats());
-            str.append("</table>\n");
-        }
-        if (!Boolean.parseBoolean(GeoWebCacheExtensions.getProperty("GEOWEBCACHE_HIDE_STORAGE_LOCATIONS"))) {
-            appendStorageLocations(str);
-        }
-
-        if (storageBroker != null) {
-            appendInternalCacheStats(str);
+        if (isAdmin) {
+            if (runtimeStats != null) {
+                str.append("<h3>Runtime Statistics</h3>\n");
+                str.append(runtimeStats.getHTMLStats());
+                str.append("</table>\n");
+            }
+            if (!Boolean.parseBoolean(GeoWebCacheExtensions.getProperty("GEOWEBCACHE_HIDE_STORAGE_LOCATIONS"))) {
+                appendStorageLocations(str);
+            }
+            if (storageBroker != null) {
+                appendInternalCacheStats(str);
+            }
         }
         str.append("</body></html>\n");
 

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityDispatcher.java
@@ -73,6 +73,14 @@ public class SecurityDispatcher implements ApplicationContextAware {
         }
     }
 
+    /**
+     * Checks if the current user is authenticated and is the administrator. Will return true if there are no active
+     * security filters.
+     */
+    public boolean isAdmin() {
+        return getFilters().stream().allMatch(SecurityFilter::isAdmin);
+    }
+
     @Override
     public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/security/SecurityFilter.java
@@ -28,4 +28,9 @@ public interface SecurityFilter {
      */
     public void checkSecurity(TileLayer layer, @Nullable BoundingBox extent, @Nullable SRS srs)
             throws SecurityException, GeoWebCacheException;
+
+    /** Checks if the current user is authenticated and is the administrator. */
+    default boolean isAdmin() {
+        return false;
+    }
 }

--- a/geowebcache/core/src/test/java/org/geowebcache/GeoWebCacheDispatcherTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/GeoWebCacheDispatcherTest.java
@@ -15,6 +15,8 @@ package org.geowebcache;
 
 import static org.geowebcache.TestHelpers.hasStatus;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import java.util.Collections;
 import javax.servlet.http.HttpServletResponse;
@@ -48,7 +50,28 @@ public class GeoWebCacheDispatcherTest {
     public MockExtensionRule extensions = new MockExtensionRule();
 
     @Test
-    public void testHomePage() throws Exception {
+    public void testHomePageUser() throws Exception {
+        String html = doTestHomePage(false);
+        assertThat(html, containsString("GWC Home"));
+        assertThat(html, containsString("Welcome to GeoWebCache"));
+        assertThat(html, not(containsString(" version ")));
+        assertThat(html, not(containsString(" build ")));
+        assertThat(html, not(containsString("Runtime Statistics")));
+        assertThat(html, not(containsString("Storage Locations")));
+    }
+
+    @Test
+    public void testHomePageAdmin() throws Exception {
+        String html = doTestHomePage(true);
+        assertThat(html, containsString("GWC Home"));
+        assertThat(html, containsString("Welcome to GeoWebCache"));
+        assertThat(html, containsString(" version "));
+        assertThat(html, containsString(" build "));
+        assertThat(html, containsString("Runtime Statistics"));
+        assertThat(html, containsString("Storage Locations"));
+    }
+
+    private String doTestHomePage(boolean isAdmin) throws Exception {
         IMocksControl stubs = EasyMock.createControl(MockType.NICE);
         TileLayerDispatcher tld = stubs.createMock("tld", TileLayerDispatcher.class);
         GridSetBroker gsb = stubs.createMock("gsb", GridSetBroker.class);
@@ -59,6 +82,7 @@ public class GeoWebCacheDispatcherTest {
         DefaultStorageFinder dfs = stubs.createMock("dfs", DefaultStorageFinder.class);
         SecurityDispatcher secDisp = stubs.createMock("secDisp", SecurityDispatcher.class);
 
+        EasyMock.expect(secDisp.isAdmin()).andReturn(isAdmin);
         EasyMock.expect(config.isRuntimeStatsEnabled()).andStubReturn(false);
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/geowebcache/home");
@@ -79,6 +103,7 @@ public class GeoWebCacheDispatcherTest {
         assertThat(response, hasStatus(HttpStatus.OK));
 
         stubs.verify();
+        return response.getContentAsString();
     }
 
     @Test


### PR DESCRIPTION
This PR hides version information and some other internal server information from the GeoWebCache home page unless the user is logged in as an administrator.

Issue: https://github.com/GeoWebCache/geowebcache/issues/1344