### PR TITLE
[GWC-1363] Support Environment Parametrization for WMSLayer Credentials

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -205,6 +205,12 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- used for tests that require environment variables -->
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Thijs Brentjens: for security fixes, OWASP library-->
     <dependency>

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -53,6 +53,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.config.ContextualConfigurationProvider.Context;
@@ -282,6 +283,8 @@ public class XMLConfiguration
                 sourceHelper = new WMSHttpHelper(null, null, proxyUrl);
                 log.fine("Not using HTTP credentials for " + wl.getName());
             }
+            GeoWebCacheEnvironment gwcEnv = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
+            sourceHelper.setGeoWebCacheEnvironment(gwcEnv);
 
             wl.setSourceHelper(sourceHelper);
             wl.setLockProvider(getGwcConfig().getLockProvider());

--- a/geowebcache/core/src/test/java/org/geowebcache/GeoWebCacheEnvironmentTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/GeoWebCacheEnvironmentTest.java
@@ -58,7 +58,7 @@ public class GeoWebCacheEnvironmentTest {
         Assert.assertEquals(1, extensions.size());
         Assert.assertTrue(extensions.contains(genv));
 
-        Assert.assertTrue(GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION);
+        Assert.assertTrue(genv.isAllowEnvParametrization());
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/config/EnvironmentAwareXMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/EnvironmentAwareXMLConfigurationTest.java
@@ -1,0 +1,263 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package org.geowebcache.config;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.GeoWebCacheExtensions;
+import org.geowebcache.grid.GridSetBroker;
+import org.geowebcache.layer.wms.WMSHttpHelper;
+import org.geowebcache.layer.wms.WMSLayer;
+import org.geowebcache.layer.wms.WMSSourceHelper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.context.WebApplicationContext;
+
+public class EnvironmentAwareXMLConfigurationTest {
+    /** Allows to set environment variables for each individual test */
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    /** Loaded from {@literal geowebcache-config-env.xml}, defines the {@link WMSLayer}s below */
+    private XMLConfiguration xmlConfig;
+
+    /** Test layer with http user/pwd set from global config */
+    private WMSLayer withDefaultCredentials;
+
+    /** Test layer with http user/pwd defined as env variable placeholders */
+    private WMSLayer withEnvVariableCredentials;
+
+    /** Test layer with its own, non parametrized http user/pwd */
+    private WMSLayer withCustomCredentials;
+
+    /**
+     * Test layer with its own, non parametrized http user/pwd, where their values contain the '${' placeholder prefix
+     */
+    private WMSLayer customCredentialsWithEnvPrefix;
+
+    /**
+     * Make {@code GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class)} return a bean, for
+     * {@link XMLConfiguration#setDefaultValues(TileLayer)} to set it on each
+     * {@link WMSHttpHelper#setGeoWebCacheEnvironment(GeoWebCacheEnvironment)}
+     */
+    @BeforeClass
+    public static void setUpAppContext() {
+        GeoWebCacheEnvironment gwcEnv = new GeoWebCacheEnvironment();
+        ApplicationContext appContext = mock(ApplicationContext.class);
+
+        when(appContext.getBeansOfType(GeoWebCacheEnvironment.class))
+                .thenReturn(Map.of("geoWebCacheEnvironment", gwcEnv));
+        when(appContext.getBean("geoWebCacheEnvironment")).thenReturn(gwcEnv);
+        new GeoWebCacheExtensions().setApplicationContext(appContext);
+    }
+
+    /**
+     * Set up the following environment variables and load the test layers from {@literal geowebcache-config-env.xml}:
+     *
+     * <ul>
+     *   <li>{@code DEFAULT_USER=default_user_value}
+     *   <li>{@code DEFAULT_SECRET=default_secret_value}
+     *   <li>{@code CUSTOM_USER=custom_user_value}
+     *   <li>{@code CUSTOM_SECRET=custom_secret_value}
+     * </ul>
+     */
+    @Before
+    public void setUp() throws URISyntaxException, GeoWebCacheException {
+
+        setEnvironmentVariablesForCredentials();
+
+        xmlConfig = loadConfig();
+        withDefaultCredentials = getLayer("default_credentials");
+        withEnvVariableCredentials = getLayer("env_var_credentials");
+        withCustomCredentials = getLayer("custom_credentials");
+        customCredentialsWithEnvPrefix = getLayer("custom_credentials_with_env_prefix");
+    }
+
+    private void setEnvironmentVariablesForCredentials() {
+        environmentVariables.set("DEFAULT_USER", "default_user_value");
+        environmentVariables.set("DEFAULT_SECRET", "default_secret_value");
+        environmentVariables.set("CUSTOM_USER", "custom_user_value");
+        environmentVariables.set("CUSTOM_SECRET", "custom_secret_value");
+    }
+
+    private void enableEnvParametrization() {
+        environmentVariables.set("ALLOW_ENV_PARAMETRIZATION", "true");
+    }
+
+    private WMSLayer getLayer(String layerName) {
+        return (WMSLayer) xmlConfig.getLayer(layerName).orElseThrow();
+    }
+
+    private XMLConfiguration loadConfig() throws GeoWebCacheException, URISyntaxException {
+        File cpDirectory =
+                new File(requireNonNull(this.getClass().getResource("./")).toURI());
+        XMLFileResourceProvider resourceProvider = new XMLFileResourceProvider(
+                "geowebcache-config-env.xml", (WebApplicationContext) null, cpDirectory.getAbsolutePath(), null);
+
+        XMLConfiguration config = new XMLConfiguration(null, resourceProvider);
+        config.setGridSetBroker(new GridSetBroker(List.of(new DefaultGridsets(true, true))));
+        config.afterPropertiesSet();
+        return config;
+    }
+
+    @Test
+    public void testLayerWithDefaultCredentialsAllowEnvDisabled() {
+        assertCredentials(withDefaultCredentials, null, null, "layer loading shall not change the layer config");
+
+        xmlConfig.setDefaultValues(withDefaultCredentials);
+        assertCredentials(
+                withDefaultCredentials, null, null, "setting default values shall not change the layer config");
+
+        assertCredentials(
+                withDefaultCredentials.getSourceHelper(),
+                "${DEFAULT_USER}",
+                "${DEFAULT_SECRET}",
+                "sourceHelper should be assigned the default user and password, no env var substitution expected");
+    }
+
+    @Test
+    public void testLayerWithDefaultCredentialsAllowEnvEnabled() {
+        enableEnvParametrization();
+
+        assertCredentials(withDefaultCredentials, null, null, "layer loading shall not change the layer config");
+
+        xmlConfig.setDefaultValues(withDefaultCredentials);
+        assertCredentials(
+                withDefaultCredentials, null, null, "setting default values shall not change the layer config");
+
+        assertCredentials(
+                withDefaultCredentials.getSourceHelper(),
+                "default_user_value",
+                "default_secret_value",
+                "sourceHelper should have resolved the global user and password");
+    }
+
+    @Test
+    public void testLayerWithEnvVarCredentialsAllowEnvDisabled() {
+        assertCredentials(
+                withEnvVariableCredentials,
+                "${CUSTOM_USER}",
+                "${CUSTOM_SECRET}",
+                "layer loading shall not change the layer config");
+
+        xmlConfig.setDefaultValues(withEnvVariableCredentials);
+        assertCredentials(
+                withEnvVariableCredentials,
+                "${CUSTOM_USER}",
+                "${CUSTOM_SECRET}",
+                "setting default values shall not change the layer config");
+
+        assertCredentials(
+                withEnvVariableCredentials.getSourceHelper(),
+                "${CUSTOM_USER}",
+                "${CUSTOM_SECRET}",
+                "sourceHelper should keep the layer user and password, no env var substitution expected");
+    }
+
+    @Test
+    public void testLayerWithEnvVarCredentialsAllowEnvEnabled() {
+        enableEnvParametrization();
+
+        assertCredentials(
+                withEnvVariableCredentials,
+                "${CUSTOM_USER}",
+                "${CUSTOM_SECRET}",
+                "layer loading shall not change the layer config");
+
+        xmlConfig.setDefaultValues(withEnvVariableCredentials);
+        assertCredentials(
+                withEnvVariableCredentials,
+                "${CUSTOM_USER}",
+                "${CUSTOM_SECRET}",
+                "setting default values shall not change the layer config");
+
+        assertCredentials(
+                withEnvVariableCredentials.getSourceHelper(),
+                "custom_user_value",
+                "custom_secret_value",
+                "sourceHelper should have resolved the layer's user and password variables");
+    }
+
+    @Test
+    public void testLayerWithCustomCredentialsIsAllowEnvAgnostic() {
+
+        assertLayerUnchanged(withCustomCredentials, "testuser", "testpass");
+
+        enableEnvParametrization();
+
+        assertLayerUnchanged(withCustomCredentials, "testuser", "testpass");
+    }
+
+    @Test
+    public void testLayerWithCustomCredentialsHavingPlaceholderPrefixIsAllowEnvAgnostic() {
+
+        assertLayerUnchanged(customCredentialsWithEnvPrefix, "${user", "pass${word");
+
+        enableEnvParametrization();
+
+        assertLayerUnchanged(customCredentialsWithEnvPrefix, "${user", "pass${word");
+    }
+
+    public void assertLayerUnchanged(WMSLayer staticCredentials, String user, String password) {
+        assertCredentials(
+                staticCredentials,
+                user,
+                password,
+                "parametrization shouldn't affect a non parametrized layer's credentials");
+
+        xmlConfig.setDefaultValues(staticCredentials);
+        assertCredentials(
+                staticCredentials,
+                user,
+                password,
+                "set default values shouldn't affect a non parametrized layer's credenals");
+
+        assertCredentials(
+                (WMSHttpHelper) staticCredentials.getSourceHelper(),
+                user,
+                password,
+                "set default values shouldn't affect a non parametrized layer's credenals");
+
+        WMSHttpHelper sourceHelper = (WMSHttpHelper) staticCredentials.getSourceHelper();
+        assertCredentials(
+                sourceHelper,
+                user,
+                password,
+                "source helper shouldn't not change credential values on a non parametrized layer");
+    }
+
+    private void assertCredentials(
+            WMSSourceHelper wmsSourceHelper, String expectedUser, String expectedPassword, String message) {
+
+        WMSHttpHelper helper = (WMSHttpHelper) wmsSourceHelper;
+        assertEquals(message, expectedUser, helper.getResolvedHttpUsername());
+        assertEquals(message, expectedPassword, helper.getResolvedHttpPassword());
+    }
+
+    private void assertCredentials(WMSLayer layer, String expectedUser, String expectedPassword, String message) {
+        assertEquals(message, expectedUser, layer.getHttpUsername());
+        assertEquals(message, expectedPassword, layer.getHttpPassword());
+    }
+}

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSHttpHelperTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSHttpHelperTest.java
@@ -1,0 +1,104 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package org.geowebcache.layer.wms;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.geowebcache.layer.wms.WMSLayer.HttpRequestMode;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.mockito.Mockito;
+
+public class WMSHttpHelperTest {
+
+    /** Allows to set environment variables for each individual test */
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private WMSHttpHelper wmsHelper(String username, String password) {
+        WMSHttpHelper wmsHelper = new WMSHttpHelper(username, password, null);
+        wmsHelper.setGeoWebCacheEnvironment(new GeoWebCacheEnvironment());
+        return wmsHelper;
+    }
+
+    private void enableEnvParametrization(boolean enable) {
+        environmentVariables.set("ALLOW_ENV_PARAMETRIZATION", String.valueOf(enable));
+    }
+
+    @Test
+    public void testNoGeoWebCacheEnvironmentSet() {
+        WMSHttpHelper helper = wmsHelper("u${ername}", "pas${word}");
+        helper.setGeoWebCacheEnvironment(null);
+        assertEquals("u${ername}", helper.getResolvedHttpUsername());
+        assertEquals("pas${word}", helper.getResolvedHttpPassword());
+    }
+
+    @Test
+    public void testCredentialsUnchangedWhenEnvParametrizationDisabled() {
+        WMSHttpHelper helper = wmsHelper("u${ername}", "pas${word}");
+        assertEquals("u${ername}", helper.getResolvedHttpUsername());
+        assertEquals("pas${word}", helper.getResolvedHttpPassword());
+
+        enableEnvParametrization(false);
+        assertEquals("u${ername}", helper.getResolvedHttpUsername());
+        assertEquals("pas${word}", helper.getResolvedHttpPassword());
+    }
+
+    @Test
+    public void testCredentialsResolvedWhenEnvParametrizationEnabled() {
+        WMSHttpHelper helper = wmsHelper("${GWC_USER}", "${GWC_PWD}");
+
+        enableEnvParametrization(true);
+        assertEquals("${GWC_USER}", helper.getResolvedHttpUsername());
+        assertEquals("${GWC_PWD}", helper.getResolvedHttpPassword());
+
+        environmentVariables.set("GWC_USER", "user_resolved");
+        environmentVariables.set("GWC_PWD", "pwd_resolved");
+
+        assertEquals("user_resolved", helper.getResolvedHttpUsername());
+        assertEquals("pwd_resolved", helper.getResolvedHttpPassword());
+    }
+
+    @Test
+    public void testExecuteRequestUsesResolvedCredentials() throws IOException, URISyntaxException {
+        enableEnvParametrization(true);
+        environmentVariables.set("GWC_USER", "user_resolved");
+        environmentVariables.set("GWC_PWD", "pwd_resolved");
+
+        WMSHttpHelper helper = spy(wmsHelper("${GWC_USER}", "${GWC_PWD}"));
+        // do not actually execute the request
+        doReturn(null).when(helper).execute(any(HttpClient.class), any(HttpRequestBase.class));
+
+        // just check the http client is built with the resolved credeltials
+        URL url = new URI("http://example.com/wms?request=getcapabilities").toURL();
+        helper.executeRequest(url, null, 0, HttpRequestMode.Get);
+        verify(helper)
+                .buildHttpClient(
+                        Mockito.anyInt(),
+                        Mockito.eq("user_resolved"),
+                        Mockito.eq("pwd_resolved"),
+                        Mockito.nullable(URL.class),
+                        Mockito.anyInt());
+    }
+}

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache-config-env.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache-config-env.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://geowebcache.org/schema/1.25.0"
+                  xsi:schemaLocation="http://geowebcache.org/schema/1.25.0 https://raw.githubusercontent.com/GeoWebCache/geowebcache/refs/heads/main/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_1250.xsd">
+<!-- 
+Sample configuration with environmant variable placeholders
+for the global and per-layer http username and password 
+ -->
+  <version>1.8.0</version>
+  <httpUsername>${DEFAULT_USER}</httpUsername>
+  <httpPassword>${DEFAULT_SECRET}</httpPassword>
+
+  <layers>
+    <wmsLayer>
+      <name>default_credentials</name>
+      <metaInformation>
+        <title>Layer with default http user and pwd</title>
+      </metaInformation>
+      <wmsUrl>
+        <string>https://example.com/geoserver/wms</string>
+      </wmsUrl>
+    </wmsLayer>
+
+    <wmsLayer>
+      <name>custom_credentials</name>
+      <metaInformation>
+        <title>Layer with non-parameterized custom http user and pwd</title>
+      </metaInformation>
+      <wmsUrl>
+        <string>https://example.com/geoserver/wms</string>
+      </wmsUrl>
+      <httpUsername>testuser</httpUsername>
+      <httpPassword>testpass</httpPassword>
+    </wmsLayer>
+
+    <wmsLayer>
+      <name>env_var_credentials</name>
+      <metaInformation>
+        <title>Layer with parameterized custom http user and pwd</title>
+      </metaInformation>
+      <wmsUrl>
+        <string>https://example.com/geoserver/wms</string>
+      </wmsUrl>
+	  <httpUsername>${CUSTOM_USER}</httpUsername>
+	  <httpPassword>${CUSTOM_SECRET}</httpPassword>
+    </wmsLayer>
+    
+    <wmsLayer>
+      <name>custom_credentials_with_env_prefix</name>
+      <metaInformation>
+        <title>Layer with non-parameterized http user and pwd that contain the ${ placeholder prefix</title>
+      </metaInformation>
+      <wmsUrl>
+        <string>https://example.com/geoserver/wms</string>
+      </wmsUrl>
+      <httpUsername>${user</httpUsername>
+      <httpPassword>pass${word</httpPassword>
+    </wmsLayer>
+  </layers>
+
+</gwcConfiguration>

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/ConfigLoader.java
@@ -266,8 +266,8 @@ public class ConfigLoader {
 
         final GeoWebCacheEnvironment gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
 
-        if (gwcEnvironment != null && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-            fromXML.setQuotaStore((String) gwcEnvironment.resolveValue(fromXML.getQuotaStore()));
+        if (gwcEnvironment != null && gwcEnvironment.isAllowEnvParametrization()) {
+            fromXML.setQuotaStore(gwcEnvironment.resolveValue(fromXML.getQuotaStore()));
         }
 
         return fromXML;

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCConfiguration.java
@@ -397,21 +397,18 @@ public class JDBCConfiguration implements Serializable {
 
         final GeoWebCacheEnvironment gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
 
-        if (allowEnvParametrization && gwcEnvironment != null && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-            conf.setDialect((String) gwcEnvironment.resolveValue(getDialect()));
-            conf.setJNDISource((String) gwcEnvironment.resolveValue(getJNDISource()));
+        if (allowEnvParametrization && gwcEnvironment != null && gwcEnvironment.isAllowEnvParametrization()) {
+            conf.setDialect(gwcEnvironment.resolveValue(getDialect()));
+            conf.setJNDISource(gwcEnvironment.resolveValue(getJNDISource()));
             ConnectionPoolConfiguration connectionPoolConfig = getConnectionPool();
             if (connectionPoolConfig != null) {
                 ConnectionPoolConfiguration expConnectionPoolConfig = SerializationUtils.clone(connectionPoolConfig);
-                expConnectionPoolConfig.setDriver(
-                        (String) gwcEnvironment.resolveValue(connectionPoolConfig.getDriver()));
-                expConnectionPoolConfig.setUrl((String) gwcEnvironment.resolveValue(connectionPoolConfig.getUrl()));
-                expConnectionPoolConfig.setUsername(
-                        (String) gwcEnvironment.resolveValue(connectionPoolConfig.getUsername()));
-                expConnectionPoolConfig.setPassword(
-                        (String) gwcEnvironment.resolveValue(connectionPoolConfig.getPassword()));
+                expConnectionPoolConfig.setDriver(gwcEnvironment.resolveValue(connectionPoolConfig.getDriver()));
+                expConnectionPoolConfig.setUrl(gwcEnvironment.resolveValue(connectionPoolConfig.getUrl()));
+                expConnectionPoolConfig.setUsername(gwcEnvironment.resolveValue(connectionPoolConfig.getUsername()));
+                expConnectionPoolConfig.setPassword(gwcEnvironment.resolveValue(connectionPoolConfig.getPassword()));
                 expConnectionPoolConfig.setValidationQuery(
-                        (String) gwcEnvironment.resolveValue(connectionPoolConfig.getValidationQuery()));
+                        gwcEnvironment.resolveValue(connectionPoolConfig.getValidationQuery()));
 
                 conf.setConnectionPool(expConnectionPoolConfig);
             }

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -493,6 +493,13 @@
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <dependency>
+        <!-- used for tests that require environment variables -->
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>1.19.0</version>
+        <scope>test</scope>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3BlobStoreInfo.java
@@ -365,7 +365,7 @@ public class S3BlobStoreInfo extends BlobStoreInfo {
         if (value == null) {
             return null;
         }
-        return gwcEnvironment.resolveValue(value).toString();
+        return gwcEnvironment.resolveValue(value);
     }
 
     private Integer toInteger(String value) {

--- a/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
+++ b/geowebcache/swiftblob/src/main/java/org/geowebcache/swift/SwiftBlobStoreConfigProvider.java
@@ -60,12 +60,12 @@ public class SwiftBlobStoreConfigProvider implements XMLConfigurationProvider {
         if (gwcEnvironment == null) {
             gwcEnvironment = GeoWebCacheExtensions.bean(GeoWebCacheEnvironment.class);
         }
-        if (gwcEnvironment != null && str != null && GeoWebCacheEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-            Object result = gwcEnvironment.resolveValue(str);
+        if (gwcEnvironment != null && str != null && gwcEnvironment.isAllowEnvParametrization()) {
+            String result = gwcEnvironment.resolveValue(str);
             if (result == null) {
                 return null;
             }
-            return result.toString();
+            return result;
         }
         return str;
     }


### PR DESCRIPTION
This commit enhances security and configurability by enabling dynamic runtime resolution of HTTP Basic Authentication credentials for WMS layers. Credentials can now be injected from environment variables, reducing the need to hardcode sensitive values. This improves code maintainability, supports secure multi- environment deployments, and simplifies testing through dynamic configuration.

1. **Dynamic Environment Parametrization**:
   - Introduced `GeoWebCacheEnvironment#isAllowEnvParametrization()` to replace the static `ALLOW_ENV_PARAMETRIZATION` field, allowing runtime toggling.

2. **Environment Variable Resolution Refactor**:
   - Replaced direct static field checks with method calls.
   - Updated `resolveValue()` and related methods to use environment variables dynamically.

3. **WMS Credentials Management Update**:
   - Added `getResolvedHttpUsername()` and `getResolvedHttpPassword()` in `WMSHttpHelper`.
   - Created `setGeoWebCacheEnvironment()` for dependency injection.

4. **Testing Enhancements**:
   - Integrated the `system-rules` library for environment variable manipulation.
   - Added tests to cover default, custom, and parameterized credentials.

5. **Code Improvements**:
   - Replaced unsafe casts in `resolveValue()`.
   - Improved exception handling by switching from `Throwable` to `RuntimeException`.
   - Added better logging and documentation for credential handling.
  
---

Fixes #1363
