### PR TITLE
Support loading the xml configuration from a read-only filesystem

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -788,14 +788,15 @@ public class XMLConfiguration
 
     @Override
     public void afterPropertiesSet() throws GeoWebCacheException {
-
+        if (!resourceProvider.hasInput()) {
+            throw new ConfigurationException(
+                    String.format("The configuration resource provider is unable to provide a configuration file"));
+        }
         if (gridSetBroker == null) {
             throw new IllegalStateException("GridSetBroker has not been set");
         }
 
-        if (resourceProvider.hasInput()) {
-            this.setGwcConfig(loadConfiguration());
-        }
+        this.setGwcConfig(loadConfiguration());
 
         log.config("Initializing GridSets from " + getIdentifier());
 


### PR DESCRIPTION
Refactor `XMLFileResourceProvider` to support read-only configuration directories.

Enhances `XMLFileResourceProvider` to allow GeoWebCache to start with a read-only configuration directory and `geowebcache.xml` file. Previously, the provider assumed that the configuration directory was always writable, which caused startup failures when running in environments with restricted file permissions.

- **Support read-only configuration directories**:
  - `hasInput()` now correctly returns `true` if the configuration file exists or if a template is available and the directory is writable.
  - `hasOutput()` ensures that the configuration file can be written before allowing output operations.
  - Improved error handling when checking directory and file writability.

- **Refactored file existence checks**:
  - Consolidated logic for checking configuration file existence and writability into `findConfigFile()`.
  - Moved the directory writability check from `findConfigFile()` to `findOrCreateConfFile()` to prevent premature failures.

- **Improved logging and exception handling**:
  - `hasInput()` and `hasOutput()` now log warnings when encountering errors instead of failing silently.
  - `findOrCreateConfFile()` now explicitly throws an exception when it cannot create a new configuration file due to permission issues.

- GeoWebCache can now start successfully with a pre-existing, read-only configuration directory.
- Configurations stored in a read-only filesystem (e.g., mounted from a read-only volume) can still be used without requiring write access.
- The provider only attempts to create a configuration file when explicitly required, eliminating side effects from query methods `hasInput()` and `hasOutput()`.

This change improves the resilience of GeoWebCache in constrained environments while maintaining backward compatibility for writable configurations.