### PR TITLE
GeoWebCache update for JAI to ImageN rename of classes and constants

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,7 +1,7 @@
-GeoWebCache 1.28-M0 (2025-09-18)
---------------------------------
+GeoWebCache 1.28.0 (2025-10-01)
+-------------------------------
 
-Milestone release, GeoNetwork 1.28-M0 is the first release requiring a Java 17 environment.
+Initial release, this is the first release requiring a Java 17 enviornment.
 
 Improvements:
 +++++++++++++
@@ -9,6 +9,17 @@ Improvements:
 - Migrate from JAI to ImageN image processing engine
 - Use GeoTools ImageWorker transition to ImageN operators
 
+
+GeoWebCache 1.28-M0 (2025-09-18)
+--------------------------------
+
+Milestone release, GeoWebCache 1.28-M0 is the first release requiring a Java 17 environment.
+
+Improvements:
++++++++++++++
+- Update to Java 17 minimum, and apply OpenRewrite Improvements to codebase
+- Migrate from JAI to ImageN image processing engine
+- Use GeoTools ImageWorker transition to ImageN operators
 
 Updates:
 ++++++++

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/MetaTile.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/MetaTile.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.BufferedImageAdapter;
@@ -54,7 +54,7 @@ public class MetaTile implements TileResponseReceiver {
 
     private static Logger log = Logging.getLogger(MetaTile.class.getName());
 
-    protected static final RenderingHints NO_CACHE = new RenderingHints(JAI.KEY_TILE_CACHE, null);
+    protected static final RenderingHints NO_CACHE = new RenderingHints(ImageN.KEY_TILE_CACHE, null);
 
     private static final boolean NATIVE_JAI_AVAILABLE;
 
@@ -70,7 +70,7 @@ public class MetaTile implements TileResponseReceiver {
         }
         NATIVE_JAI_AVAILABLE = nativeJAIAvailable;
         if (!NATIVE_JAI_AVAILABLE) {
-            log.config("Native JAI is not installed");
+            log.config("Native ImageN is not installed");
         }
     }
 

--- a/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/mime/ImageMime.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageWriter;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.media.colorindexer.ColorIndexer;
 import org.eclipse.imagen.media.colorindexer.Quantizer;
 import org.geotools.image.ImageWorker;
@@ -68,8 +68,8 @@ public class ImageMime extends MimeType {
                 ParameterBlock pb = new ParameterBlock();
                 pb.setSource(ri, 0);
                 pb.set(bands, 0);
-                final RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, new ImageLayout(ri));
-                ri = JAI.create("BandSelect", pb, hints);
+                final RenderingHints hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, new ImageLayout(ri));
+                ri = ImageN.create("BandSelect", pb, hints);
             }
             return ri;
         }
@@ -92,8 +92,8 @@ public class ImageMime extends MimeType {
                         ParameterBlock pb = new ParameterBlock();
                         pb.setSource(canvas, 0); // The source image.
                         pb.set(indexer, 0);
-                        canvas = JAI.create(
-                                "ColorIndexer", pb, JAI.getDefaultInstance().getRenderingHints());
+                        canvas = ImageN.create(
+                                "ColorIndexer", pb, ImageN.getDefaultInstance().getRenderingHints());
                     }
                 }
             }
@@ -261,14 +261,14 @@ public class ImageMime extends MimeType {
             int numBands = renderedImage.getSampleModel().getNumBands();
             if (numBands == 4 || numBands == 2) {
                 ImageWorker iw = new ImageWorker(renderedImage);
-                iw.setRenderingHints(JAI.getDefaultInstance().getRenderingHints());
+                iw.setRenderingHints(ImageN.getDefaultInstance().getRenderingHints());
                 double[] mins = iw.getMinimums();
 
                 return mins[mins.length - 1] == 255; // fully opaque
             } else if (renderedImage.getColorModel() instanceof IndexColorModel) {
                 // JPEG would still compress a bit better, but in order to figure out
                 // if the image has transparency we'd have to expand to RGB or roll
-                // a new JAI image op that looks for the transparent pixels. Out of scope
+                // a new ImageN image op that looks for the transparent pixels. Out of scope
                 // for the moment
                 return false;
             } else {

--- a/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/layer/wms/WMSLayerTest.java
@@ -69,7 +69,7 @@ import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.eclipse.imagen.ImageLayout;
-import org.eclipse.imagen.JAI;
+import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.RenderedOp;
 import org.eclipse.imagen.media.bandselect.BandSelectDescriptor;
 import org.geowebcache.GeoWebCacheException;
@@ -646,7 +646,7 @@ public class WMSLayerTest extends TileLayerTest {
             ImageLayout il = new ImageLayout();
             il.setSampleModel(sm);
             il.setColorModel(cm);
-            RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, il);
+            RenderingHints hints = new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, il);
             RenderedOp grayAlpha = BandSelectDescriptor.create(baseImage, new int[] {0, 3}, hints);
             ByteArrayOutputStream output = new ByteArrayOutputStream();
             try {


### PR DESCRIPTION
No direct API usage, apparnelty everythign is done via ImageWorker.

Concurrent merge of jai-rename branches:

* https://github.com/eclipse-imagen/imagen/pull/115
* https://github.com/geosolutions-it/imageio-ext/pull/334
* https://github.com/geotools/geotools/pull/5364
* https://github.com/mapfish/mapfish-print-v2/pull/39
* https://github.com/GeoWebCache/geowebcache/pull/1434
* https://github.com/geoserver/geoserver/pull/8821

Reviewers: This change requires these branches to be merged at the same time, see upstream [pull request](https://github.com/eclipse-imagen/imagen/pull/115) for a complete integration test of the jai-rename branches.