### PR TITLE
[1401] Use GeoTools Bill of Materials (BOM) to manage geotools dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.settings
 *.project
 .factorypath
+.pmd
 bin
 target
 .DS_Store

--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-metadata</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -125,19 +124,16 @@
     <dependency>
       <groupId>javax.media</groupId>
       <artifactId>jai_core</artifactId>
-      <version>1.1.3</version>
     </dependency>
 
     <dependency>
       <groupId>javax.media</groupId>
       <artifactId>jai_codec</artifactId>
-      <version>1.1.3</version>
     </dependency>
 
     <dependency>
       <groupId>javax.media</groupId>
       <artifactId>jai_imageio</artifactId>
-      <version>1.1</version>
     </dependency>
 
     <dependency>

--- a/geowebcache/distributed/pom.xml
+++ b/geowebcache/distributed/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-xml</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/geowebcache/georss/pom.xml
+++ b/geowebcache/georss/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-coverage</artifactId>
-      <version>${gt.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/geowebcache/mbtiles/pom.xml
+++ b/geowebcache/mbtiles/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-mbtiles</artifactId>
-      <version>${gt.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/geowebcache/pom.xml
+++ b/geowebcache/pom.xml
@@ -52,39 +52,23 @@
 
   <properties>
     <gt.version>34-SNAPSHOT</gt.version>
-    <jts.version>1.20.0</jts.version>
-    <jaiext.version>1.1.31</jaiext.version>
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.7.13</spring.security.version>
     <xstream.version>1.4.21</xstream.version>
-    <commons-io.version>2.19.0</commons-io.version>
-    <commons-dbcp.version>1.4</commons-dbcp.version>
-    <commons-collections.version>4.4</commons-collections.version>
     <commons-codec.version>1.18.0</commons-codec.version>
-    <commons-text.version>1.13.0</commons-text.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
-    <guava.version>33.4.8-jre</guava.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <jsr305.version>3.0.1</jsr305.version>
-    <log4j.version>2.24.3</log4j.version>
-    <h2.version>1.1.119</h2.version>
-    <hsql.version>2.7.1</hsql.version>
-    <postgresql.version>42.7.7</postgresql.version>
-    <oracle.version></oracle.version>
     <java.awt.headless>true</java.awt.headless>
     <jalopy.phase>disabled</jalopy.phase>
     <jalopy.srcExcludesPattern>disabled</jalopy.srcExcludesPattern>
     <test.maxHeapSize>64M</test.maxHeapSize>
     <maven.test.jvmargs></maven.test.jvmargs>
-    <imageio-ext.version>1.4.15</imageio-ext.version>
     <hazelcast.version>5.3.8</hazelcast.version>
     <joda-time.version>2.8.1</joda-time.version>
     <spotless.action>apply</spotless.action>
     <spotless.apply.skip>false</spotless.apply.skip>
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${spotless.apply.skip}</pom.fmt.skip>
-    <jackson.version>2.19.0</jackson.version>
-    <jackson.databind.version>${jackson.version}</jackson.databind.version>
     <jetty.version>9.4.55.v20240627</jetty.version>
     <errorProneFlags></errorProneFlags>
     <errorProne.version>2.31.0</errorProne.version>
@@ -102,6 +86,26 @@
 
   <dependencyManagement>
     <dependencies>
+      <!--
+        Import the GeoTools platform-dependencies BOM to get consistent third-party dependency versions
+        Provides managed versions for several libraries across projects, such as jackson, commons-logging/pool/lang3/cli/text/dbcp,
+        JTS, guava, imageio-ext, jai-ext, and more.
+      -->
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-platform-dependencies</artifactId>
+        <version>${gt.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Import the GeoTools BOM to have access to all gt artifacts without specifying the version -->
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-bom</artifactId>
+        <version>${gt.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
@@ -133,53 +137,10 @@
       </dependency>
 
       <dependency>
-        <groupId>org.locationtech.jts</groupId>
-        <artifactId>jts-core</artifactId>
-        <version>${jts.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>xercesImpl</artifactId>
-            <groupId>xerces</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.1.0</version>
         <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>${jsr305.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-dbcp</groupId>
-        <artifactId>commons-dbcp</artifactId>
-        <version>${commons-dbcp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>${commons-text.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-collections4</artifactId>
-        <version>${commons-collections.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -191,106 +152,6 @@
         <artifactId>commons-fileupload</artifactId>
         <version>${commons-fileupload.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.14</version>
-      </dependency>
-
-      <!-- configure geotools logging -->
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-metadata</artifactId>
-        <version>${gt.version}</version>
-      </dependency>
-      <!-- logging dependencies -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-1.2-api</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-jul</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <!-- bridge slf4j to log4j -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j2-impl</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>2.0.16</version>
-      </dependency>
-
-      <!-- bridge commons-logging to log4j -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-jcl</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.3.5</version>
-      </dependency>
-
-      <dependency>
-        <groupId>it.geosolutions.jaiext.utilities</groupId>
-        <artifactId>jt-utilities</artifactId>
-        <version>${jaiext.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>it.geosolutions.jaiext.colorindexer</groupId>
-        <artifactId>jt-colorindexer</artifactId>
-        <version>${jaiext.version}</version>
-      </dependency>
-
-      <!-- PNG Encoder dependencies -->
-      <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
-        <artifactId>imageio-ext-png</artifactId>
-        <version>${imageio-ext.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
-        <artifactId>imageio-ext-streams</artifactId>
-        <version>${imageio-ext.version}</version>
-      </dependency>
-
-      <!-- dependency>
-      <groupId>jcs</groupId>
-      <artifactId>jcs</artifactId>
-      <version>1.3</version>
-      <exclusions>
-    <exclusion>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-    </exclusion>
-    <exclusion>
-      <groupId>berkeleydb</groupId>
-      <artifactId>berkeleydb</artifactId>
-    </exclusion>
-    <exclusion>
-      <groupId>hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-    </exclusion>
-      </exclusions>
-    </dependency -->
 
       <dependency>
         <groupId>junit</groupId>
@@ -367,13 +228,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.freemarker</groupId>
-        <artifactId>freemarker</artifactId>
-        <version>2.3.18</version>
-        <!-- track same version than GeoServer -->
-      </dependency>
-
-      <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>${xstream.version}</version>
@@ -383,30 +237,6 @@
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
         <version>1.5.4</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>${h2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.hsqldb</groupId>
-        <artifactId>hsqldb</artifactId>
-        <version>${hsql.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${postgresql.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.oracle</groupId>
-        <artifactId>ojdbc14</artifactId>
-        <version>${oracle.version}</version>
       </dependency>
 
       <!-- Berkeley DB JE -->
@@ -424,22 +254,7 @@
         <version>${joda-time.version}</version>
       </dependency>
 
-      <!-- Pin some additional transitive dependencies in S3 module for consistency-->
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.databind.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
+      <!-- Jackson dependencies managed by platform-dependencies BOM -->
       <dependency>
         <!-- used for tests that require environment variables -->
         <groupId>com.github.stefanbirkner</groupId>

--- a/geowebcache/rest/pom.xml
+++ b/geowebcache/rest/pom.xml
@@ -26,10 +26,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.freemarker</groupId>
-      <artifactId>freemarker</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/geowebcache/sqlite/pom.xml
+++ b/geowebcache/sqlite/pom.xml
@@ -24,12 +24,10 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-mbtiles</artifactId>
-      <version>${gt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-mbtiles</artifactId>
-      <version>${gt.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/geowebcache/wms/pom.xml
+++ b/geowebcache/wms/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-wms</artifactId>
-      <version>${gt.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Integrate the GeoTools Bill of Materials (gt-bom) into GeoWebCache, centralizing management of GeoTools dependency versions.

* Import `org.geotools:gt-bom` in the root `pom.xml`'s `<dependencyManagement>` section. This makes GeoWebCache a direct consumer of GeoTools' curated dependency set.
* Remove explicit `<version>${gt.version}</version>` declarations for individual GeoTools artifacts from all module POMs. Versions are now inherited from the imported `gt-bom`.
* Remove unused dependency org.freemarker:freemarker
* Delegate the following dependency versions to the GeoTools BOM:
  * apache commons (io, logging, collections, text, dbcp)
  * guava
  * h2
  * hsqldb
  * httpclient
  * imageio-ext
  * jackson-annotations
  * jackson-core
  * jackson-databind
  * jai_core/codec
  * jai_imageio
  * jaiext
  * jts
  * log4j-1.2-api
  * log4j-api
  * log4j-core
  * log4j-jcl
  * log4j-jul
  * log4j-slf4j2-impl
  * ojdbc14
  * postgresql
  * slf4j-api