### PR TITLE
[1402] Use Spring framework BOM to manage Spring and Spring Security dependencies

### DIFF
--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -103,6 +103,20 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.geowebcache</groupId>
         <artifactId>gwc-core</artifactId>
         <version>${project.version}</version>
@@ -338,62 +352,6 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- Spring dependencies -->
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-aop</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${spring.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>org.springframework</artifactId>
-            <groupId>spring-jcl</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-webmvc</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-expression</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>${spring.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
-        <version>${spring.version}</version>
-        <!-- optional>true</optional -->
-      </dependency>
-
       <!--  Jetty starter dependencies -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -419,17 +377,6 @@
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>${xstream.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-web</artifactId>
-        <version>${spring.security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-config</artifactId>
-        <version>${spring.security.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
As part of the preparation work for the "GeoServer 3" migration to Spring 6, we'll use Maven Bill of Materials for dependency sets that provide them (e.g. the new GeoTools BOM will include BOMs for log4j, slf4j, and jackson).

For server projects, we're adding each individual spring and spring-security dependency, either to the root pom's dependencyManagement or in individual modules.

In order to centralize version management for all spring and spring-security dependencies and reduce boilerplate, we'll adopt the [spring-framework-bom](https://mvnrepository.com/artifact/org.springframework/spring-framework-bom/5.3.39) and [spring-security-bom](https://mvnrepository.com/artifact/org.springframework.security/spring-security-bom/5.8.16) BOMs.

---
Fixes #1402
