### PR TITLE
fix(gwc-core): srs equals(..) should allow one-directional aliases

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/grid/SRS.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/grid/SRS.java
@@ -110,14 +110,15 @@ public class SRS implements Comparable<SRS>, Serializable {
         if (!(obj instanceof SRS)) {
             return false;
         }
-        boolean equivalent = false;
         SRS other = (SRS) obj;
         if (other.number == this.number) {
-            equivalent = true;
-        } else if (this.aliases != null && other.aliases != null) {
-            equivalent = this.aliases.contains(other.number) || other.aliases.contains(this.number);
+            return true;
+        } else if (this.aliases != null && this.aliases.contains(other.number)) {
+            return true;
+        } else if (other.aliases != null && other.aliases.contains(this.number)) {
+            return true;
         }
-        return equivalent;
+        return false;
     }
 
     public int getNumber() {

--- a/geowebcache/core/src/test/java/org/geowebcache/grid/SRSTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/grid/SRSTest.java
@@ -1,0 +1,69 @@
+package org.geowebcache.grid;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Simple Test class for testing the behavior of a {@link GridSubset} with a non-zero zoomStart parameter. */
+public class SRSTest {
+    private SRS createSRSWithReflection(int epsgCode) {
+        return createSRSWithReflection(epsgCode, null);
+    }
+
+    private SRS createSRSWithReflection(int epsgCode, List<Integer> aliases) {
+        try {
+            Constructor<SRS> constructor = SRS.class.getDeclaredConstructor(int.class, List.class);
+            constructor.setAccessible(true);
+
+            return constructor.newInstance(epsgCode, aliases);
+        } catch (NoSuchMethodException
+                | InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException e) {
+            Assert.fail("Failed to invoke SRS constructor via reflection: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /** Two SRS objects created with the same EPSG code should be equal */
+    @Test
+    public void testCompareSameSRS() {
+        SRS srs1 = createSRSWithReflection(3308);
+        SRS srs2 = createSRSWithReflection(3308);
+
+        Assert.assertEquals("Expect two identical SRS", srs1, srs2);
+        Assert.assertEquals("Expect two identical SRS", srs2, srs1);
+    }
+
+    /** Two SRS objects created with different EPSG codes should not be equal */
+    @Test
+    public void testCompareDifferentSRS() {
+        SRS srs1 = createSRSWithReflection(3308);
+        SRS srs2 = createSRSWithReflection(3857);
+
+        Assert.assertNotEquals("Expect two different SRS", srs1, srs2);
+        Assert.assertNotEquals("Expect two different SRS", srs2, srs1);
+    }
+
+    /** But two different SRS objects created with alias EPSG codes should be equal */
+    @Test
+    public void testCompareAliasSRS() {
+        SRS srs1 = createSRSWithReflection(3857, List.of(900913));
+        SRS srs2 = createSRSWithReflection(900913, List.of(3857));
+
+        Assert.assertEquals("Expect two alias SRS to be equal", srs1, srs2);
+        Assert.assertEquals("Expect two alias SRS to be equal", srs2, srs1);
+    }
+
+    /** Two different SRS objects. One has an alias of the other, but not vice versa. They should still be equal. */
+    @Test
+    public void testCompareOneDirectionalAliasSRS() {
+        SRS srs1 = createSRSWithReflection(900913, List.of(3857));
+        SRS srs2 = createSRSWithReflection(3857);
+
+        Assert.assertEquals("Expect two alias SRS to be equal", srs1, srs2);
+        Assert.assertEquals("Expect two alias SRS to be equal", srs2, srs1);
+    }
+}


### PR DESCRIPTION
### Problem

SRS comparison bug is leading to missing bounding box in WMTS capabilities in GeoServer.

### Replication

I've created a Gridset using the GeoServer GWC REST API and assigned it to my layer in GeoServer. Now I view my layer capabilities, and there's no WGS84BoundingBox associated with the layer. Assigning a standard WebMercatorGrid resolves the issue, but I don't want that gridset.

### Why it happens

This seems to happen because TileLayer#getGridSubsetForSRS(..) can't locate a gridset that's using EPSG:900913 or EPSG:4326 on my layer. Except I have my gridset defined as EPSG:3857, which is an alias of EPSG:900913. A bug in the comparison code seems to be preventing it from accepting EPSG:3857 as an alias! 

Normally, this is fine because SRS is accessed using the static method SRS.getSRS(..) which looks it up in a cache. Unfortunately, during XML deserialization, I believe the **private constructor** is being invoked. That leaves `aliases` as null, which broke the comparison logic.

Alternative fixes might include initializing the aliases to an empty list, or adding a SRS-specific deserializer.

