### PR TITLE
Upgrade commons-logging from 1.2 to 1.3.5

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -231,7 +231,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
+        <version>1.3.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is just a regular dependency upgrade.