### PR TITLE
Upgrade build for Java 17 as base Java version

### DIFF
--- a/.github/workflows/azure-integration.yml
+++ b/.github/workflows/azure-integration.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11, 17, 21 ]
+        java-version: [ 17, 21 ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v3
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         cache: 'maven'
 
     - name: Tests against Azure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,31 +7,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3 -Xmx1g -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
 
 jobs:
-  openjdk11:
-    runs-on: [ubuntu-22.04]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: 11
-        distribution: 'temurin'
-    - name: Maven repository caching
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: gwc-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: mvn -B clean install -Dspotless.apply.skip=true -Dall -T2 --file geowebcache/pom.xml
-    - name: Remove SNAPSHOT jars from repository
-      run: |
-        find .m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-
   openjdk17:
     runs-on: [ubuntu-22.04]
     steps:
@@ -80,10 +58,10 @@ jobs:
     runs-on: [ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Maven repository caching
       uses: actions/cache@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Maven repository caching
       uses: actions/cache@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Maven repository caching
       uses: actions/cache@v3

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,16 +1,20 @@
 GeoWebCache 1.28-SNAPSHOT (2025-04-03)
 --------------------------------------
 
-<Release Description>
+Stable release, GeoNetwork 1.28.0 is the first release requiring a Java 17 environment.
 
 Improvements:
 +++++++++++++
-- <New feature>
+- Java 17 minimum
 
 Fixes:
 ++++++
 - <Bug fix>
 
+Updates:
+++++++++
+
+- Upgrade to GeoTools 34.x
 
 GeoWebCache 1.27.0 (2025-04-02)
 ------------------------------

--- a/documentation/en/build.xml
+++ b/documentation/en/build.xml
@@ -49,6 +49,7 @@
   
   <target name="docs"
     description="Generate html documentation">
+    <antcall target="sphinx-init"/>
     
     <mkdir dir="${build.directory}"/>
     <antcall target="sphinx">
@@ -72,11 +73,24 @@
   
   <target name="site"
     description="Generate html documentation">
+    <antcall target="autobuild-init"/>
+
     
     <mkdir dir="${build.directory}"/>
     <antcall target="autobuild">
       <param name="id" value="user" />
     </antcall>
+  </target>
+
+  <target name="sphinx-init" unless="sphinx.available">
+    <local name="message"/>
+    <property name="message" value="sphinx-build not available:${line.separator}
+    ${line.separator}
+    virtualenv venv${line.separator}
+    source venv/bin/activate${line.separator}
+    pip install -r requirements.txt${line.separator}
+    "/> 
+    <fail message="${message}"/>
   </target>
 
   <target name="sphinx" if="sphinx.available">
@@ -88,6 +102,16 @@
     </exec>
   </target>
 
+  <target name="autobuild-init" unless="autobuild.available">
+    <local name="message"/>
+    <property name="message" value="autobuild not available:${line.separator}
+    ${line.separator}
+    virtualenv venv${line.separator}
+    source venv/bin/activate${line.separator}
+    pip install -r requirements.txt${line.separator}
+    "/> 
+    <fail message="${message}"/>
+  </target>
   
   <target name="autobuild" if="autobuild.available">
     <local name="argLine"/>

--- a/documentation/en/user/source/configuration/layers/howto.rst
+++ b/documentation/en/user/source/configuration/layers/howto.rst
@@ -33,8 +33,8 @@ It is recommended to use a special XML editing tool or at the very least a text 
 
 Two recommended free editors, both of which have support for XML validation, are:
 
-* `jEdit <http://www.jedit.org/>`_ (cross platform)
-* `Notepad++ <http://notepad-plus-plus.org/>`_ (Windows only)
+* `jEdit <https://www.jedit.org>`_ (cross platform)
+* `Notepad++ <https://notepad-plus-plus.org/>`_ (Windows only)
 
 It is also possible to validate an XML document outside of a text editor environment.
 

--- a/documentation/en/user/source/configuration/storage.rst
+++ b/documentation/en/user/source/configuration/storage.rst
@@ -23,13 +23,15 @@ does not explicitly indicate which blobstore shall be used.
 
 .. note:: **there will always be a "default" blobstore**. If a blobstore to be used by default is not explicitly configured, one will
    be created automatically following the legacy cache location lookup mechanism used in versions prior to 1.8.0.
- 
+
+.. _configuration.file
+
 Configuration File
 ------------------
 
-The location of the configuration file, :file:`geowebcache.xml`, will be defined by the ``GEOWEBCACHE_CACHE_DIR`` application argument.
+The location of the configuration file, :file:`geowebcache.xml`, will be defined by the ``GEOWEBCACHE_CACHE_DIR`` application parameter.
 
-There are a few ways to define this argument:
+There are a few ways to define ``GEOWEBCACHE_CACHE_DIR``:
 
 * JVM system environment variable
 * Servlet context parameteter
@@ -37,39 +39,41 @@ There are a few ways to define this argument:
 
 The variable in all cases is defined as ``GEOWEBCACHE_CACHE_DIR``.
 
-To set as a JVM system environment variable, add the parameter ``-DGEOWEBCACHE_CACHE_DIR=<path>`` to your servlet startup script.  
-In Tomcat, this can be added to the Java Options (JAVA_OPTS) variable in the startup script.
+1. To set as a JVM system environment variable, add the parameter ``-DGEOWEBCACHE_CACHE_DIR=<path>`` to your servlet startup script.
 
-To set as a servlet context parameter, edit the GeoWebCache :file:`web.xml` file and add the following code:
+   In Tomcat, this can be added to the Java Options (``JAVA_OPTS``) variable in the startup script, or by creating :file:`setenv.sh` / :file:`setenv.bat`:
 
-.. code-block:: xml
+2. To set as a servlet context parameter, edit the GeoWebCache :file:`web.xml` file and add the following code:
 
-   <context-param>
-     <param-name>GEOWEBCACHE_CACHE_DIR</param-name>
-     <param-value>PATH</param-value>
-   </context-param>
+   .. code-block:: xml
+   
+      <context-param>
+        <param-name>GEOWEBCACHE_CACHE_DIR</param-name>
+        <param-value>PATH</param-value>
+      </context-param>
 
-where ``PATH`` is the location of the cache directory.
+    where ``PATH`` is the location of the cache directory.
 
-To set as an operating system environment variable, run one of the the following commands:
+3. To set as an operating system environment variable, run one of the the following commands:
 
-Windows::
+   Windows::
+   
+     > set GEOWEBCACHE_CACHE_DIR=<path>
+   
+   Linux/OS X::
+   
+     $ export GEOWEBCACHE_CACHE_DIR=<path>
 
-  > set GEOWEBCACHE_CACHE_DIR=<path>
+4. Not recommended: It is possible to set this location directly in the :file:`geowebcache-core-context.xml` file.
+   However this file will be replaced each update:
 
-Linux/OS X::
+   .. code-block:: xml
+   
+      <!-- bean id="gwcBlobStore" class="org.geowebcache.storage.blobstore.file.FileBlobStore" destroy-method="destroy">
+        <constructor-arg value="/tmp/gwc_blobstore" />
+      </bean -->
 
-  $ export GEOWEBCACHE_CACHE_DIR=<path>
-
-Finally, although not recommended, it is possible to set this location directly in the :file:`geowebcache-core-context.xml` file.  Uncomment this code:
-
-.. code-block:: xml
-
-   <!-- bean id="gwcBlobStore" class="org.geowebcache.storage.blobstore.file.FileBlobStore" destroy-method="destroy">
-     <constructor-arg value="/tmp/gwc_blobstore" />
-   </bean -->
-
-making sure to edit the path.  As usual, any changes to the servlet configuration files will require :ref:`configuration.reload`.
+   making sure to edit the path.  As usual, any changes to the servlet configuration files will require :ref:`configuration.reload`.
 
 .. note:: if ``GEOWEBCACHE_CACHE_DIR`` is not provided by any of the above mentioned methods, the directory will default
     to the temporary storage folder specified by the web application container. (For Tomcat, this is the :file:`temp` directory inside the root.)

--- a/documentation/en/user/source/development/index.rst
+++ b/documentation/en/user/source/development/index.rst
@@ -7,11 +7,11 @@ You are encouraged to help contribute code to GeoWebCache.  To do so, you will f
 
 This is the current prerequisites:
 
- * Java 8 (`OpenJDK <http://openjdk.java.net>`__ linux, `OpenJDK Temurin 8 <https://adoptium.net/?variant=openjdk8&jvmVariant=hotspot>` windows and macOS installers)
- * `Maven <http://maven.apache.org/>`_
- * `Git <http://git-scm.com>`_
+ * Java 17 (`OpenJDK <https://openjdk.java.net>`__ linux, `OpenJDK Temurin 17 <https://adoptium.net/temurin/releases/?variant=openjdk8&jvmVariant=hotspot&os=any&arch=any&version=17>` windows and macOS installers)
+ * `Maven <https://maven.apache.org/>`_
+ * `Git <https://git-scm.com>`_
 
-Please make sure you use **Java 8** to compile to ensure that we don't accidentally use new features only available in Java 11.
+Please make sure you use **Java 17** to compile to ensure that we don't accidentally use new features only available in Java 21.
 
 You are encouraged to join the `GeoWebCache Developers mailing list <https://lists.sourceforge.net/lists/listinfo/geowebcache-devel>`__ to discuss your work.  It is always a good idea to ask whether anyone else has already solved the same problem.
 
@@ -27,28 +27,28 @@ Setting Up
 
    .. code-block:: bash
 
-      set JAVA_HOME=c:\Program Files\Temurin\jdk8u322-b06
+      set JAVA_HOME=c:\Program Files\Temurin\jdk-17.0.15_6
 
    Linux/OS X:
 
    .. code-block:: bash
 
-      export JAVA_HOME=/opt/jdk1.7.0_79
+      export JAVA_HOME=/opt/jdk-17.0.15_6
 
-#. You can download maven from http://maven.apache.org/download.html, unpack and include the :file:`bin` directory in your PATH variable.
+#. You can download maven from https://maven.apache.org/download.html, unpack and include the :file:`bin` directory in your PATH variable.
 
    Windows:
 
    .. code-block:: bash
 
-      set M2_HOME = C:\java\apache-maven-3.8.5
+      set M2_HOME = C:\java\apache-maven-3.9.5
       set PATH=%PATH%;%M2_HOME%\bin;%JAVA_HOME%\bin
 
    Linux:
 
    .. code-block:: bash
 
-      export M2_HOME = ~/java/apache-maven-3.8.5
+      export M2_HOME = ~/java/apache-maven-3.9.5
       export PATH=$PATH:$M2_HOME/bin:$JAVA_HOME/bin
 
    For more detail instructions on maven see the `download page <http://maven.apache.org/download.cgi>`_.
@@ -89,6 +89,9 @@ Build
 
       cd web
       mvn jetty:run
+   
+   The service is available on http://localhost:8081/geonetwork allowing local testing with http://localhost:8080/geoserver layers.  To change the port number use ``jetty.http.port``
+   as describde in `jetty 10 documentation <https://jetty.org/docs/jetty/10/programming-guide/maven-jetty/jetty-maven-plugin.html>`_.
 
 #. A WAR is built as the last step in ``mvn clean install`` above.
 

--- a/documentation/en/user/source/faq/index.rst
+++ b/documentation/en/user/source/faq/index.rst
@@ -4,5 +4,7 @@ Frequently Asked Questions
 This section will answer common questions about GeoWebCache.
 
 Does GeoWebCache support WFS feature caching?
-  Not currently.  Earlier versions of GeoWebCache had an experimental prototype of vector feature caching, but it was highly unstable and was removed from GeoWebCache as of version 1.2.5.
 
+  Not currently.  Earlier versions of GeoWebCache had an experimental prototype of vector feature caching, but it was highly unstable and was removed from GeoWebCache as of version 1.2.5.
+  
+  However when used with a vector tiles output format GeoWebCache can cache a vector representation of the features within each tile. It is up to client software to stich together the resulting shapes during vector tile rendering.

--- a/documentation/en/user/source/installation/geowebcache.rst
+++ b/documentation/en/user/source/installation/geowebcache.rst
@@ -3,11 +3,11 @@
 Installing GeoWebCache
 ======================
 
-Once the :ref:`Java Servlet environment <prerequisites>` is in place, installing GeoWebCache is simple. 
+Once the :ref:`Java Servlet environment <prerequisites>` is in place:
 
-The latest Web ARchive (WAR) file can be downloaded from `GeoWebCache.osgeo.org <https://geowebcache.osgeo.org>`_.  
+1. The :file:`geowebcache-war.zip` Web ARchive (WAR) file can be downloaded from `GeoWebCache.osgeo.org <https://geowebcache.osgeo.org>`_.  
 
-Unpack the zip file and make sure to read the software :ref:`license`.
+2. Unpack the zip file and make sure to read the software :ref:`license`, and locate the :file:`geowebcache.war` for deployment.
 
 Option 1: Tomcat Administration Tool
 ------------------------------------
@@ -18,13 +18,23 @@ Option 1: Tomcat Administration Tool
 
 #. After the upload is complete, look for :guilabel:`geowebcache` in the :guilabel:`Applications` table. 
 
-#. GeoWebCache should be installed at ``http://localhost:8080/geowebcache``.
+#. Once the application is started, GeoWebCache is available ``http://localhost:8080/geowebcache``.
 
 Option 2: Manual Installation
 -----------------------------
 
-The file :file:`geowebcache.war` is just a zip file.  The Tomcat Administration Tool unpacks this file to a folder inside the Tomcat webapps directory called ``<tomcat dir>/webapps/geowebcache``.  If you wish, you can unpack this archive manually in this location. You can also make configuration changes before copying to the webapps directory.
+1. Tomcat will need to be stopped before making any changes to the webapps directory.
+   
+   Ensure that the Tomcat process is stopped before proceeding, as the JVM does not always release file handles immediately.
 
-.. note:: Tomcat will need to be stopped before making any changes to the webapps directory.  Ensure that the Tomcat process is stopped before proceeding, as the JVM does not always release file handles immediately.
+2. To manually deploy:
 
-After restarting Tomcat, GeoWebCache should be installed at ``http://localhost:8080/geowebcache``.
+   * Copy the file :file:`geowebcache.war` to :file:`<tomcat dir>/webapps`.
+   
+     On startup Tomcat will deploy the application to the folder :file:`<tomcat dir>/webapps/geowebcache`
+     
+   * If you wish, you can unpack this archive manually in this location. The :file:`geowebcache.war` may be treated as a zip file and be unpacked to :file:`<tomcat dir>/webapps/geowebcache`.
+  
+    This approach allows you to make configuration changes before restartig Tomcat.
+
+3. After restarting Tomcat, GeoWebCache is available ``http://localhost:8080/geowebcache``.

--- a/documentation/en/user/source/installation/index.rst
+++ b/documentation/en/user/source/installation/index.rst
@@ -3,17 +3,16 @@
 Installation
 ============
 
-This section describes how to install GeoWebCache on the most common platforms.  GeoWebCache will work on any operating system that supports Java 1.5, including FreeBSD and Solaris.
+This section describes how to install GeoWebCache, which will work on any operating system that supports Java 17.
 
 The following software will need to be set up prior to installing GeoWebCache:
 
- * **Java Runtime Environment (JRE)** (version 1.5 or greater, preferably from Oracle)
- * **Java Servlet Container** (such as Apache Tomcat)
+ * **Java Runtime Environment (JRE)** (version 17 or 21)
+ * **Java Servlet Container** (such as Apache Tomcat or Jetty)
 
-In essence, GeoWebCache is a set of Java classes (program files) and a number of configuration files. The combination is known as a Java Servlet, and these are commonly distributed in a zip file known as a Web ARchive, or WAR file for short. 
+In essence, GeoWebCache is web application consisting of Java classes (program files) and a number of configuration files. The combination is known as a Java Servlet, and these are commonly distributed in a zip file known as a Web ARchive, or WAR file for short.
 
-To use its content, we need a Java Virtual Machine and a Servlet Container. The latter is a network service that accepts requests from clients, such as web browsers, and delegates them to the appropriate servlet.
-
+To run this web application, we need both a Java Runtime Environment (responsible for running the Java program files) and Servlet Container (that accepts HTTPS requests from clients, such as web browsers, and delegates them to the GeoWebCache).
 
 .. toctree::
    :maxdepth: 2

--- a/documentation/en/user/source/installation/prerequisites/linux.rst
+++ b/documentation/en/user/source/installation/prerequisites/linux.rst
@@ -3,35 +3,44 @@
 Linux
 =====
 
-Due to licensing issues, many Linux distributions come with a variety of Java environments. Additionally, to minimize the chance of a security breach with default settings, most versions of Tomcat are configured to not allow access to the file system.  Therefore, it is highly recommended to follow these instructions, even if you already have a servlet container set up.
+Many linux distirbutions provide their own distirbution of OpenJDK, or you may install your own from OpenJDK or Adoptium (as recommended below).
+
+Caution is required before considering your Linux distirbution of Apache Tomcat:
+
+* Package manager may recommend or udpate to Apache Tomcat 10 or newer (which is not supported by GeoWebCache).
+* Tomcat may be configured, in the interests of security, to restrict access to the local file system.
+
+We recommend providing your own environment as outlined below.
 
 Java Runtime Environment
 ------------------------
 
-In your browser, navigate to `<http://www.java.com/en/download/manual.jsp>`_, and download the latest JRE (SE is fine; you do not need FX or EE). Make sure to select **Linux_x64** if you are running on an x86_64 kernel.  Take note of where you saved the file. (This document will assume the file is saved in ``/home/user/Download/`` and is named ``jre16.bin`` although the file name will likely be different.)
+Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoWebCache requires a Java 17 or Java 21 environment, available from `OpenJDK <https://openjdk.java.net/>`__, `Adoptium <https://adoptium.net/>`_, or provided by your OS distribution.
 
-Next, open a shell and switch to superuser. Depending on your distribution, type ``sudo su`` or just ``su``. Then, ``cd /opt`` and run the command ``sh /home/user/Download/jre1.6.bin>``.  This should install Java into /opt. If you receive the message ``ELF not found``, it probably means you need to get the ``Linux`` (i586) version instead of ``Linux_64``.
-
+See :doc:`/installation/upgrading` for compatibility table.
+  
 Apache Tomcat
 -------------
 
-Back in your browser, navigate to `<http://tomcat.apache.org>`_, find the **Tomcat 6.x** link in the **Downloads** section, and save the ``tar.gz`` file listed under **Binary Distributions / Core**.  Back in your superuser shell, unpack this file as well by running ``tar xzvf /home/user/Download/apache-tomcat-a.b.c.tar.gz>`` (Make sure to use the correct file name.) 
+Back in your browser, navigate to `<https://tomcat.apache.org>`_, find the **Tomcat 9.x** link in the **Downloads** section, and save the ``tar.gz`` file listed under **Binary Distributions / Core**.  Back in your superuser shell, unpack this file as well by running ``tar xzvf /home/user/Download/apache-tomcat-9.0.106.tar.gz>`` (Make sure to use match the version numbers you downloaded name.) 
 
 Set the owner of the extracted directory to be your user account: ``chown <user> apache-tomcat-a.b.c``.
 
-Using your favorite text editor, open ``/opt/apache-tomcat-a.b.c/bin/catalina.sh``.  Because we don't want to worry about system-wide settings, we will make our changes in the top of this file. Find the line that starts with ``# OS specific support`` (around line 81), and insert the following right before, making sure to input the correct path to your JRE::
+Using your favorite text editor, open ``/opt/apache-tomcat-9.0.106/bin/catalina.sh``.  Because we don't want to worry about system-wide settings, we will make our changes in the top of this file. Find the line that starts with ``# OS specific support`` (around line 81), and insert the following right before, making sure to input the correct path to your JRE:
 
-  export PATH="/opt/jre1.6/bin:$PATH"
+.. code-block:: bash
+
+  export PATH="/opt/jdk-17.0.15_6/bin:$PATH"
   JAVA_OPTS="-server -Xmx256M"
 
 The first line sets the the JRE just installed is the one that Tomcat uses.  The second line tells Tomcat to run with server settings and to use 256MB for heap memory. (It may be possible to run with less heap memory, but this is no recommended.)  On big installations you will want to use 1024MB or more. Note that this resource is shared among all servlets running in the container, so if you add more servlets later you may have to adjust this number.
 
 Access Control
---------------
+^^^^^^^^^^^^^^
 
 If you wish to use Tomcat's web administration tool, you will need to create an account for the administrator.
 
-Open ``/opt/apache-tomcat-a.b.c/conf/tomcat-users.xml`` in a text editor. Immediately after the line containing ``<tomcat-users>``, insert::
+Open ``/opt/apache-tomcat-9.0.106/conf/tomcat-users.xml`` in a text editor. Immediately after the line containing ``<tomcat-users>``, insert::
 
   <role rolename="manager"/>
   <user username="tomcat" password="s3cret" roles="manager"/>
@@ -39,10 +48,10 @@ Open ``/opt/apache-tomcat-a.b.c/conf/tomcat-users.xml`` in a text editor. Immedi
 Replace ``s3cret`` with your actual password. After making this change you will have to restart Tomcat.
 
 Controlling Tomcat
-------------------
+^^^^^^^^^^^^^^^^^^
 
 Running as your own user, you should be able to start and stop Tomcat by using the scripts
-``/opt/apache-tomcat-a.b.c/bin/startup.sh`` and ``/opt/apache-tomcat-a.b.c/bin/shutdown.sh``
+``/opt/apache-tomcat-9.0.106/bin/startup.sh`` and ``/opt/apache-tomcat-a.b.c/bin/shutdown.sh``
 
 Verify Tomcat is running by navigating to to http://localhost:8080 (the default location of the Tomcat web interface). If Tomcat is running correctly, you should see a page congratulating you on a successful installation.
 

--- a/documentation/en/user/source/installation/prerequisites/macosx.rst
+++ b/documentation/en/user/source/installation/prerequisites/macosx.rst
@@ -3,5 +3,56 @@
 MacOS X
 =======
 
-TODO, please contribute
+MacOS has a number of command line package managers for open source components. We recommend using `SDKMAN! <https://sdkman.io/>`_ to manage Java and Tomcat environment.
 
+Java
+----
+
+Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoWebCache requires a Java 17 or Java 21 environment.
+
+* Required: Java Development Kit 17 (JDK 17)
+
+  Open JDK:
+
+  https://adoptium.net/temurin/releases/?version=17 Temurin 17 (LTS) - Recommended
+
+* SDKMan!
+  
+  .. code-block:: bash
+  
+     # list to determine latest Temurin JDK 17
+     sdk list java 17
+     
+     # Installing latest Temurin JDK 17 shown above
+     sdk install java 17.0.15-tem
+     
+     # Select Java for use 
+     sdk use java 17<tab>
+
+See :doc:`/installation/upgrading` for compatibility table.
+
+Apache Tomcat
+-------------
+
+GeoWebCache requires Apache Tomcat 9 required for JavaEE environment.
+
+1. Navigate to `Tomcat 9 <https://tomcat.apache.org/download-90.cgi>`_ **Downloads** section, and save the ``zip`` file listed under **Binary Distributions / Core**.
+
+   * Tomcat 9 Required: GeoWebCache uses the JavaEE environment last supported in Tomcat 9.
+   
+   * Tomcat 10 Unsupported: GeoWebCache is not yet compatibile with the JakartaEE environment used by Tomcat 10 and newer.
+
+* SDKMan!
+
+  .. code-block:: bash
+  
+     # list to determine latest Apache Tomcat 9
+     sdk list tomcat 9 
+     
+     # Installing latest Tomcat 9 shown above
+     sdk install tomcat 9.0.102 
+     
+     # Select tomcat for use
+     sdk use tomcat 9.0.102 
+
+GeoWebCache is not compatible with Apache Tomcat 10 JakarataEE environment.

--- a/documentation/en/user/source/installation/prerequisites/windows.rst
+++ b/documentation/en/user/source/installation/prerequisites/windows.rst
@@ -6,27 +6,49 @@ Windows
 Java Runtime Environment
 ------------------------
 
-In your browser, navigate to `<http://www.java.com/en/download/manual.jsp>`_, and download the latest JRE (SE is fine; you do not need FX or EE).  You can use either the Online or Offline installer.
+Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoWebCache requires a Java 17 or Java 21 environment.
+
+1. Download an OpenJDK release for your platform:
+
+   * https://adoptium.net/temurin/releases/?version=17 Temurin 17 (LTS) (Recommended)
+
+2. Choose the options to:
+
+   * Updating the JAVA_HOME environment variable
+   * Add the installation to the PATH environment variable
+
+See :doc:`/installation/upgrading` for compatibility table.
 
 Apache Tomcat
 -------------
 
-Back in your browser, navigate to `<http://tomcat.apache.org>`_, find the **Tomcat 6.x** link in the **Downloads** section, and save the ``Windows Service Installer`` file listed under **Binary Distributions / Core**.  Run this application to install Tomcat as a Windows service.  After installing, you should have a small system tray icon. You can right click on it to ensure that it is running with the latest version of Java, and assign at least 256MB of heap memory. Note that this resource is shared among all servlets running in the container, so if you add more servlets later you may have to adjust this number.
+1. Navigate to `<https://tomcat.apache.org>`_, find the **Tomcat 9.x** link in the **Downloads** section, and save the ``Windows Service Installer`` file listed under **Binary Distributions / Core**.
+
+   * Tomcat 9 Required: GeoWebCache uses the JavaEE environment last supported in Tomcat 9.
+   
+   * Tomcat 10 Unsupported: GeoWebCache is not yet compatibile with the JakartaEE environment used by Tomcat 10 and newer.
+2. Run this application to install Tomcat as a Windows service.
+   
+    After installing, use the small system tray icon. You can right click on it to ensure that it is running with the latest version of Java, and assign at least 256MB of heap memory.
+    
+    Note that this resource is shared among all servlets running in the container, so if you add more servlets later you may have to adjust this number.
 
 Access Control
---------------
+^^^^^^^^^^^^^^
 
 If you wish to use Tomcat's web administration tool, you will need to create an account for the administrator.
 
-Do this by opening the conf\tomcat-users.xml`` file in from your Tomcat Program Files directory (by default ``C:\Program Files\Apache Software Foundation\Tomcat a.b`` in a text editor.  Immediately after ``<tomcat-users>`` insert::
+Do this by opening the :file:`conf\tomcat-users.xml` file in from your Tomcat Program Files directory (by default ``C:\Program Files\Apache Software Foundation\Tomcat 9.0`` in a text editor.  Immediately after ``<tomcat-users>`` insert:
 
-  <role rolename="manager"/>
-  <user username="tomcat" password="s3cret" roles="manager"/>
+.. code-block:: xml
+
+   <role rolename="manager"/>
+   <user username="tomcat" password="s3cret" roles="manager"/>
 
 Replace ``s3cret`` with your actual password. After making this change you will have to restart Tomcat.
 
 Controlling Tomcat
-------------------
+^^^^^^^^^^^^^^^^^^
 
 By default, Tomcat will now start automatically with your computer. You can modify this by going through the :menuselection:`Control Panel -> Administrative Tools -> Services`, and editing the settings for the **Apache Tomcat** service.
 

--- a/documentation/en/user/source/installation/upgrading.rst
+++ b/documentation/en/user/source/installation/upgrading.rst
@@ -1,9 +1,53 @@
 .. _upgrading:
 
-Upgrading from a pre 1.15 release
-=================================
+Upgrading
+=========
 
-In 1.15 GeoWebCache changed to work on Java 9 and higher.  This included several changes to package names to avoid splitting packages across modules.  If you used any of the following classes in plugins, while emebdding GWC in a larger application, or using modified application contexts, you will need to make the follwing changes.
+1. Before you start:
+   
+   * Make a note of any customizations made to geowebcache :file:`WEB-INF` folder.
+
+     .. warning:: When updating, be sure to preserve any changes made to :file:`WEB-INF/geowebcache-core-context.xml` or :file:`WEB-INF/web.xml` as these files will be replaced during the upgrading process.
+
+   * To maintain cache location, follow the :ref:`configuration.file` instructions to define ``GEOWEBCACHE_CACHE_DIR`` and the location of :file:`geowebcache.xml` configuration.
+
+2. Stop Tomcat, follow the installation instructions to download and install the latest GeoWebCache version.
+   
+   Deploying a new version of GeoWebCache will replace :file:`<tomcat dir>/webapps/geowebcache` folder.
+
+3. Re-apply any customizations made to the :file:`WEB-INF` folder.
+
+4. Start tomcat 
+
+Java Compatibility
+------------------
+
+GeoWebCache is compiled with Java 17 (LTS) and tested with Java 17 LTS and Java 21 LTS.
+
+============ ================= ================ ================ ==================
+Java         Initial           Required         Final            Tested
+============ ================= ================ ================ ==================
+Java 21 LTS  GeoWebCache 1.25                                    OpenJDK
+Java 17 LTS  GeoWebCache 1.22  GeoWebCache 1.28                  OpenJDK
+Java 11 LTS  GeoWebCache 1.15  GeoWebCache 1.22 GeoWebCache 1.27 OpenJDK
+Java 8 LTS   GeoWebCache 1.9   GeoWebCache 1.9  GeoWebCache 1.22 Oracle and OpenJDK
+============ ================= ================ ================ ==================
+
+GeoWebCache 1.18 Update
+-----------------------
+
+Java 17 Minimum
+^^^^^^^^^^^^^^^
+
+GeoWebCache 1.18 is now compiled with Java 17 LTS, and is tested with Java 17 LTS and Java 21 LTS.
+
+GeoWebCache 1.15 Update
+-----------------------
+
+Java 9 Minimum
+^^^^^^^^^^^^^^
+
+In 1.15 GeoWebCache changed to work with Java 9 or higher, with Java 11 LTS recommended. This included several changes to package names to avoid splitting packages across modules.  If you used any of the following classes in plugins, while emebdding GWC in a larger application, or using modified application contexts, you will need to make the follwing changes.
 
 +----------------+---------------------------------------+-------------------------------------------+
 | Module         | ≤ 1.14                                | ≥ 1.15                                    |
@@ -38,8 +82,11 @@ In 1.15 GeoWebCache changed to work on Java 9 and higher.  This included several
 +----------------+---------------------------------------+-------------------------------------------+
 
 
-Upgrading from a pre 1.4 release
-================================
+GeoWebCache 1.4.0 Update
+------------------------
+
+File Blob Store replaces metastore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Starting with GeoWebCache 1.4.0 the metastore support has been removed and all its functionality has been moved to the file blob store, including support for tile expiration based on creatin date and request parameter handling.
 

--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -3,14 +3,7 @@
 Production
 ==========
 
-This section is a work in progress, and will eventually be extended to cover topics such as:
-
-* Service architecture
-* Apache Portable Runtime
-* Java Advanced Imaging / ImageIO
-* External tools for optimizing tiles
-* Profiling
-* Links for tips on improving WMS performance
+While many optimizations are configured for GeoWebCache by default, here are some additional considerations when operating in a production enviornment..
 
 Operating Environment
 ---------------------
@@ -18,16 +11,14 @@ Operating Environment
 Java Settings
 +++++++++++++
 
-GeoWebCache speed depends in part on the chosen Java Runtime Environment (JRE). GeoWebCache is tested with both OpenJDK 8 and OpenJDK 11. JREs other than these may work correctly, but are not tested nor supported.
+GeoWebCache speed depends in part on the chosen Java Runtime Environment (JRE). GeoWebCache is compiled for Java 17, and is tested with both OpenJDK 17 and OpenJDK 11. JREs other than these may work correctly, but are not tested nor supported.
 
 GeoWebCache does not need a lot of heap memory assigned to the JVM. Usually 512M is just fine if its the only web application running on the servlet container.
 
 Java Advanced Imaging / ImageIO
 +++++++++++++++++++++++++++++++
 
-GeoWebCache uses the Java Advanced Imaging library (for image processing) and ImageIO for image encoding/decoding. 
-
-The Java 8 plugin system offered native code additions for these two libraries. We no longer recommend use of these plugins due improvements in JIT performance, and native code posing a risk to system stability. 
+GeoWebCache uses the Java Advanced Imaging library (for image processing) and ImageIO for image encoding/decoding.
 
 Servlet container settings
 ++++++++++++++++++++++++++
@@ -90,18 +81,18 @@ As of version 1.2.5, it is possible to control how GWC behaves in the event that
 * ``GWC_SEED_RETRY_WAIT`` : specifies how much to wait before each retry upon a failure to seed a tile, in milliseconds. Defaults to ``100ms``
 * ``GWC_SEED_ABORT_LIMIT`` : specifies the aggregated number of failures that a group of seeding threads should reach before aborting the seeding operation as a whole. This value is shared by all the threads launched as a single thread group; so if the value is ``10`` and you launch a seed task with four threads, when ``10`` failures are reached by all or any of those four threads the four threads will abort the seeding task. The default is ``1000``.
 
-These environment variables can be established by any of the following ways, in order of precedence:
+These applicaiton properties can be established by any of the following ways, in order of precedence:
 
 - As a Java environment variable: for example `java -DGWC_SEED_RETRY_COUNT=5 ...`
 - As a Servlet context parameter in the web application's ``WEB-INF/web.xml`` configuration file. for example:
  
-.. code-block:: xml
-
-  <context-param>
-    <!-- milliseconds between each retry upon a backend request failure -->
-    <param-name>GWC_SEED_RETRY_WAIT</param-name>
-    <param-value>500</param-value>
-  </context-param>
+  .. code-block:: xml
+  
+    <context-param>
+      <!-- milliseconds between each retry upon a backend request failure -->
+      <param-name>GWC_SEED_RETRY_WAIT</param-name>
+      <param-value>500</param-value>
+    </context-param>
   
 - As a System environment variable: `export GWC_SEED_ABORT_LIMIT=2000; <your usual command to run GWC here>` (or for Tomcat, use the Tomcat's `CATALINA_OPTS` in Tomcat's `bin/catalina.sh` as this: `CATALINA_OPTS="GWC_SEED_ABORT_LIMIT=2000 GWC_SEED_RETRY_COUNT=2`
 

--- a/documentation/en/user/source/quickstart/index.rst
+++ b/documentation/en/user/source/quickstart/index.rst
@@ -12,9 +12,9 @@ All servers conforming to the `OGC Web Map Service specification <http://www.ope
 View preconfigured layers
 -------------------------
 
-GeoWebCache comes preconfigured with three layers.  To view them, navigate to your GeoWebCache demo page at ``http://GEOWEBCACHE_URL/demo`` (often this is ``http://localhost:8080/geowebcache/demo``).  Click on any of the links next to the :guilabel:`OpenLayers` column.
+GeoWebCache comes preconfigured with three layers from a default GeoServer install which may be installed alongside GeoNetwork.  To view them, navigate to your GeoWebCache demo page at ``http://localhost:8080/geowebcache/demo``.  Click on any of the links next to the :guilabel:`OpenLayers` column.
 
-These layers are all served by the WMS available at ``http://demo.opengeo.org/geoserver/``.
+These layers are all served by the WMS available at ``http://localhost:8080/geowebcache/``.
 
 .. list-table::
    :header-rows: 1
@@ -29,14 +29,14 @@ These layers are all served by the WMS available at ``http://demo.opengeo.org/ge
    * - **topp:states**
      - topp:states
 
-.. note:: This information is set in the :file:`geowebcache.xml` file, which is typically available at :file:`opt/apache-tomcat-6.0.29/webapps/geowebcache/WEB-INF/classes` or :file:`C:\\Program Files\\Apache Software Foundation\\Tomcat 6.0.29\\webapps\\geowebcache\\WEB-INF\\classes`.  See the section on :ref:`configuration.layers` for more information on customizing this file.
+.. note:: This information is set in the :file:`geowebcache.xml` file, which is typically available at :file:`webapps/geowebcache/WEB-INF/classes`. See the section on :ref:`configuration.layers` for more information on customizing this file.
 
 .. _quickstart.wms:
 
 View layers from a WMS
 ----------------------
 
-The file :file:`geowebcache-core-context.xml` is a configuration file controling how the application is loaded. It is located inside the WEB-INF folder, typically :file:`/opt/apache-tomcat-6.0.29/webapps/geowebcache/WEB-INF/` or :file:`C:\\Program Files\\Apache Software Foundation\\Tomcat 6.0.29\\webapps\\geowebcache\\WEB-INF` along with several other configuration files.
+The file :file:`geowebcache-core-context.xml` is a configuration file controling how the application is loaded. It is located inside the WEB-INF folder, typically :file:`webapps/geowebcache/WEB-INF/` along with several other configuration files.
 
 #. Open :file:`geowebcache-core-context.xml` in a text editor.
 
@@ -52,7 +52,7 @@ The file :file:`geowebcache-core-context.xml` is a configuration file controling
 
    .. code-block:: xml
 
-      <constructor-arg value="http://localhost:8282/geoserver/wms?request=getcapabilities&amp;version=1.1.0&amp;service=wms" />
+      <constructor-arg value="http://localhost:8080/geoserver/wms?request=getcapabilities&amp;version=1.1.0&amp;service=wms" />
 
 #. Replace the value with a URL pointing to a valid WMS capabilities document, such as:
 

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheInfo.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheInfo.java
@@ -73,6 +73,7 @@ public class CacheInfo {
 
     private CacheStorageInfo cacheStorageInfo;
 
+    @SuppressWarnings("UnusedMethod") // required by serialization
     private Object readResolve() {
         if (cacheStorageInfo == null) {
             cacheStorageInfo = new CacheStorageInfo();

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheStorageInfo.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/config/CacheStorageInfo.java
@@ -42,6 +42,7 @@ public class CacheStorageInfo {
 
     private int packetSize;
 
+    @SuppressWarnings("UnusedMethod") // required by serialization
     private Object readResolve() {
         if (storageFormat == null) {
             storageFormat = EXPLODED_FORMAT_CODE;

--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/ArcGISCacheLayer.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/ArcGISCacheLayer.java
@@ -65,8 +65,6 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
      * configuration properties
      */
 
-    private Boolean enabled;
-
     /** The location of the conf.xml tiling scheme configuration file */
     private File tilingScheme;
 
@@ -98,16 +96,6 @@ public class ArcGISCacheLayer extends AbstractTileLayer {
     @Override
     public String getBlobStoreId() {
         return null;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
     }
 
     public File getTilingScheme() {

--- a/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/config/CacheInfoPersisterTest.java
+++ b/geowebcache/arcgiscache/src/test/java/org/geowebcache/arcgis/config/CacheInfoPersisterTest.java
@@ -44,7 +44,7 @@ public class CacheInfoPersisterTest {
         Assert.assertEquals(0.5, sr.getZOrigin(), 1e-6);
         Assert.assertEquals(1, sr.getZScale(), 1e-6);
         Assert.assertEquals(10000, sr.getMScale(), 1e-6);
-        Assert.assertEquals(0.0037383177570093459, sr.getXYTolerance(), 1e-6);
+        Assert.assertEquals(0.003738317757009346, sr.getXYTolerance(), 1e-6);
         Assert.assertEquals(2, sr.getZTolerance(), 1e-6);
         Assert.assertEquals(2, sr.getMTolerance(), 1e-6);
         Assert.assertTrue(sr.isHighPrecision());
@@ -131,7 +131,7 @@ public class CacheInfoPersisterTest {
         TileImageInfo tii = (TileImageInfo) xs.fromXML(new StringReader(tileImageInfo));
         Assert.assertNotNull(tii);
         Assert.assertEquals("JPEG", tii.getCacheTileFormat());
-        Assert.assertEquals(80f, tii.getCompressionQuality(), 1e-6f);
+        Assert.assertEquals(80f, tii.getCompressionQuality(), 0);
         Assert.assertTrue(tii.isAntialiasing());
         Assert.assertEquals(1, tii.getBandCount());
         Assert.assertEquals(0.0f, tii.getLERCError(), 0d);

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/AzureClient.java
@@ -16,7 +16,6 @@ package org.geowebcache.azure;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.ProxyOptions;
-import com.azure.core.http.ProxyOptions.Type;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -126,7 +125,7 @@ public class AzureClient {
         ProxyOptions proxyOptions = null;
         Proxy proxy = blobStoreConfig.getProxy();
         if (null != proxy) {
-            ProxyOptions.Type type = Type.HTTP;
+            ProxyOptions.Type type = ProxyOptions.Type.HTTP;
             InetSocketAddress address = (InetSocketAddress) proxy.address();
             String proxyUsername = blobStoreConfig.getProxyUsername();
             String proxyPassword = blobStoreConfig.getProxyPassword();

--- a/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
+++ b/geowebcache/azureblob/src/main/java/org/geowebcache/azure/DeleteManager.java
@@ -142,6 +142,7 @@ class DeleteManager implements Closeable {
         }
     }
 
+    @SuppressWarnings("Finally")
     public void issuePendingBulkDeletes() throws StorageException {
         final String pendingDeletesKey = keyBuilder.pendingDeletes();
         Lock lock;

--- a/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
+++ b/geowebcache/azureblob/src/test/java/org/geowebcache/azure/AzureBlobStoreConformanceTest.java
@@ -41,6 +41,7 @@ public abstract class AzureBlobStoreConformanceTest extends AbstractBlobStoreTes
     protected abstract AzureBlobStoreData getConfiguration();
 
     @Override
+    @SuppressWarnings("CatchFail")
     public void createTestUnit() throws Exception {
         AzureBlobStoreData config = getConfiguration();
 

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -285,7 +286,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
                     response,
                     e.getErrorCode(),
                     "text/plain",
-                    new ByteArrayResource(e.getMessage().getBytes()),
+                    new ByteArrayResource(e.getMessage().getBytes(StandardCharsets.UTF_8)),
                     CacheResult.OTHER,
                     runtimeStats);
         } catch (RequestFilterException e) {
@@ -313,7 +314,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
                     response,
                     403,
                     "text/plain",
-                    new ByteArrayResource("Not Authorized".getBytes()),
+                    new ByteArrayResource("Not Authorized".getBytes(StandardCharsets.UTF_8)),
                     CacheResult.OTHER,
                     runtimeStats);
             LOG.warning(e.getMessage());
@@ -377,7 +378,7 @@ public class GeoWebCacheDispatcher extends AbstractController {
     private void handleServiceRequest(String serviceStr, HttpServletRequest request, HttpServletResponse response)
             throws Exception {
 
-        Conveyor conv = null;
+        Conveyor conv;
 
         // 1) Figure out what Service should handle this request
         Service service = findService(serviceStr);

--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheEnvironment.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheEnvironment.java
@@ -163,7 +163,7 @@ public class GeoWebCacheEnvironment {
      * @return Optional resolved value.
      */
     @SuppressWarnings("unchecked")
-    public <T extends Object> Optional<T> resolveValueIfEnabled(final String value, Class<T> type) {
+    public <T> Optional<T> resolveValueIfEnabled(final String value, Class<T> type) {
         if (StringUtils.isBlank(value)) return Optional.empty();
         final String resultValue = resolveValueIfEnabled(value);
         if (type.isAssignableFrom(String.class)) {

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GridSetConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GridSetConfiguration.java
@@ -26,7 +26,7 @@ public interface GridSetConfiguration extends BaseConfiguration {
     /**
      * Get a GridSet by name
      *
-     * @throw NoSuchElementException if the named gridset is not available.
+     * @throws NoSuchElementException if the named gridset is not available.
      */
     Optional<GridSet> getGridSet(final String name);
 

--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -221,9 +221,9 @@ public class Demo {
         String prefix = "";
 
         buf.append(layer.getMimeTypes().stream()
-                .filter(type -> type instanceof ImageMime || type == XMLMime.kml || type == XMLMime.kmz)
+                .filter(type -> type instanceof ImageMime || XMLMime.kml.equals(type) || XMLMime.kmz.equals(type))
                 .map(type -> {
-                    if (type == XMLMime.kmz) {
+                    if (XMLMime.kmz.equals(type)) {
                         return String.format(
                                 "<a href=\"%sservice/kml/%s.kml.kmz\">kmz</a>", prefix, escapeHtml4(layer.getName()));
                     } else {

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -13,10 +13,10 @@
  */
 package org.geowebcache.filter.parameters;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -127,7 +127,7 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
 
     /** Is the given value exactly a value that could be produced by the filter. */
     public boolean isFilteredValue(final String value) {
-        if (Objects.equal(value, this.getDefaultValue())) {
+        if (Objects.equals(value, this.getDefaultValue())) {
             return true;
         }
         if (Optional.ofNullable(this.getLegalValues())
@@ -136,7 +136,7 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
             return true;
         }
         try {
-            return Objects.equal(value, this.apply(value));
+            return Objects.equals(value, this.apply(value));
         } catch (ParameterException ex) {
             return false;
         }

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/BoundingBox.java
@@ -222,7 +222,7 @@ public class BoundingBox implements Serializable {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj != null && obj.getClass() == this.getClass()) {
+        if (obj instanceof BoundingBox) {
             BoundingBox other = (BoundingBox) obj;
             return this.equals(other, EQUALITYTHRESHOLD);
         }
@@ -276,10 +276,12 @@ public class BoundingBox implements Serializable {
                 || other.getMaxY() < getMinY());
     }
 
+    @SuppressWarnings("AmbiguousMethodReference")
     public BoundingBox intersection(BoundingBox bboxB) {
-        return intersection(this, bboxB);
+        return BoundingBox.intersection(this, bboxB);
     }
 
+    @SuppressWarnings("AmbiguousMethodReference")
     public static BoundingBox intersection(BoundingBox bboxA, BoundingBox bboxB) {
         BoundingBox retBbox = new BoundingBox(0, 0, -1, -1);
         if (bboxA.intersects(bboxB)) {

--- a/geowebcache/core/src/main/java/org/geowebcache/grid/GridSubset.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/GridSubset.java
@@ -334,7 +334,7 @@ public class GridSubset {
 
                 long baseX = gridLoc[0] * 2;
                 long baseY = gridLoc[1] * 2;
-                long baseZ = idx + 1;
+                long baseZ = idx + 1L;
 
                 long[] xOffset = {0, 1, 0, 1};
                 long[] yOffset = {0, 0, 1, 1};

--- a/geowebcache/core/src/main/java/org/geowebcache/io/XMLBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/io/XMLBuilder.java
@@ -47,7 +47,7 @@ public class XMLBuilder {
         ESCAPE_ENTITIES = Collections.unmodifiableMap(entities);
     }
 
-    class NodeInfo {
+    static class NodeInfo {
         String name;
         boolean indented;
         boolean containsIndented = false;

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -301,7 +302,7 @@ public abstract class TileLayer implements Info {
         Iterator<FormatModifier> iter = formatModifiers.iterator();
         while (iter.hasNext()) {
             FormatModifier mod = iter.next();
-            if (mod.getResponseFormat() == responseFormat) {
+            if (Objects.equals(mod.getResponseFormat(), responseFormat)) {
                 return mod;
             }
         }

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayerDispatcher.java
@@ -14,12 +14,11 @@
 package org.geowebcache.layer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -28,7 +27,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
@@ -65,8 +63,9 @@ public class TileLayerDispatcher
     private ApplicationContext applicationContext;
 
     /**
-     * Used for testing only, in production use {@link #TileLayerDispatcher(GridSetBroker)} instead, configurations are
-     * loaded from the application context, the {@code config} parameter will be overwritten
+     * Used for testing only, in production use {@link #TileLayerDispatcher(GridSetBroker, TileLayerDispatcherFilter)}
+     * instead, configurations are loaded from the application context, the {@code configs} parameter will be
+     * overwritten
      */
     public TileLayerDispatcher(
             GridSetBroker gridSetBroker,
@@ -154,13 +153,10 @@ public class TileLayerDispatcher
      *
      * @return all layers, but filtered based on the tileLayerDispatcherFilter.
      */
-    @SuppressWarnings("unchecked")
     public Iterable<TileLayer> getLayerListFiltered() {
         Iterable<TileLayer> result = getLayerList();
         if (tileLayerDispatcherFilter != null) {
-            Stream s = StreamSupport.stream(result.spliterator(), false)
-                    .filter(x -> !tileLayerDispatcherFilter.exclude(x));
-            result = s::iterator;
+            result = Iterables.filter(result, x -> !tileLayerDispatcherFilter.exclude(x));
         }
         return result;
     }
@@ -270,7 +266,7 @@ public class TileLayerDispatcher
     }
 
     public synchronized void removeGridSetRecursive(String gridsetToRemove) {
-        Collection<TileLayer> deletedLayers = new LinkedList<>();
+        List<TileLayer> deletedLayers = new ArrayList<>();
         try {
             for (TileLayer tl : getLayerList()) {
                 if (Objects.nonNull(tl.getGridSubset(gridsetToRemove))) {
@@ -334,6 +330,7 @@ public class TileLayerDispatcher
     }
 
     /** @deprecated use GeoWebCacheExtensions.reinitializeConfigurations instead */
+    @Deprecated
     public void reInit() { // do not know how to get rid of it, it's used in mock testing...
         GeoWebCacheExtensions.reinitialize(this.applicationContext);
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSSourceHelper.java
@@ -74,7 +74,7 @@ public abstract class WMSSourceHelper {
         }
         wmsParams.putAll(filteringParameters);
 
-        if (tile.getMimeType() == XMLMime.kml) {
+        if (XMLMime.kml.equals(tile.getMimeType())) {
             // This is a hack for GeoServer to produce regionated KML,
             // but it is unlikely to do much harm, especially since nobody
             // else appears to produce regionated KML at this point

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/FormatModifier.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/FormatModifier.java
@@ -97,7 +97,7 @@ public class FormatModifier implements Serializable {
     public synchronized ImageWriteParam adjustImageWriteParam(ImageWriteParam param) {
         if (imgWriteParam == null) {
             if (getCompressionQuality() != null) {
-                if (getResponseFormat() == ImageMime.jpeg) {
+                if (ImageMime.jpeg.equals(getResponseFormat())) {
                     param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
                     param.setCompressionQuality(getCompressionQuality());
                 } else {

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeedTask.java
@@ -208,6 +208,7 @@ class SeedTask extends GWCTask {
         super.state = GWCTask.STATE.DONE;
     }
 
+    @SuppressWarnings("ThreadPriorityCheck")
     private void reprioritize() {
         Thread.currentThread().setPriority((java.lang.Thread.NORM_PRIORITY + java.lang.Thread.MIN_PRIORITY) / 2);
     }

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/TileBreeder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/TileBreeder.java
@@ -528,8 +528,8 @@ public class TileBreeder implements ApplicationContextAware {
      */
     private Iterator<GWCTask> filterTasks(STATE... filter) {
         Set<STATE> states = new HashSet<>(Arrays.asList(filter));
-        lock.readLock().lock();
         List<GWCTask> runningTasks = new ArrayList<>(this.currentPool.size());
+        lock.readLock().lock();
         try {
             Collection<SubmittedTask> values = this.currentPool.values();
             for (SubmittedTask t : values) {

--- a/geowebcache/core/src/main/java/org/geowebcache/service/OWSException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/service/OWSException.java
@@ -48,6 +48,11 @@ public class OWSException extends Exception {
     }
 
     @Override
+    public String getMessage() {
+        return exceptionText;
+    }
+
+    @Override
     public String toString() {
         StringBuilder str = new StringBuilder();
         str.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");

--- a/geowebcache/core/src/main/java/org/geowebcache/stats/RuntimeStats.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/stats/RuntimeStats.java
@@ -72,7 +72,7 @@ public class RuntimeStats {
      * @param intervalDescs the description for each of the previously defined intervals
      */
     public RuntimeStats(int pollInterval, List<Integer> intervals, List<String> intervalDescs) {
-        this(pollInterval, intervals, intervalDescs, Clock.systemDefaultZone());
+        this(pollInterval, intervals, intervalDescs, Clock.systemUTC());
     }
     /**
      * @param pollInterval seconds between recording aggregate values
@@ -122,6 +122,8 @@ public class RuntimeStats {
         statsThread.start();
     }
 
+    @SuppressWarnings(
+            "ThreadPriorityCheck") // errorprone complaint on Thread.yield(), revisit, might indeed be unnecessary
     public void destroy() {
         if (this.statsThread != null) {
             statsThread.run = false;
@@ -177,18 +179,18 @@ public class RuntimeStats {
 
                 str.append("<tr><th colspan=\"2\" scope=\"row\">Total number of requests:</th><td colspan=\"3\">"
                         + totalRequests);
-                str.append(" (" + totalRequests / (runningTime) + "/s ) ");
+                str.append(" (" + totalRequests / runningTime + "/s ) ");
                 str.append("</td></tr>\n");
 
                 str.append(
                         "<tr><th colspan=\"2\" scope=\"row\">Total number of untiled WMS requests:</th><td colspan=\"3\">"
                                 + totalWMS);
-                str.append(" (" + totalWMS / (runningTime) + "/s ) ");
+                str.append(" (" + totalWMS / runningTime + "/s ) ");
                 str.append("</td></tr>\n");
 
                 str.append("<tr><th colspan=\"2\" scope=\"row\">Total number of bytes:</th><td colspan=\"3\">"
                         + totalBytes);
-                str.append(" (" + formatBits((totalBytes * 8.0) / (runningTime)) + ") ");
+                str.append(" (" + formatBits((totalBytes * 8.0) / runningTime) + ") ");
                 str.append("</td></tr>\n");
 
                 str.append("</tbody>");
@@ -379,7 +381,7 @@ public class RuntimeStats {
         public void run() {
             try {
                 while (run) {
-                    Thread.sleep(stats.pollInterval * 1000);
+                    Thread.sleep(stats.pollInterval * 1000L);
                     updateLists();
                 }
             } catch (InterruptedException e) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/BlobStoreAggregator.java
@@ -71,7 +71,9 @@ public class BlobStoreAggregator {
 
     /**
      * Indicates if this configurations contains a {@link BlobStoreInfo) identified by a given name.
+     *
      * @param blobStoreInfoName the name of a {@link BlobStoreInfo} for which existence is desired.
+     *
      * @return True if a {@link BlobStoreInfo} currently exists with the unique name provided, false otherwise.
      */
     public boolean blobStoreExists(final String blobStoreInfoName) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/CompositeBlobStore.java
@@ -596,6 +596,7 @@ public class CompositeBlobStore implements BlobStore, BlobStoreConfigurationList
      * @param exists The storage is already a GWC cache
      * @param empty The storage is empty
      */
+    @SuppressWarnings("FallThrough")
     public static void checkSuitability(String location, final boolean exists, boolean empty)
             throws UnsuitableStorageException {
         switch (getStoreSuitabilityCheck()) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/UnsuitableStorageException.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/UnsuitableStorageException.java
@@ -27,6 +27,7 @@ public class UnsuitableStorageException extends StorageException {
         super(msg);
     }
 
+    @SuppressWarnings("FallThrough") // REVISIT the switch logic is hard to follow
     public static void checkSuitability(String location, final boolean exists, boolean empty)
             throws UnsuitableStorageException {
         switch (CompositeBlobStore.getStoreSuitabilityCheck()) {

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathFilter.java
@@ -114,8 +114,8 @@ public class DefaultFilePathFilter implements FilenameFilter {
         String[] parts = name.split("_");
         long halfX = Long.parseLong(parts[0]);
         long halfY = Long.parseLong(parts[1]);
-        long shift = z / 2;
-        long half = 2 << shift;
+        long shift = (long) z / 2;
+        long half = 2L << shift;
         long minX = halfX * half;
         long minY = halfY * half;
         long maxX = minX + half;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathGenerator.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/DefaultFilePathGenerator.java
@@ -61,7 +61,7 @@ public class DefaultFilePathGenerator implements FilePathGenerator {
         StringBuilder path = new StringBuilder(256);
 
         long shift = z / 2;
-        long half = 2 << shift;
+        long half = 2L << shift;
         int digits = 1;
         if (half > 10) {
             digits = (int) (Math.log10(half)) + 1;

--- a/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/storage/blobstore/file/FileBlobStore.java
@@ -348,7 +348,7 @@ public class FileBlobStore implements BlobStore {
         } else {
             throw new StorageException("Couldn't rename layer directory " + oldLayerPath + " to " + newLayerPath);
         }
-        return renamed;
+        return true;
     }
 
     private File getLayerPath(String layerName) {
@@ -697,7 +697,7 @@ public class FileBlobStore implements BlobStore {
 
         final int blockSize = this.diskBlockSize;
 
-        long actuallyUsedStorage = blockSize * (int) Math.ceil((double) fileSize / blockSize);
+        long actuallyUsedStorage = blockSize * (long) Math.ceil((double) fileSize / blockSize);
 
         return actuallyUsedStorage;
     }
@@ -749,7 +749,7 @@ public class FileBlobStore implements BlobStore {
         if (!layerPath.exists()) {
             return Stream.of();
         }
-        @SuppressWarnings("PMD.CloseResource") // wrapped and closed in the return value
+        @SuppressWarnings({"PMD.CloseResource", "StreamResourceLeak"}) // wrapped and closed in the return value
         final DirectoryStream<Path> layerDirStream = Files.newDirectoryStream(layerPath.toPath(), filter);
         return StreamSupport.stream(layerDirStream.spliterator(), false)
                 .onClose( // Delegate closing so that when the returned stream is closed, so is the

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -9,7 +9,6 @@
     <description>GeoWebCache is an advanced tile cache for WMS servers. It supports a large variety of protocols and
       formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</description>
     <keywords>
-      <string>WFS</string>
       <string>WMS</string>
       <string>WMTS</string>
       <string>GEOWEBCACHE</string>
@@ -148,12 +147,12 @@
   </gridSets>
 
   <layers>
-
+    
     <wmsLayer>
       <!-- 
       <blobStoreId>myS3Cache</blobStoreId>
       -->
-      <name>topp:states</name>
+      <name>states</name>
       <mimeFormats>
         <string>image/gif</string>
         <string>image/jpeg</string>
@@ -188,7 +187,8 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <!-- Use of workspace 'topp' web map service, allows name 'states' (rather than 'topp:states') -->
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,9 +217,9 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
-      <wmsLayers>nasa:bluemarble</wmsLayers>
+      <wmsLayers>nurc:Arc_Sample</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
         <legend style=""/>
       </legends>
@@ -257,9 +257,11 @@
       <expireClientsList>
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
+      <!-- global geoserver wms service allows layers different workspaces -->
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
+      <!-- layers from several workspaces -->
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>
       <bgColor>0x0066FF</bgColor>

--- a/geowebcache/core/src/main/resources/geowebcache_empty.xml
+++ b/geowebcache/core/src/main/resources/geowebcache_empty.xml
@@ -91,7 +91,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -104,7 +104,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -141,7 +141,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/FileBlobStoreComformanceTest.java
@@ -71,6 +71,7 @@ public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlob
     }
 
     private void executeStoresConcurrently(int numberOfStores, int numberOfThreads) throws InterruptedException {
+
         ExecutorService service = Executors.newFixedThreadPool(numberOfStores);
         CountDownLatch latch = new CountDownLatch(numberOfStores);
         for (int i = 0; i < numberOfStores; i++) {
@@ -100,6 +101,7 @@ public class FileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileBlob
     public void testConcurrentMetadataWithPointInKey() throws InterruptedException {
         assertThat(store.getLayerMetadata("testLayer", "test.Key"), nullValue());
         int numberOfThreads = 2;
+
         ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
         for (int i = 0; i < numberOfThreads; i++) {

--- a/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/XYZFileBlobStoreComformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/blobstore/file/XYZFileBlobStoreComformanceTest.java
@@ -57,6 +57,7 @@ public class XYZFileBlobStoreComformanceTest extends AbstractBlobStoreTest<FileB
     }
 
     @Override
+    @SuppressWarnings("CatchFail")
     public void createTestUnit() throws Exception {
         this.layers = createMock(TileLayerDispatcher.class);
         GridSet wgs84Grid = new DefaultGridsets(false, false).worldEpsg4326();

--- a/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/DefaultingConfigurationTest.java
@@ -60,7 +60,7 @@ public class DefaultingConfigurationTest {
         boolean cacheBypass = tl.isCacheBypassAllowed();
         int timeout = tl.getBackendTimeout();
         assertFalse(cacheBypass);
-        assertEquals(timeout, 120);
+        assertEquals(120, timeout);
         assertNull(tl.getFormatModifiers());
     }
 
@@ -68,9 +68,9 @@ public class DefaultingConfigurationTest {
     public void initializationTest() {
         initialize(tl);
         Set<String> subsets = tl.getGridSubsets();
-        assertEquals(subsets.size(), 2);
-        assertEquals(subsets.toArray()[0], "EPSG:4326");
-        assertEquals(subsets.toArray()[1], "EPSG:900913");
+        assertEquals(2, subsets.size());
+        assertEquals("EPSG:4326", subsets.toArray()[0]);
+        assertEquals("EPSG:900913", subsets.toArray()[1]);
     }
 
     GeoWebCacheConfiguration getGwcConfig() {

--- a/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTestData.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/GWCConfigIntegrationTestData.java
@@ -27,6 +27,7 @@ import org.geowebcache.grid.SRS;
 import org.geowebcache.layer.wms.WMSLayer;
 
 /** Test data for {@link GWCConfigIntegrationTest} */
+@SuppressWarnings("MutablePublicArray")
 public class GWCConfigIntegrationTestData {
 
     // Names / ids for config objects
@@ -102,7 +103,7 @@ public class GWCConfigIntegrationTestData {
 
         WMSLayer wmsLayer = new WMSLayer(
                 LAYER_TOPP_STATES,
-                new String[] {"http://demo.opengeo.org/geoserver/topp/wms"},
+                new String[] {"http://localhost:8080/geoserver/topp/wms"},
                 null,
                 null,
                 Arrays.asList("image/gif", "image/jpeg", "image/png", "image/png8"),

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
@@ -82,8 +82,8 @@ public class XMLConfigurationBackwardsCompatibilityTest {
         assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
-        assertEquals(layer.getBackendTimeout().intValue(), 60);
-        assertEquals(layer2.getBackendTimeout().intValue(), 235);
+        assertEquals(60, layer.getBackendTimeout().intValue());
+        assertEquals(235, layer2.getBackendTimeout().intValue());
         assertTrue(layer.isCacheBypassAllowed().booleanValue());
         assertFalse(layer2.isCacheBypassAllowed().booleanValue());
     }
@@ -100,18 +100,18 @@ public class XMLConfigurationBackwardsCompatibilityTest {
         assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
-        assertEquals(layer.getBackendTimeout().intValue(), 120);
-        assertEquals(layer2.getBackendTimeout().intValue(), 120);
+        assertEquals(120, layer.getBackendTimeout().intValue());
+        assertEquals(120, layer2.getBackendTimeout().intValue());
         assertTrue(layer.isCacheBypassAllowed().booleanValue());
         assertTrue(layer2.isCacheBypassAllowed().booleanValue());
 
         FormatModifier fm = layer.getFormatModifier(ImageMime.jpeg);
-        assertEquals(fm.getBgColor(), "0xDDDDDD");
-        assertEquals(fm.getRequestFormat(), ImageMime.png);
+        assertEquals("0xDDDDDD", fm.getBgColor());
+        assertEquals(ImageMime.png, fm.getRequestFormat());
 
         List<RequestFilter> filters = layer.getRequestFilters();
-        assertEquals(filters.get(0).getName(), "testWMSRasterFilter");
-        assertEquals(filters.get(1).getName(), "testFileRasterFilter");
+        assertEquals("testWMSRasterFilter", filters.get(0).getName());
+        assertEquals("testFileRasterFilter", filters.get(1).getName());
     }
 
     @Test
@@ -126,20 +126,20 @@ public class XMLConfigurationBackwardsCompatibilityTest {
         assertNotNull(grid);
 
         // The additions in 1.0.1 are allowCacheBypass and backendTimeout
-        assertEquals(layer.getBackendTimeout().intValue(), 120);
-        assertEquals(layer2.getBackendTimeout().intValue(), 120);
+        assertEquals(120, layer.getBackendTimeout().intValue());
+        assertEquals(120, layer2.getBackendTimeout().intValue());
         assertTrue(layer.isCacheBypassAllowed().booleanValue());
         assertTrue(layer2.isCacheBypassAllowed().booleanValue());
 
         FormatModifier fm = layer.getFormatModifier(ImageMime.jpeg);
-        assertEquals(fm.getBgColor(), "0xDDDDDD");
-        assertEquals(fm.getRequestFormat(), ImageMime.png);
+        assertEquals("0xDDDDDD", fm.getBgColor());
+        assertEquals(ImageMime.png, fm.getRequestFormat());
 
         List<RequestFilter> filters = layer.getRequestFilters();
         RequestFilter filter0 = filters.get(0);
-        assertEquals(filter0.getName(), "testWMSRasterFilter");
+        assertEquals("testWMSRasterFilter", filter0.getName());
         RequestFilter filter1 = filters.get(1);
-        assertEquals(filter1.getName(), "testFileRasterFilter");
+        assertEquals("testFileRasterFilter", filter1.getName());
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationLayerConformanceTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationLayerConformanceTest.java
@@ -156,14 +156,7 @@ public class XMLConfigurationLayerConformanceTest extends LayerConfigurationTest
 
     @Override
     protected Matcher<TileLayer> infoEquals(int expected) {
-        return new CustomMatcher<>("Layer with value" + expected) {
-
-            @Override
-            public boolean matches(Object item) {
-                return item instanceof WMSLayer
-                        && ((WMSLayer) item).getWmsLayers().equals(expected);
-            }
-        };
+        throw new UnsupportedOperationException("unused");
     }
 
     @Override

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/MetaTileTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/MetaTileTest.java
@@ -158,7 +158,7 @@ public class MetaTileTest {
 
         int height = Integer.parseInt(wmsParams.get("HEIGHT"));
 
-        Assert.assertEquals(height, 256 + 50);
+        Assert.assertEquals(256 + 50, height);
 
         long[] midGridPos = {83, 45, 6};
         mt = new WMSMetaTile(
@@ -180,7 +180,7 @@ public class MetaTileTest {
 
         height = Integer.parseInt(wmsParams.get("HEIGHT"));
 
-        Assert.assertEquals(height, 768 + 2 * 50);
+        Assert.assertEquals(768 + 2 * 50, height);
 
         String[] coordStrs = wmsParams.get("BBOX").split(",");
 
@@ -222,7 +222,7 @@ public class MetaTileTest {
 
         int height = Integer.parseInt(wmsParams.get("HEIGHT"));
 
-        Assert.assertEquals(height, 256);
+        Assert.assertEquals(256, height);
     }
 
     private WMSLayer createWMSLayer(BoundingBox layerBounds) {

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
@@ -546,6 +546,7 @@ public class WMSLayerTest extends TileLayerTest {
         long[] gridLoc = trIter.nextMetaGridLocation(new long[3]);
 
         // six concurrent requests max
+
         ExecutorService requests = Executors.newFixedThreadPool(6);
         ExecutorCompletionService<ConveyorTile> completer = new ExecutorCompletionService<>(requests);
 
@@ -662,7 +663,7 @@ public class WMSLayerTest extends TileLayerTest {
         }
     }
 
-    class MockTileSupport {
+    static class MockTileSupport {
 
         final byte[] fakeWMSResponse;
         final StorageBroker storageBroker = EasyMock.createMock(StorageBroker.class);

--- a/geowebcache/core/src/test/java/org/geowebcache/mime/XMLMimeTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/mime/XMLMimeTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+@SuppressWarnings("CatchFail")
 public class XMLMimeTest {
 
     @Test

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1100.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1100.xml
@@ -150,7 +150,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -163,7 +163,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -201,7 +201,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1110.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1110.xml
@@ -150,7 +150,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -163,7 +163,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -201,7 +201,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1120.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1120.xml
@@ -150,7 +150,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -171,7 +171,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -212,7 +212,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1130.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1130.xml
@@ -150,7 +150,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -171,7 +171,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -212,7 +212,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1140.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1140.xml
@@ -170,7 +170,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -199,7 +199,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -240,7 +240,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1150.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1150.xml
@@ -170,7 +170,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -199,7 +199,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -240,7 +240,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1170.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1170.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1180.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1180.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1190.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1190.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1200.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1200.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1210.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1210.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1220.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1220.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1230.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1230.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1240.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1240.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1250.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1250.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_126.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_126.xml
@@ -77,7 +77,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
     </wmsLayer>
   </layers>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1260.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_1260.xml
@@ -188,7 +188,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/topp/wms</string>
+        <string>https://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
       <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
         <legend style="population"/>
@@ -217,7 +217,7 @@
         </gridSubset>
       </gridSubsets>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nasa:bluemarble</wmsLayers>
       <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
@@ -258,7 +258,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>https://demo.boundlessgeo.com/geoserver/wms</string>
+        <string>https://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_140.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_140.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_150.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_150.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_151.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_151.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_153.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_153.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_160.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_160.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_161.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_161.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_170.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_170.xml
@@ -89,7 +89,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -102,7 +102,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -140,7 +140,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_180.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_180.xml
@@ -133,7 +133,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -146,7 +146,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -184,7 +184,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_190.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_190.xml
@@ -133,7 +133,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -146,7 +146,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -184,7 +184,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_4326_override.xml
@@ -176,7 +176,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
 
@@ -189,7 +189,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -227,7 +227,7 @@
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/BDBQuotaStore.java
@@ -16,7 +16,6 @@ package org.geowebcache.diskquota.bdb;
 import static org.geowebcache.diskquota.DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED;
 import static org.geowebcache.util.FileUtils.listFilesNullSafe;
 
-import com.google.common.base.Objects;
 import com.sleepycat.je.CursorConfig;
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.LockMode;
@@ -34,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -397,12 +397,12 @@ public class BDBQuotaStore implements QuotaStore {
 
     @Override
     public void deleteGridSubset(String layerName, String gridSetId) {
-        issue(new Deleter(layerName, ts -> Objects.equal(ts.getGridsetId(), gridSetId)));
+        issue(new Deleter(layerName, ts -> Objects.equals(ts.getGridsetId(), gridSetId)));
     }
 
     @Override
     public void deleteParameters(String layerName, String parametersId) {
-        issue(new Deleter(layerName, ts -> Objects.equal(ts.getParametersId(), parametersId)));
+        issue(new Deleter(layerName, ts -> Objects.equals(ts.getParametersId(), parametersId)));
     }
 
     private class Deleter implements Callable<Void> {

--- a/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/DiskQuotaEntityModel.java
+++ b/geowebcache/diskquota/bdb/src/main/java/org/geowebcache/diskquota/bdb/DiskQuotaEntityModel.java
@@ -78,7 +78,7 @@ public class DiskQuotaEntityModel extends AnnotationModel {
     }
 
     @Override
-    public ClassMetadata getClassMetadata(String className) {
+    public synchronized ClassMetadata getClassMetadata(String className) {
         ClassMetadata metadata = super.getClassMetadata(className);
         if (metadata != null) {
             return metadata;
@@ -88,7 +88,7 @@ public class DiskQuotaEntityModel extends AnnotationModel {
     }
 
     @Override
-    public EntityMetadata getEntityMetadata(String className) {
+    public synchronized EntityMetadata getEntityMetadata(String className) {
         EntityMetadata metadata = super.getEntityMetadata(className);
         if (metadata != null) {
             return metadata;
@@ -98,7 +98,7 @@ public class DiskQuotaEntityModel extends AnnotationModel {
     }
 
     @Override
-    public Set<String> getKnownClasses() {
+    public synchronized Set<String> getKnownClasses() {
         return classes.keySet();
     }
 }

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +31,6 @@ import org.geowebcache.config.BaseConfiguration;
 import org.geowebcache.config.DefaultGridsets;
 import org.geowebcache.config.GridSetConfiguration;
 import org.geowebcache.config.MockConfigurationResourceProvider;
-import org.geowebcache.config.TileLayerConfiguration;
 import org.geowebcache.config.XMLConfiguration;
 import org.geowebcache.config.XMLConfigurationBackwardsCompatibilityTest;
 import org.geowebcache.diskquota.bdb.BDBQuotaStore;
@@ -112,8 +110,6 @@ public class BDBQuotaStoreTest {
                         e -> e.getValue().stream().map(ParametersUtils::getKvp).collect(Collectors.toSet())));
         XMLConfiguration xmlConfig = loadXMLConfig();
         context.addBean("xmlConfig", xmlConfig, XMLConfiguration.class.getInterfaces());
-        LinkedList<TileLayerConfiguration> configList = new LinkedList<>();
-        configList.add(xmlConfig);
         context.addBean(
                 "DefaultGridsets",
                 new DefaultGridsets(true, true),
@@ -311,7 +307,7 @@ public class BDBQuotaStoreTest {
                         throw new AssertionError("Unexpected Exception", e);
                     }
                 })
-                .collect(Collectors.summingLong(mb -> mb * 1024 * 1024));
+                .collect(Collectors.summingLong(mb -> mb * 1024L * 1024L));
         assertThat(quotaToDelete, greaterThan(0L));
         long quotaToKeep = tilePageCalculator.getTileSetsFor(layerName).stream()
                 .filter(ts -> !ts.getGridsetId().equals(gridSetId))
@@ -327,7 +323,7 @@ public class BDBQuotaStoreTest {
                         throw new AssertionError("Unexpected Exception", e);
                     }
                 })
-                .collect(Collectors.summingLong(mb -> mb * 1024 * 1024));
+                .collect(Collectors.summingLong(mb -> mb * 1024L * 1024L));
         assertThat(quotaToKeep, greaterThan(0L));
 
         assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToDelete + quotaToKeep));
@@ -356,7 +352,7 @@ public class BDBQuotaStoreTest {
                         throw new AssertionError("Unexpected Exception", e);
                     }
                 })
-                .collect(Collectors.summingLong(mb -> mb * 1024 * 1024));
+                .collect(Collectors.summingLong(mb -> mb * 1024L * 1024L));
         assertThat(quotaToDelete, greaterThan(0L));
         long quotaToKeep = tilePageCalculator.getTileSetsFor(layerName).stream()
                 .filter(ts -> !ts.getParametersId().equals(parametersId))
@@ -372,7 +368,7 @@ public class BDBQuotaStoreTest {
                         throw new AssertionError("Unexpected Exception", e);
                     }
                 })
-                .collect(Collectors.summingLong(mb -> mb * 1024 * 1024));
+                .collect(Collectors.summingLong(mb -> mb * 1024L * 1024L));
         assertThat(quotaToKeep, greaterThan(0L));
 
         assertThat(store.getUsedQuotaByLayerName(layerName), bytes(quotaToDelete + quotaToKeep));
@@ -445,7 +441,7 @@ public class BDBQuotaStoreTest {
     public void testGetLeastRecentlyUsedPage() throws Exception {
         MockSystemUtils mockSystemUtils = new MockSystemUtils();
         mockSystemUtils.setCurrentTimeMinutes(1000);
-        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60 * 1000);
+        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60L * 1000L);
         SystemUtils.set(mockSystemUtils);
 
         final String layerName = testTileSet.getLayerName();

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/LayerCacheInfoBuilder.java
@@ -190,7 +190,7 @@ final class LayerCacheInfoBuilder {
 
         private final String parametersId;
 
-        private class Stats {
+        private static class Stats {
             long runTimeMillis;
 
             long numTiles;
@@ -290,7 +290,7 @@ final class LayerCacheInfoBuilder {
          *
          * @author groldan
          */
-        private class TraversalCanceledException extends RuntimeException {
+        private static class TraversalCanceledException extends RuntimeException {
             private static final long serialVersionUID = 1L;
             // doesn't need a body
         }

--- a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
+++ b/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/storage/PagePyramid.java
@@ -89,7 +89,7 @@ class PagePyramid {
                     + " x "
                     + pagesY
                     + " ("
-                    + nf.format(pagesX * pagesY)
+                    + nf.format(pagesX * (long) pagesY)
                     + "), "
                     + "tiles:"
                     + tilesPerPageX

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/ConfigLoaderTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/ConfigLoaderTest.java
@@ -159,9 +159,8 @@ public class ConfigLoaderTest {
     @Test
     public void testSaveConfig() throws ConfigurationException, IOException {
         DiskQuotaConfig config = new DiskQuotaConfig();
-        List<LayerQuota> quotas = new ArrayList<>();
+
         LayerQuota lq = new LayerQuota("topp:states", LRU, new Quota(10, StorageUnit.MiB));
-        quotas.add(lq);
         config.addLayerQuota(lq);
 
         File configFile = new File(cacheDir, "geowebcache-diskquota.xml");
@@ -170,10 +169,6 @@ public class ConfigLoaderTest {
         }
         loader.saveConfig(config);
         Assert.assertTrue(configFile.exists());
-
-        // loader = new ConfigLoader(storageFinder, contextProvider, tld);
-        // DiskQuotaConfig loadConfig = loader.loadConfig();
-        // assertNotNull(loadConfig);
     }
 
     @Test

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PagePyramidTest.java
@@ -80,7 +80,7 @@ public class PagePyramidTest {
 
             PageLevelInfo pageInfo = pp.getPageInfo(z);
 
-            long levelPages = pageInfo.pagesX * pageInfo.pagesY;
+            long levelPages = pageInfo.pagesX * (long) pageInfo.pagesY;
             BigInteger tilesPerPage = pageInfo.tilesPerPage;
 
             totalPages += levelPages;
@@ -143,10 +143,10 @@ public class PagePyramidTest {
         int tilesPerPageX = pyramid.getTilesPerPageX(level);
         int tilesPerPageY = pyramid.getTilesPerPageY(level);
         long[] expected = {
-            coverages[level][0] + tilesPerPageX * pageX, //
-            coverages[level][1] + tilesPerPageY * pageY, //
-            coverages[level][0] + tilesPerPageX * pageX + tilesPerPageX - 1, //
-            coverages[level][0] + tilesPerPageY * pageY + tilesPerPageY - 1, //
+            coverages[level][0] + (long) tilesPerPageX * pageX, //
+            coverages[level][1] + (long) tilesPerPageY * pageY, //
+            coverages[level][0] + (long) tilesPerPageX * pageX + tilesPerPageX - 1, //
+            coverages[level][0] + (long) tilesPerPageY * pageY + tilesPerPageY - 1, //
             pageZ
         };
         Assert.assertEquals(asList(expected), asList(gridCoverage[1]));

--- a/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PageStatsTest.java
+++ b/geowebcache/diskquota/core/src/test/java/org/geowebcache/diskquota/storage/PageStatsTest.java
@@ -62,7 +62,7 @@ public class PageStatsTest {
         numHits = 100;
         stats.addHitsAndAccessTime(numHits, CREATION_TIME_MINUTES + 3, CREATION_TIME_MINUTES);
         frequencyOfUsePerMinute = stats.getFrequencyOfUsePerMinute();
-        Assert.assertEquals(110f / 4f, frequencyOfUsePerMinute, 1e-6f);
+        Assert.assertEquals(110f / 4f, frequencyOfUsePerMinute, 1e-5f);
     }
 
     @Test

--- a/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
+++ b/geowebcache/diskquota/jdbc/src/main/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreFactory.java
@@ -198,7 +198,7 @@ public class JDBCQuotaStoreFactory implements QuotaStoreFactory, ApplicationCont
                 bds.setMaxOpenPreparedStatements(cp.getMaxOpenPreparedStatements());
                 bds.setMinIdle(cp.getMinConnections());
                 bds.setMaxActive(cp.getMaxConnections());
-                bds.setMaxWait(cp.getConnectionTimeout() * 1000);
+                bds.setMaxWait(cp.getConnectionTimeout() * 1000L);
                 bds.setValidationQuery(cp.getValidationQuery());
 
                 ds = bds;

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.base.Objects;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -25,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -462,7 +462,7 @@ public abstract class JDBCQuotaStoreTest {
         assertThat(
                 store.getTileSets(),
                 containsInAnyOrder(expectedTileSets.stream()
-                        .filter(ts -> !(Objects.equal(ts.getParametersId(), paramIds[1])
+                        .filter(ts -> !(Objects.equals(ts.getParametersId(), paramIds[1])
                                 && ts.getLayerName().equals(layerName)))
                         .map(Matchers::equalTo)
                         .collect(Collectors.toSet())));
@@ -634,7 +634,7 @@ public abstract class JDBCQuotaStoreTest {
         assertEquals(sysUtils.currentTimeMinutes(), lastAccessTimeMinutes);
 
         float frequencyOfUsePerMinute = stats.getFrequencyOfUsePerMinute();
-        assertEquals(100f, frequencyOfUsePerMinute, 1e-6f);
+        assertEquals(100f, frequencyOfUsePerMinute, 1e-5f);
 
         // now 1 minute later...
         sysUtils.setCurrentTimeMinutes(sysUtils.currentTimeMinutes() + 2);
@@ -762,7 +762,7 @@ public abstract class JDBCQuotaStoreTest {
     public void testGetLeastRecentlyUsedPage() throws Exception {
         MockSystemUtils mockSystemUtils = new MockSystemUtils();
         mockSystemUtils.setCurrentTimeMinutes(1000);
-        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60 * 1000);
+        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60L * 1000L);
         SystemUtils.set(mockSystemUtils);
 
         final String layerName = testTileSet.getLayerName();
@@ -777,8 +777,8 @@ public abstract class JDBCQuotaStoreTest {
         PageStatsPayload payload1 = new PageStatsPayload(page1, testTileSet);
         PageStatsPayload payload2 = new PageStatsPayload(page2, testTileSet);
 
-        payload1.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 1 * 60 * 1000);
-        payload2.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 2 * 60 * 1000);
+        payload1.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 1 * 60L * 1000L);
+        payload2.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 2 * 60L * 1000L);
 
         Collection<PageStatsPayload> statsUpdates = Arrays.asList(payload1, payload2);
         store.addHitsAndSetAccesTime(statsUpdates).get();
@@ -786,7 +786,7 @@ public abstract class JDBCQuotaStoreTest {
         leastRecentlyUsedPage = store.getLeastRecentlyUsedPage(layerNames);
         assertEquals(page1, leastRecentlyUsedPage);
 
-        payload1.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 10 * 60 * 1000);
+        payload1.setLastAccessTime(mockSystemUtils.currentTimeMillis() + 10 * 60L * 1000L);
         store.addHitsAndSetAccesTime(statsUpdates).get();
 
         leastRecentlyUsedPage = store.getLeastRecentlyUsedPage(layerNames);
@@ -797,7 +797,7 @@ public abstract class JDBCQuotaStoreTest {
     public void testGetLeastRecentlyUsedPageSkipEmpty() throws Exception {
         MockSystemUtils mockSystemUtils = new MockSystemUtils();
         mockSystemUtils.setCurrentTimeMinutes(1000);
-        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60 * 1000);
+        mockSystemUtils.setCurrentTimeMillis(mockSystemUtils.currentTimeMinutes() * 60L * 1000L);
         SystemUtils.set(mockSystemUtils);
 
         final String layerName = testTileSet.getLayerName();

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/OnlineTestRule.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/OnlineTestRule.java
@@ -68,8 +68,6 @@ public class OnlineTestRule extends ExternalResource {
     /**
      * Check whether the fixture is available. This method also loads the configuration if present, and tests the
      * connection using {@link #isOnline()}.
-     *
-     * @return true if fixture is available for use
      */
     void checkAvailable() {
         configureFixture();
@@ -189,6 +187,7 @@ public class OnlineTestRule extends ExternalResource {
 
     /** Tear down method for test, calls through to {@link #disconnect()} if the test is active. */
     @Override
+    @SuppressWarnings("Finally")
     protected final void after() {
         try {
             tearDownInternal();

--- a/geowebcache/diskquota/jdbc/src/test/resources/gwc-test-config.xml
+++ b/geowebcache/diskquota/jdbc/src/test/resources/gwc-test-config.xml
@@ -24,7 +24,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
   </layers>

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/GeoRSSPollTask.java
@@ -325,6 +325,7 @@ class GeoRSSPollTask implements Runnable {
         }
     }
 
+    @SuppressWarnings("ThreadPriorityCheck")
     protected void stopSeeding(boolean checkLiveCount) {
         if (this.seedTasks != null) {
             int liveCount = 0;

--- a/geowebcache/gmaps/src/test/java/org/geowebcache/service/gmaps/GMapsConverterTest.java
+++ b/geowebcache/gmaps/src/test/java/org/geowebcache/service/gmaps/GMapsConverterTest.java
@@ -90,7 +90,7 @@ public class GMapsConverterTest {
     private static final String TEST_LAYER_NAME = "testLayer";
 
     @Test
-    public void testConveyorCreation() {
+    public void testConveyorCreation() throws UnsupportedEncodingException, GeoWebCacheException {
         StorageBroker sb = null;
 
         List<ParameterFilter> filters = new ArrayList<>();
@@ -120,15 +120,11 @@ public class GMapsConverterTest {
 
         GMapsConverter converter = new GMapsConverter(sb, tld, gsb);
 
-        try {
-            ConveyorTile conveyorTile = converter.getConveyor(request, response);
-            Map<String, String> parameters = conveyorTile.getParameters();
-            Assert.assertNotNull(parameters);
-            // assertTrue(parameters.contains(URLEncoder.encode(CQL_FILTER_PARAMETER_VALUE,"UTF8")));
-            Assert.assertEquals(
-                    CQL_FILTER_PARAMETER_VALUE, URLDecoder.decode(parameters.get(CQL_FILTER_PARAMETER_NAME), "UTF8"));
-        } catch (UnsupportedEncodingException | GeoWebCacheException e) {
-            Assert.fail();
-        }
+        ConveyorTile conveyorTile = converter.getConveyor(request, response);
+        Map<String, String> parameters = conveyorTile.getParameters();
+        Assert.assertNotNull(parameters);
+        // assertTrue(parameters.contains(URLEncoder.encode(CQL_FILTER_PARAMETER_VALUE,"UTF8")));
+        Assert.assertEquals(
+                CQL_FILTER_PARAMETER_VALUE, URLDecoder.decode(parameters.get(CQL_FILTER_PARAMETER_NAME), "UTF8"));
     }
 }

--- a/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLService.java
+++ b/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLService.java
@@ -206,7 +206,7 @@ public class KMLService extends Service {
         ConveyorKMLTile tile = (ConveyorKMLTile) conv;
 
         TileLayer layer;
-        if (tile.getHint() == HINT_DEBUGGRID) {
+        if (HINT_DEBUGGRID.equals(tile.getHint())) {
             layer = KMLDebugGridLayer.getInstance();
 
             // Generate random tile for debugging
@@ -223,7 +223,7 @@ public class KMLService extends Service {
                 writeTileResponse(tile, false, stats, mimeStr);
                 return;
             }
-        } else if (tile.getHint() == HINT_SITEMAP_GLOBAL) {
+        } else if (HINT_SITEMAP_GLOBAL.equals(tile.getHint())) {
             layer = null;
         } else {
             layer = tld.getTileLayer(tile.getLayerId());
@@ -396,7 +396,7 @@ public class KMLService extends Service {
         TileLayer tileLayer = tile.getLayer();
 
         boolean packageData = false;
-        if (tile.getWrapperMimeType() == XMLMime.kmz) {
+        if (XMLMime.kmz.equals(tile.getWrapperMimeType())) {
             packageData = true;
         }
 

--- a/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLSiteMap.java
+++ b/geowebcache/kml/src/main/java/org/geowebcache/service/kml/KMLSiteMap.java
@@ -52,7 +52,7 @@ public class KMLSiteMap {
         tile.servletResp.setContentType("application/xml");
         tile.servletResp.setStatus(200);
 
-        if (tile.getHint() == KMLService.HINT_SITEMAP_LAYER) {
+        if (KMLService.HINT_SITEMAP_LAYER.equals(tile.getHint())) {
             writeSiteMap();
         } else {
             writeSiteMapIndex();

--- a/geowebcache/mbtiles/src/main/java/org/geowebcache/mbtiles/layer/MBTilesLayer.java
+++ b/geowebcache/mbtiles/src/main/java/org/geowebcache/mbtiles/layer/MBTilesLayer.java
@@ -73,7 +73,6 @@ public class MBTilesLayer extends AbstractTileLayer implements TileJSONProvider 
     /*
      * configuration properties
      */
-    private Boolean enabled;
 
     private File tilesPath;
 
@@ -98,16 +97,6 @@ public class MBTilesLayer extends AbstractTileLayer implements TileJSONProvider 
     @Override
     public String getBlobStoreId() {
         return null;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
     }
 
     /** Returns the location of the actual tiles set. */

--- a/geowebcache/mbtiles/src/test/java/org/geowebcache/mbtiles/layer/MBTilesLayerTest.java
+++ b/geowebcache/mbtiles/src/test/java/org/geowebcache/mbtiles/layer/MBTilesLayerTest.java
@@ -233,6 +233,7 @@ public class MBTilesLayerTest {
     }
 
     @Test
+    @SuppressWarnings("MissingFail")
     public void testEmptyTile() throws GeoWebCacheException, IOException {
         try {
             MBTilesLayer testLayer = (MBTilesLayer) config.getLayer("testName").get();

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -69,7 +69,7 @@
     <spotless.apply.skip>false</spotless.apply.skip>
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${spotless.apply.skip}</pom.fmt.skip>
-    <jetty.version>9.4.55.v20240627</jetty.version>
+    <jetty.version>10.0.25</jetty.version>
     <errorProneFlags></errorProneFlags>
     <errorProne.version>2.31.0</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
@@ -327,13 +327,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.0</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.3</version>
           <executions>
             <execution>
               <goals>
@@ -354,13 +349,105 @@
             <skipTests>${skipITs}</skipTests>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>1.4</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.5.3</version>
+        </plugin>
+
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>4.9.10</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.43.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.github.ekryd.sortpom</groupId>
+          <artifactId>sortpom-maven-plugin</artifactId>
+          <version>2.15.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.commonjava.maven.plugins</groupId>
+          <artifactId>directory-maven-plugin</artifactId>
+          <version>0.3.1</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-maven-plugin</artifactId>
+          <version>10.0.25</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.11.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>3.22.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.8.2.0</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.4</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -381,7 +468,6 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -409,11 +495,42 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <!-- Enforcing a minimum Maven version is crucial to ensure that:
+                 - Plugin version resolution works as expected: Different Maven versions
+                   may resolve plugin versions differently due to changes in the default
+                   lifecycle mappings, dependency resolution behavior, and plugin inheritance.
+                 - Features and bug fixes required by newer plugins are available: For example,
+                   some plugins (e.g., surefire-plugin 3.x) require Maven 3.6+ or 3.8+.
+                 - Consistent builds across environments: Without enforcing a Maven version,
+                   developers or CI/CD pipelines using different Maven versions may face
+                   unexpected build failures or inconsistencies.
+            -->
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.8,4.0)</version>
+                  <message>You must use Maven 3.8 or higher to build this project.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[17,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>17</release>
           <encoding>UTF-8</encoding>
           <parameters>true</parameters>
         </configuration>
@@ -421,7 +538,6 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -437,7 +553,6 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -454,7 +569,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.9.10</version>
         <executions>
           <execution>
             <goals>
@@ -472,7 +586,6 @@
 
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2</version>
         <configuration>
           <!--descriptorRefs>
             <descriptorRef>project</descriptorRef>
@@ -490,7 +603,6 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -516,7 +628,6 @@
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
-        <version>2.15.0</version>
         <executions>
           <execution>
             <phase>verify</phase>
@@ -538,7 +649,6 @@
       <plugin>
         <groupId>org.commonjava.maven.plugins</groupId>
         <artifactId>directory-maven-plugin</artifactId>
-        <version>0.3.1</version>
         <executions>
           <execution>
             <id>directories</id>
@@ -557,26 +667,27 @@
 
   <reporting>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-        </configuration>
-      </plugin>
       <!-- javadoc -->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>11</source>
+          <release>17</release>
+          <!-- Force non-modular mode for projects without module-info.java -->
+          <legacyMode>true</legacyMode>
+          <!-- Specifies whether or not the version text is included.-->
           <version>false</version>
+          <!-- Omit qualifying package name before class names in output.-->
           <noqualifier>all</noqualifier>
-          <maxmemory>256M</maxmemory>
-          <encoding>ISO-8859-1</encoding>
-          <additionalparam>-keywords</additionalparam>
+          <!-- Shuts off non-error and non-warning messages.-->
+          <quiet>true</quiet>
+          <!-- The maximum Java heap size to be used to run javadoc. -->
+          <maxmemory>${javadoc.maxHeapSize}</maxmemory>
+          <!-- Specifies the encoding name of the source files.-->
+          <encoding>UTF-8</encoding>
+          <!-- Set an additional parameter for the command line. -->
+          <additionalOptions>-keywords</additionalOptions>
+          <breakiterator>true</breakiterator>
+
           <tags>
             <tag>
               <name>todo</name>
@@ -595,8 +706,8 @@
             </tag>
           </tags>
           <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
-            <link>http://docs.geotools.org/stable/javadocs/</link>
+            <link>https://docs.oracle.com/en/java/javase/17/docs/api/</link>
+            <link>https://docs.geotools.org/stable/javadocs/</link>
           </links>
         </configuration>
       </plugin>
@@ -615,7 +726,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-pmd-plugin</artifactId>
-            <version>3.22.0</version>
             <executions>
               <execution>
                 <goals>
@@ -675,12 +785,45 @@
         <plugins>
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
             <configuration>
               <fork>false</fork>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:${project.build.directory}/generated-sources/.* -Xep:SelfAssertion:OFF ${errorProneFlags}</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:${project.build.directory}/generated-sources/.* \
+                -Xep:SelfAssertion:OFF \
+                -Xep:MissingSummary:OFF \
+                -Xep:DefaultCharset:OFF \
+                -Xep:DoubleCheckedLocking:OFF \
+                -Xep:EmptyBlockTag:OFF \
+                -Xep:EmptyCatch:OFF \
+                -Xep:EqualsGetClass:OFF \
+                -Xep:Finalize:OFF \
+                -Xep:FutureReturnValueIgnored:OFF \
+                -Xep:InconsistentCapitalization:OFF \
+                -Xep:InconsistentHashCode:OFF \
+                -Xep:InlineMeInliner:OFF \
+                -Xep:InlineMeSuggester:OFF \
+                -Xep:InvalidBlockTag:OFF \
+                -Xep:InvalidLink:OFF \
+                -Xep:InvalidParam:OFF \
+                -Xep:JavaTimeDefaultTimeZone:OFF \
+                -Xep:JavaUtilDate:OFF \
+                -Xep:JdkObsolete:OFF \
+                -Xep:LongDoubleConversion:OFF \
+                -Xep:MixedMutabilityReturnType:OFF \
+                -Xep:NonApiType:OFF \
+                -Xep:NotJavadoc:OFF \
+                -Xep:ObjectEqualsForPrimitives:OFF \
+                -Xep:OperatorPrecedence:OFF \
+                -Xep:StringCaseLocaleUsage:OFF \
+                -Xep:StringSplitter:OFF \
+                -Xep:SynchronizeOnNonFinalField:OFF \
+                -Xep:UnnecessaryParentheses:OFF \
+                -Xep:UnnecessaryStringBuilder:OFF \
+                -Xep:UnrecognisedJavadocTag:OFF \
+                -Xep:UnusedVariable:OFF \
+                ${errorProneFlags}</arg>
                 <arg>-Xlint:${lint}</arg>
                 <arg>-Werror</arg>
               </compilerArgs>
@@ -709,7 +852,6 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.8.2.0</version>
             <executions>
               <execution>
                 <goals>
@@ -741,7 +883,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.1.1</version>
             <executions>
               <execution>
                 <goals>

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/exception/RestException.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/exception/RestException.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
  * An exception with an associated {@link HttpStatus}. Used to wrap other exceptions so they can be caught and
  * appropriately handled by an {@link org.springframework.web.bind.annotation.ExceptionHandler}
  */
+@SuppressWarnings("OverrideThrowableToString")
 public class RestException extends RuntimeException {
     /** serialVersionUID */
     private static final long serialVersionUID = 5762645820684796082L;

--- a/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3Ops.java
+++ b/geowebcache/s3storage/src/main/java/org/geowebcache/s3/S3Ops.java
@@ -109,6 +109,7 @@ class S3Ops {
         deleteExecutorService.shutdownNow();
     }
 
+    @SuppressWarnings("Finally")
     private void issuePendingBulkDeletes() throws StorageException {
         final String pendingDeletesKey = keyBuilder.pendingDeletes();
         Lock lock;

--- a/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
+++ b/geowebcache/s3storage/src/test/java/org/geowebcache/s3/S3BlobStoreConformanceTest.java
@@ -44,6 +44,7 @@ public class S3BlobStoreConformanceTest extends AbstractBlobStoreTest<S3BlobStor
     public TemporaryS3Folder tempFolder = new TemporaryS3Folder(testConfigLoader.getProperties());
 
     @Override
+    @SuppressWarnings("CatchFail")
     public void createTestUnit() throws Exception {
         Assume.assumeTrue(tempFolder.isConfigured());
         S3BlobStoreInfo config = tempFolder.getConfig();

--- a/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/MbtilesBlobStore.java
+++ b/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/MbtilesBlobStore.java
@@ -736,7 +736,7 @@ public final class MbtilesBlobStore extends SqliteBlobStore {
         }
     }
 
-    protected void persistParameterMap(TileObject stObj) {
+    void persistParameterMap(TileObject stObj) {
         if (Objects.nonNull(stObj.getParametersId())) {
             putLayerMetadata(
                     stObj.getLayerName(),

--- a/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/Utils.java
+++ b/geowebcache/sqlite/src/main/java/org/geowebcache/sqlite/Utils.java
@@ -13,6 +13,7 @@
  */
 package org.geowebcache.sqlite;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,18 +77,21 @@ final class Utils {
         return map;
     }
 
+    @FormatMethod
     static void check(boolean condition, String message, Object... arguments) {
         if (!condition) {
             throw exception(message, arguments);
         }
     }
 
+    @FormatMethod
     static RuntimeException exception(String message, Object... arguments) {
         String finalMessage = String.format(message, arguments);
         LOGGER.severe(finalMessage);
         return new RuntimeException(finalMessage);
     }
 
+    @FormatMethod
     static RuntimeException exception(Exception exception, String message, Object... arguments) {
         String finalMessage = String.format(message, arguments);
         LOGGER.severe(finalMessage);

--- a/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqliteConnectionManagerTest.java
+++ b/geowebcache/sqlite/src/test/java/org/geowebcache/sqlite/SqliteConnectionManagerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -213,6 +214,7 @@ public final class SqliteConnectionManagerTest extends TestSupport {
         }.result;
     }
 
+    @FormatMethod
     private static void execute(Connection connection, String sql, Object... arguments) {
         String finalSql = String.format(sql, arguments);
         try (PreparedStatement statement = connection.prepareStatement(finalSql)) {
@@ -226,6 +228,7 @@ public final class SqliteConnectionManagerTest extends TestSupport {
 
         public abstract void extract(ResultSet resultSet) throws Exception;
 
+        @FormatMethod
         public ExecuteQuery(Connection connection, String query, Object... arguments) {
             String finalQuery = String.format(query, arguments);
             try (PreparedStatement statement = connection.prepareStatement(finalQuery)) {

--- a/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
+++ b/geowebcache/swiftblob/src/test/java/org/geowebcache/swift/SwiftBlobStoreTest.java
@@ -78,6 +78,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /** Unit testing for the Swift Blobstore class */
+@SuppressWarnings("DirectInvocationOnMock")
 public class SwiftBlobStoreTest {
 
     private String TEST_KEY = "test/key";
@@ -267,7 +268,7 @@ public class SwiftBlobStoreTest {
 
     @Test
     @SuppressWarnings("PMD.CloseResource")
-    public void get() {
+    public void get() throws StorageException {
         String thePayloadData = "Test Content";
         Date lastModified = new Date();
         ByteSourcePayload testByteSourcePayload = new ByteSourcePayload(new ByteSource() {
@@ -281,28 +282,24 @@ public class SwiftBlobStoreTest {
         when(swiftObject.getLastModified()).thenReturn(lastModified);
         when(swiftObject.getPayload()).thenReturn(testByteSourcePayload);
 
-        try {
-            when(objectApi.get("sample/key")).thenReturn(swiftObject);
-            boolean result = this.swiftBlobStore.get(sampleTileObject);
+        when(objectApi.get("sample/key")).thenReturn(swiftObject);
+        boolean result = this.swiftBlobStore.get(sampleTileObject);
 
-            verify(keyBuilder, times(1)).forTile(sampleTileObject);
-            verify(objectApi, times(1)).get("sample/key");
-            verify(swiftObject, times(1)).getPayload();
+        verify(keyBuilder, times(1)).forTile(sampleTileObject);
+        verify(objectApi, times(1)).get("sample/key");
+        verify(swiftObject, times(1)).getPayload();
 
-            ByteArrayResource expectedByteArray = new ByteArrayResource(thePayloadData.getBytes());
-            ByteArrayResource actualByteArray = (ByteArrayResource) sampleTileObject.getBlob();
+        ByteArrayResource expectedByteArray = new ByteArrayResource(thePayloadData.getBytes());
+        ByteArrayResource actualByteArray = (ByteArrayResource) sampleTileObject.getBlob();
 
-            assertEquals(thePayloadData.length(), sampleTileObject.getBlobSize());
-            assertArrayEquals(expectedByteArray.getContents(), actualByteArray.getContents());
-            assertEquals(lastModified.getTime(), sampleTileObject.getCreated());
-            assertTrue(result);
+        assertEquals(thePayloadData.length(), sampleTileObject.getBlobSize());
+        assertArrayEquals(expectedByteArray.getContents(), actualByteArray.getContents());
+        assertEquals(lastModified.getTime(), sampleTileObject.getCreated());
+        assertTrue(result);
 
-            when(objectApi.get("sample/key")).thenReturn(null);
-            result = this.swiftBlobStore.get(sampleTileObject);
-            assertFalse(result);
-        } catch (StorageException e) {
-            fail("A storage exception was not expected to be thrown");
-        }
+        when(objectApi.get("sample/key")).thenReturn(null);
+        result = this.swiftBlobStore.get(sampleTileObject);
+        assertFalse(result);
     }
 
     @Test

--- a/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSDocumentFactory.java
+++ b/geowebcache/tms/src/main/java/org/geowebcache/service/tms/TMSDocumentFactory.java
@@ -232,9 +232,9 @@ public class TMSDocumentFactory {
     }
 
     protected String profileForGridSet(GridSet gridSet) {
-        if (gridSet == gsb.getWorldEpsg4326()) {
+        if (gsb.getWorldEpsg4326().equals(gridSet)) {
             return "global-geodetic";
-        } else if (gridSet == gsb.getWorldEpsg3857()) {
+        } else if (gsb.getWorldEpsg3857().equals(gridSet)) {
             return "global-mercator";
         } else {
             return "local";

--- a/geowebcache/tms/src/test/java/org/geowebcache/service/tms/TMSServiceTest.java
+++ b/geowebcache/tms/src/test/java/org/geowebcache/service/tms/TMSServiceTest.java
@@ -178,6 +178,7 @@ public class TMSServiceTest {
         }
     }
 
+    @SuppressWarnings("DirectInvocationOnMock")
     private static TileLayer mockTileLayer(
             TileLayerDispatcher tld,
             GridSetBroker gridsetBroker,
@@ -239,9 +240,6 @@ public class TMSServiceTest {
 
     @Test
     public void testTileMapServiceDocument() throws Exception {
-
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new TMSService(sb, tld, gridsetBroker, mock(RuntimeStats.class));
 

--- a/geowebcache/web/pom.xml
+++ b/geowebcache/web/pom.xml
@@ -157,7 +157,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.2.3</version>
         <executions>
           <execution>
             <phase>install</phase>
@@ -175,18 +174,21 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.14.v20181114</version>
         <configuration>
           <webApp>
             <contextPath>/geowebcache</contextPath>
           </webApp>
+          <httpConnector>
+            <!--host>localhost</host-->
+            <port>8081</port>
+          </httpConnector>
           <systemProperties>
             <systemProperty>
               <name>log4j2.configurationFile</name>
               <value>src/test/resources/log4j2-test.xml</value>
             </systemProperty>
           </systemProperties>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <scan>10</scan>
           <stopPort>9966</stopPort>
           <stopKey>foo</stopKey>
           <supportedPackagings>

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/RestIntegrationTest.java
@@ -394,9 +394,9 @@ public class RestIntegrationTest {
             assertThat(
                     doc,
                     hasXPath(
-                            "/layers/layer[name/text()='topp:states']/atom:link/@href",
+                            "/layers/layer[name/text()='states']/atom:link/@href",
                             equalTo(jetty.getUri()
-                                    .resolve("/geowebcache/rest/layers/topp:states.xml")
+                                    .resolve("/geowebcache/rest/layers/states.xml")
                                     .toString())));
             assertThat(
                     doc,
@@ -557,10 +557,7 @@ public class RestIntegrationTest {
                 admin.getClient(), equalTo(200), doc -> {
                     assertThat(doc, hasXPath("/wmsLayer/name", equalTo("img states")));
                     assertThat(
-                            doc,
-                            hasXPath(
-                                    "/wmsLayer/wmsUrl/string",
-                                    equalTo("https://demo.boundlessgeo.com/geoserver/wms?")));
+                            doc, hasXPath("/wmsLayer/wmsUrl/string", equalTo("http://localhost:8080/geoserver/wms?")));
                     assertThat(doc, hasXPath("/wmsLayer/wmsLayers", equalTo("nurc:Img_Sample,topp:states")));
                 });
     }
@@ -572,7 +569,7 @@ public class RestIntegrationTest {
             doGetXML(
                     "rest/layers/img%20states.xml",
                     client, equalTo(401), doc -> {
-                        assertThat(doc, not(hasXPath("//wmsUrl", containsString("demo.opengeo.org"))));
+                        assertThat(doc, not(hasXPath("//wmsUrl", containsString("localhost:8080"))));
                         assertThat(doc, not(hasXPath("//wmsLayer", containsString("nurc"))));
                         assertThat(doc, not(hasXPath("//wmsLayer", containsString("Img_Sample"))));
                         assertThat(doc, not(hasXPath("//wmsLayer", containsString("topp"))));
@@ -613,7 +610,7 @@ public class RestIntegrationTest {
         doGetXML(
                 "rest/layers/img%20states.xml",
                 notAUser.getClient(), equalTo(401), doc -> {
-                    assertThat(doc, not(hasXPath("//wmsUrl", containsString("demo.opengeo.org"))));
+                    assertThat(doc, not(hasXPath("//wmsUrl", containsString("localhost:8080"))));
                     assertThat(doc, not(hasXPath("//wmsLayer", containsString("nurc"))));
                     assertThat(doc, not(hasXPath("//wmsLayer", containsString("Img_Sample"))));
                     assertThat(doc, not(hasXPath("//wmsLayer", containsString("topp"))));
@@ -1026,7 +1023,7 @@ public class RestIntegrationTest {
                 "</seedRequest>";
 
         try (CloseableHttpResponse response =
-                handlePost(URI.create("/geowebcache/rest/seed/topp:states.xml"), admin.getClient(), seedLayer)) {
+                handlePost(URI.create("/geowebcache/rest/seed/states.xml"), admin.getClient(), seedLayer)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -1034,7 +1031,7 @@ public class RestIntegrationTest {
     @Test
     public void testSeedGet() throws Exception {
         try (CloseableHttpResponse response =
-                handleGet(URI.create("/geowebcache/rest/seed/topp:states"), admin.getClient())) {
+                handleGet(URI.create("/geowebcache/rest/seed/states"), admin.getClient())) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -1049,7 +1046,7 @@ public class RestIntegrationTest {
     @Test
     public void testSeedGetSeedForm() throws Exception {
         try (CloseableHttpResponse response =
-                handleGet(URI.create("/geowebcache/rest/seed/topp:states"), admin.getClient())) {
+                handleGet(URI.create("/geowebcache/rest/seed/states"), admin.getClient())) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -1064,7 +1061,7 @@ public class RestIntegrationTest {
     @Test
     public void testSeedGetLayerJson() throws Exception {
         try (CloseableHttpResponse response =
-                handleGet(URI.create("/geowebcache/rest/seed/topp:states.json"), admin.getClient())) {
+                handleGet(URI.create("/geowebcache/rest/seed/states.json"), admin.getClient())) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -1072,7 +1069,7 @@ public class RestIntegrationTest {
     @Test
     public void testSeedGetLayerXml() throws Exception {
         try (CloseableHttpResponse response =
-                handleGet(URI.create("/geowebcache/rest/seed/topp:states.xml"), admin.getClient())) {
+                handleGet(URI.create("/geowebcache/rest/seed/states.xml"), admin.getClient())) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -1090,7 +1087,7 @@ public class RestIntegrationTest {
     public void testLayerKillAll() throws Exception {
         String killCommand = "kill_all=all";
         try (CloseableHttpResponse response =
-                handlePost(URI.create("/geowebcache/rest/seed/topp:states"), admin.getClient(), killCommand)) {
+                handlePost(URI.create("/geowebcache/rest/seed/states"), admin.getClient(), killCommand)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }

--- a/geowebcache/web/src/test/java/org/geowebcache/jetty/Start.java
+++ b/geowebcache/web/src/test/java/org/geowebcache/jetty/Start.java
@@ -42,7 +42,7 @@ public class Start {
             HttpConfiguration httpConfiguration = new HttpConfiguration();
 
             ServerConnector http = new ServerConnector(jettyServer, new HttpConnectionFactory(httpConfiguration));
-            http.setPort(Integer.getInteger("jetty.port", 8080));
+            http.setPort(Integer.getInteger("jetty.http.port", 8081));
             http.setAcceptQueueSize(100);
             http.setIdleTimeout(1000 * 60 * 60);
 

--- a/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoderImpl.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/io/codec/ImageEncoderImpl.java
@@ -104,7 +104,7 @@ public class ImageEncoderImpl implements ImageEncoder {
 
             @Override
             public RenderedImage prepareImage(RenderedImage image, MimeType type) {
-                boolean isPNG8 = type == ImageMime.png8;
+                boolean isPNG8 = ImageMime.png8.equals(type);
                 if (isPNG8) {
                     return applyPalette(image);
                 }
@@ -150,10 +150,11 @@ public class ImageEncoderImpl implements ImageEncoder {
         TIFF("image/tiff"),
         BMP("image/bmp");
 
-        private String[] formatNames;
+        @SuppressWarnings("ImmutableEnumChecker") // instance is immutable
+        private final List<String> formatNames;
 
         WriteHelper(String... formatNames) {
-            this.formatNames = formatNames;
+            this.formatNames = List.of(formatNames);
         }
 
         public ImageWriteParam prepareParams(Map<String, String> inputParams, ImageWriter writer) {

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSTileFuser.java
@@ -155,9 +155,10 @@ public class WMSTileFuser {
         DEFAULT(1, "default"),
         SPEED(2, "speed");
 
-        private RenderingHints hints;
+        @SuppressWarnings("ImmutableEnumChecker") // RenderingHints is mutable
+        private final RenderingHints hints;
 
-        private String mode;
+        private final String mode;
 
         HintsLevel(int numHint, String mode) {
             this.mode = mode;
@@ -213,6 +214,8 @@ public class WMSTileFuser {
                             RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF));
                     hints.add(new RenderingHints(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE));
                     break;
+                default:
+                    hints = null;
             }
         }
 

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesGridSetConfigurationConformanceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/wms/GetCapabilitiesGridSetConfigurationConformanceTest.java
@@ -20,10 +20,10 @@ import static org.geowebcache.util.TestUtils.requirePresent;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import org.easymock.EasyMock;
 import org.geotools.data.ows.OperationType;
 import org.geotools.ows.wms.CRSEnvelope;
@@ -148,7 +148,7 @@ public class GetCapabilitiesGridSetConfigurationConformanceTest extends GridSetC
             @Override
             public boolean matches(Object item) {
                 return item instanceof GridSet
-                        && Objects.equal(((GridSet) item).getDescription(), Integer.toString(expected));
+                        && Objects.equals(((GridSet) item).getDescription(), Integer.toString(expected));
             }
         };
     }

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSServiceTest.java
@@ -147,6 +147,7 @@ public class WMSServiceTest {
                 tileRequest.getTileIndex());
     }
 
+    @SuppressWarnings("DirectInvocationOnMock")
     private TileLayer mockTileLayer(String layerName, List<String> gridSetNames) throws Exception {
 
         TileLayer tileLayer = mock(TileLayer.class);

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSTileFuserTest.java
@@ -64,6 +64,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+@SuppressWarnings("FloatCast")
 public class WMSTileFuserTest {
 
     GridSetBroker gridSetBroker = new GridSetBroker(Collections.singletonList(new DefaultGridsets(false, false)));

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
@@ -93,9 +93,9 @@ public class WMTSService extends Service {
         // "/{layer}/{style}/tilejson/{tileformat}"
         TILEJSON_STYLE(buildRestPattern(4, true), RequestType.TILEJSON, true);
 
-        Pattern pattern;
-        RequestType type;
-        boolean hasStyle;
+        final Pattern pattern;
+        final RequestType type;
+        final boolean hasStyle;
 
         RestRequest(String pattern, RequestType type, boolean hasStyle) {
             this.pattern = Pattern.compile(pattern);
@@ -144,7 +144,7 @@ public class WMTSService extends Service {
             } else {
                 values.put("tileformat", matcher.group(++i));
             }
-            if (request.getParameter("format") instanceof String) {
+            if (request.getParameter("format") != null) {
                 if (isFeatureInfo) {
                     values.put("infoformat", request.getParameter("format"));
                 } else {

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSUtils.java
@@ -25,11 +25,11 @@ final class WMTSUtils {
 
     private WMTSUtils() {}
 
-    protected static List<String> getLayerFormats(TileLayer layer) throws IOException {
+    static List<String> getLayerFormats(TileLayer layer) throws IOException {
         return layer.getMimeTypes().stream().map(MimeType::getFormat).collect(Collectors.toList());
     }
 
-    protected static List<String> getLayerFormatsExtensions(TileLayer layer) throws IOException {
+    static List<String> getLayerFormatsExtensions(TileLayer layer) throws IOException {
         return layer.getMimeTypes().stream().map(MimeType::getFileExtension).collect(Collectors.toList());
     }
 

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -98,6 +98,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.context.WebApplicationContext;
 import org.w3c.dom.Document;
 
+@SuppressWarnings("DirectInvocationOnMock")
 public class WMTSServiceTest {
 
     private WMTSService service;
@@ -289,9 +290,6 @@ public class WMTSServiceTest {
 
     @Test
     public void testGetCap() throws Exception {
-
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
@@ -548,8 +546,6 @@ public class WMTSServiceTest {
         });
         extensions.add(new WMTSExtensionImpl());
         // mock execution context
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
         extensions.forEach(service::addExtension);
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
@@ -618,8 +614,6 @@ public class WMTSServiceTest {
     @Test
     public void testGetCapServiceInfo() throws Exception {
         TileLayerDispatcher tldx = mockTileLayerDispatcher();
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new WMTSService(sb, tldx, null, mock(RuntimeStats.class));
 
@@ -681,9 +675,6 @@ public class WMTSServiceTest {
 
     @Test
     public void testGetCapOneWGS84BBox() throws Exception {
-
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
@@ -749,9 +740,6 @@ public class WMTSServiceTest {
     @Test
     public void testGetCapUnboundedStyleFilter() throws Exception {
 
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
-
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
@@ -810,9 +798,6 @@ public class WMTSServiceTest {
     @Test
     public void testGetCapEmptyStyleFilter() throws Exception {
 
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
-
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
@@ -870,9 +855,6 @@ public class WMTSServiceTest {
 
     @Test
     public void testGetCapMultipleStyles() throws Exception {
-
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
@@ -975,9 +957,6 @@ public class WMTSServiceTest {
     @Test
     public void testGetCapWithMultipleDimensions() throws Exception {
 
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
-
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
@@ -1048,9 +1027,6 @@ public class WMTSServiceTest {
     @Test
     public void testGetTileWithStyle() throws Exception {
 
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
-
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
@@ -1112,8 +1088,6 @@ public class WMTSServiceTest {
     @Test
     public void testDispatchCustomOperations() throws Exception {
         // instantiating all the necessary machinery to perform the request
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
         Map<String, String[]> kvp = new CaseInsensitiveMap<>();
         kvp.put("service", new String[] {"WMTS"});
@@ -1368,9 +1342,6 @@ public class WMTSServiceTest {
 
     @Test
     public void testGetCapWithTileJSONDifferentUrls() throws Exception {
-
-        GeoWebCacheDispatcher gwcd = mock(GeoWebCacheDispatcher.class);
-        when(gwcd.getServletPrefix()).thenReturn(null);
 
         service = new WMTSService(sb, tld, null, mock(RuntimeStats.class));
 

--- a/geowebcache/wmts/src/test/resources/org/geowebcache/service/wmts/geowebcache_190.xml
+++ b/geowebcache/wmts/src/test/resources/org/geowebcache/service/wmts/geowebcache_190.xml
@@ -127,7 +127,7 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/topp/wms</string>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
     </wmsLayer>
     <wmsLayer>
@@ -139,7 +139,7 @@
         <string>image/png8</string>
       </mimeFormats>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
     </wmsLayer>
@@ -176,7 +176,7 @@
         <expirationRule minZoom="0" expiration="500"/>
       </expireClientsList>
       <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
+        <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>


### PR DESCRIPTION
* Configure maven-enforcer-plugin to require Java 17

* Configure maven-enforcer-plugin to require maven 3.8+ as done in GeoServer.

* Upgrade github actions workflows to use Java 17

* Remove cobertura-maven-plugin (modules/extension/xsd/**), as it is not compatible with Java 11

* Update maven-javadoc-plugin configuration to use legacyMode=true and not fail due to module-info.java not present.

* Plugin version upgrades:
  * jacoco 0.8.7 -> 0.8.13
  * maven-checkstyle-plugin 3.3.0 -> 3.6.0
  * maven-compiler-plugin 3.11.0 -> 3.14.0
  * maven-javadoc-plugin 3.6.3 -> 3.11.2

* Add .mvn/jvm.config with necessary --add-exports and --add-opens for internal jdk.compiler packages.

  This ensures that build-time tools and compiler plugins interacting with javac internals can function correctly under Java 17's module system.

* Centralize maven plugin versions in the root pom's pluginManagement section.

---
This is a coordinated effort across [GeoTools](https://github.com/geotools/geotools/pull/5204), [GeoServer](https://github.com/geoserver/geoserver/pull/8573), and GeoWebCache
