### PR TITLE
Updated log4j from 2.24.1 to 2.24.3

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -66,7 +66,7 @@
     <guava.version>33.2.1-jre</guava.version>
     <hamcrest.version>3.0</hamcrest.version>
     <jsr305.version>3.0.1</jsr305.version>
-    <log4j.version>2.24.1</log4j.version>
+    <log4j.version>2.24.3</log4j.version>
     <h2.version>1.1.119</h2.version>
     <hsql.version>2.7.1</hsql.version>
     <postgresql.version>42.7.3</postgresql.version>


### PR DESCRIPTION
This dependency upgrade includes a critical bug fix that can cause getLogger to return null.