### PR TITLE
Upgrade OWASP Encoder from 1.2.3 to 1.3.1

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -210,7 +210,7 @@
     <dependency>
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
-      <version>1.2.3</version>
+      <version>1.3.1</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
This is just a regular dependency upgrade.