### PR TITLE
[1380] Update jai-ext to latest version (1.1.30)

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -53,7 +53,7 @@
   <properties>
     <gt.version>33-SNAPSHOT</gt.version>
     <jts.version>1.20.0</jts.version>
-    <jaiext.version>1.1.29</jaiext.version>
+    <jaiext.version>1.1.30</jaiext.version>
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.7.13</spring.security.version>
     <xstream.version>1.4.21</xstream.version>


### PR DESCRIPTION
Fixes #1380 . Update jai-ext to latest version (1.1.30) to include fix for https://github.com/geosolutions-it/jai-ext/issues/309.