### PR TITLE
fix for GeoServer 3 upgrade

### DIFF
--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/XStreamListAliasWrapper.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/converter/XStreamListAliasWrapper.java
@@ -93,9 +93,9 @@ public class XStreamListAliasWrapper {
                     UriComponents uriComponents = MvcUriComponentsBuilder.fromMethodName(
                                     controllerClass, alias + "Get", name)
                             .buildAndExpand("");
-                    // build URI with URI.normalize() to remove double slashes
+                    // remove the repeated gwc that GeoServer (sometimes) adds to the URL
                     String normalizedLayerUri = URI.create(
-                                    uriComponents.encode().toUriString().replace("$", ""))
+                                    uriComponents.encode().toUriString().replace("/gwc/gwc", "/gwc"))
                             .normalize()
                             .toASCIIString();
                     writer.addAttribute("href", normalizedLayerUri + ".xml");


### PR DESCRIPTION
changed hack to remove  with a hack to remove the result of double gwc that GeoServer sometimes adds  (i.e. '/gwc/gwc' becomes '/gwc' ).