### PR TITLE
GWC make use of XMLUtils to make better use of GeoTools Hints

### DIFF
--- a/geowebcache/core/pom.xml
+++ b/geowebcache/core/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>gt-coverage</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -21,7 +21,9 @@ import com.thoughtworks.xstream.io.xml.DomReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -49,6 +51,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -117,6 +120,10 @@ public class XMLConfiguration
                 GridSetConfiguration {
 
     public static final String DEFAULT_CONFIGURATION_FILE_NAME = "geowebcache.xml";
+
+    public static final String SCHEMA_NAMESPACE_PREFIX = "http://geowebcache.org/schema/";
+
+    public static final String DEFAULT_SCHEMA_RESOURCE = "geowebcache.xsd";
 
     private static Logger log = Logging.getLogger(XMLConfiguration.class.getName());
 
@@ -630,14 +637,12 @@ public class XMLConfiguration
         Node rootNode = doc.getDocumentElement();
 
         // debugPrint(rootNode);
-
         if (!rootNode.getNodeName().equals("gwcConfiguration")) {
             log.config("The configuration file is of the pre 1.0 type, trying to convert.");
             rootNode = applyTransform(rootNode, "geowebcache_pre10.xsl").getFirstChild();
         }
 
         // debugPrint(rootNode);
-
         if (rootNode.getNamespaceURI().equals("http://geowebcache.org/schema/1.0.0")) {
             log.config("Updating configuration from 1.0.0 to 1.0.1");
             rootNode = applyTransform(rootNode, "geowebcache_100.xsl").getFirstChild();
@@ -717,6 +722,11 @@ public class XMLConfiguration
             rootNode = applyTransform(rootNode, "geowebcache_151.xsl").getFirstChild();
         }
 
+        if (!rootNode.getNamespaceURI().equals("http://geowebcache.org/schema/2.0.0")) {
+            log.config("Updating configuration to 2.0.0");
+            rootNode = applyTransform(rootNode, "geowebcache_200.xsl").getFirstChild();
+        }
+
         // Check again after transform
         if (!rootNode.getNodeName().equals("gwcConfiguration")) {
             log.log(Level.SEVERE, "Unable to parse file, expected gwcConfiguration at root after transform.");
@@ -727,8 +737,8 @@ public class XMLConfiguration
                 validate(rootNode);
                 log.config("TileLayerConfiguration file validated fine.");
             } catch (SAXException e) {
-                log.warning("GWC configuration validation error: " + e.getMessage());
-                log.warning(
+                log.fine("GWC configuration validation error: " + e.getMessage());
+                log.fine(
                         "Will try to use configuration anyway. Please check the order of declared elements against the schema.");
             } catch (IOException e) {
                 throw new RuntimeException(e.getMessage(), e);
@@ -740,14 +750,14 @@ public class XMLConfiguration
 
     static void validate(Node rootNode) throws SAXException, IOException {
         // Perform validation
-        // TODO dont know why this one suddenly failed to look up, revert to
-        // XMLConstants.W3C_XML_SCHEMA_NS_URI
-        SchemaFactory factory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
-        // We normally don't need access to external schemas
+        SchemaFactory factory = XMLUtils.newSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        // We do not need access to external schemas
         factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         try (InputStream is = XMLConfiguration.class.getResourceAsStream("geowebcache.xsd")) {
-
+            if (is == null) {
+                throw new IOException("Could not load schema resource 'geowebcache.xsd'");
+            }
             Schema schema = factory.newSchema(new StreamSource(is));
             Validator validator = schema.newValidator();
 
@@ -1465,5 +1475,18 @@ public class XMLConfiguration
         this.gridSets = null;
         this.layers = null;
         this.gwcConfig = null;
+    }
+
+    /** Print a DOM tree to an output stream or if there is an exception while doing so, print the stack trace. */
+    public static void printDom(Node dom, OutputStream os) {
+        Transformer trans;
+        PrintWriter w = new PrintWriter(os);
+        try {
+            trans = XMLUtils.newTransformer(); // XMLUtils.newTransformer()
+            trans.transform(new DOMSource(dom), new StreamResult(new OutputStreamWriter(os)));
+        } catch (TransformerException e) {
+            w.println("An error ocurred while transforming the given DOM:");
+            e.printStackTrace(w);
+        }
     }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -614,7 +614,7 @@ public class XMLConfiguration
     static Node loadDocument(InputStream xmlFile) throws ConfigurationException, IOException {
         Node topNode = null;
         try {
-            DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory docBuilderFactory = XMLUtils.newDocumentBuilderFactory();
             docBuilderFactory.setNamespaceAware(true);
             DocumentBuilder docBuilder = XMLUtils.newDocumentBuilder(docBuilderFactory);
             topNode = checkAndTransform(docBuilder.parse(xmlFile));

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -41,6 +41,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -742,6 +743,9 @@ public class XMLConfiguration
         // TODO dont know why this one suddenly failed to look up, revert to
         // XMLConstants.W3C_XML_SCHEMA_NS_URI
         SchemaFactory factory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
+        // We normally don't need access to external schemas
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         try (InputStream is = XMLConfiguration.class.getResourceAsStream("geowebcache.xsd")) {
 
             Schema schema = factory.newSchema(new StreamSource(is));

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -45,7 +45,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
@@ -54,6 +53,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
@@ -616,7 +616,7 @@ public class XMLConfiguration
         try {
             DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
             docBuilderFactory.setNamespaceAware(true);
-            DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+            DocumentBuilder docBuilder = XMLUtils.newDocumentBuilder(docBuilderFactory);
             topNode = checkAndTransform(docBuilder.parse(xmlFile));
         } catch (Exception e) {
             throw (IOException) new IOException(e.getMessage()).initCause(e);
@@ -758,7 +758,7 @@ public class XMLConfiguration
 
         Document dom;
         try (InputStream is = XMLConfiguration.class.getResourceAsStream("geowebcache.xsd")) {
-            dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+            dom = XMLUtils.newDocumentBuilder().parse(is);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -777,7 +777,7 @@ public class XMLConfiguration
         try (InputStream is = XMLConfiguration.class.getResourceAsStream(xslFilename)) {
 
             try {
-                transformer = TransformerFactory.newInstance().newTransformer(new StreamSource(is));
+                transformer = XMLUtils.newTransformer(new StreamSource(is));
                 transformer.transform(new DOMSource(oldRootNode), result);
             } catch (TransformerFactoryConfigurationError | TransformerException e) {
                 log.log(Level.FINE, e.getMessage(), e);

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
-  targetNamespace="http://geowebcache.org/schema/1.28.0" xmlns:gwc="http://geowebcache.org/schema/1.28.0"
-  elementFormDefault="qualified" version="1.28.0">
+  targetNamespace="http://geowebcache.org/schema/2.0.0" xmlns:gwc="http://geowebcache.org/schema/2.0.0"
+  elementFormDefault="qualified" version="2.0.0">
 
   <xs:element name="gwcConfiguration">
     <xs:annotation>

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_200.xsl
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_200.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:gwc="http://geowebcache.org/schema/1.6.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="xml" version="1.0" encoding="utf-8" indent="yes"/>
+
+<xsl:template match="node()|*">
+  <xsl:copy>
+    <xsl:apply-templates/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="/|comment()|processing-instruction()">
+    <xsl:copy>
+      <xsl:apply-templates/>
+    </xsl:copy>
+</xsl:template>
+
+<xsl:template match="*">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:element>
+</xsl:template>
+
+<xsl:template match="@*">
+    <xsl:attribute name="{local-name()}">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+</xsl:template>
+
+<xsl:template match="gwc:keyword">
+  <string><xsl:apply-templates/></string>
+</xsl:template>
+
+<xsl:template match="gwc:gwcConfiguration">
+  <gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://geowebcache.org/schema/2.0.0"
+    xsi:schemaLocation="http://geowebcache.org/schema/2.0.0 http://geowebcache.org/schema/2.0.0/geowebcache.xsd">
+    <xsl:apply-templates/>
+  </gwcConfiguration>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
@@ -36,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 public class ServerConfigurationTest {
 
-    private static final String VERSION_PATTERN = "1(\\.\\d+)+(\\-\\w+)*";
+    private static final String VERSION_PATTERN = "2(\\.\\d+)+(\\-\\w+)*";
 
     ServerConfiguration config;
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationBackwardsCompatibilityTest.java
@@ -29,6 +29,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.geotools.xml.XMLUtils;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.request.RequestFilter;
@@ -45,7 +46,9 @@ public class XMLConfigurationBackwardsCompatibilityTest {
 
     public static final String GWC_125_CONFIG_FILE = "geowebcache_125.xml";
 
-    public static final String LATEST_FILENAME = "geowebcache_130.xml";
+    public static final String GWC_130_CONFIG_FILE = "geowebcache_130.xml";
+
+    public static final String LATEST_FILENAME = "geowebcache_200.xml";
 
     @Test
     public void testLoadPre10() throws Exception {
@@ -227,14 +230,14 @@ public class XMLConfigurationBackwardsCompatibilityTest {
 
     /** Utility method to print out a dom. */
     protected void print(Document dom) throws Exception {
-        TransformerFactory txFactory = TransformerFactory.newInstance();
+        TransformerFactory txFactory = XMLUtils.newTransformerFactory();
         try {
             txFactory.setAttribute("{http://xml.apache.org/xalan}indent-number", Integer.valueOf(2));
         } catch (Exception e) {
             // some
         }
 
-        Transformer tx = txFactory.newTransformer();
+        Transformer tx = XMLUtils.newTransformer(txFactory);
         tx.setOutputProperty(OutputKeys.METHOD, "xml");
         tx.setOutputProperty(OutputKeys.INDENT, "yes");
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -81,6 +82,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
+import org.w3c.dom.Node;
 import org.xml.sax.SAXParseException;
 
 public class XMLConfigurationTest {
@@ -113,6 +115,15 @@ public class XMLConfigurationTest {
         config = new XMLConfiguration(null, configDir.getAbsolutePath());
         config.setGridSetBroker(gridSetBroker);
         config.afterPropertiesSet();
+    }
+
+    @Test
+    public void testValidateVersionedSchemaFromNamespace() throws Exception {
+        try (InputStream xml = XMLConfigurationTest.class.getResourceAsStream("geowebcache-config-env.xml")) {
+            assertNotNull(xml);
+            Node document = XMLConfiguration.loadDocument(xml);
+            XMLConfiguration.validate(document);
+        }
     }
 
     @Test
@@ -477,10 +488,17 @@ public class XMLConfigurationTest {
                 overrideDescription.contains("OVERRIDE"));
     }
 
+    /**
+     * GeoWebCache 1.8.0 default to one disabled blob store
+     *
+     * @throws Exception
+     */
     @Test
-    public void testNoBlobStores() throws Exception {
+    public void testSingleDisabledBlobStores() throws Exception {
         assertNotNull(config.getBlobStores());
-        assertTrue(config.getBlobStores().isEmpty());
+        assertEquals("single blobstore", 1, config.getBlobStoreCount());
+        BlobStoreInfo store = config.getBlobStores().get(0);
+        assertFalse("single disabled blobstore", store.isEnabled());
     }
 
     @Test
@@ -499,6 +517,8 @@ public class XMLConfigurationTest {
         store2.setFileSystemBlockSize(512);
         store2.setBaseDirectory("/tmp/test2");
 
+        int baseline = config.getBlobStoreCount();
+
         config.addBlobStore(store1);
         config.addBlobStore(store2);
 
@@ -516,12 +536,12 @@ public class XMLConfigurationTest {
 
         List<BlobStoreInfo> stores = config2.getBlobStores();
         assertNotNull(stores);
-        assertEquals(2, stores.size());
-        assertNotSame(store1, stores.get(0));
-        assertEquals(store1, stores.get(0));
+        assertEquals(baseline + 2, stores.size());
+        assertNotSame(store1, stores.get(baseline + 0));
+        assertEquals(store1, stores.get(baseline + 0));
 
-        assertNotSame(store2, stores.get(1));
-        assertEquals(store2, stores.get(1));
+        assertNotSame(store2, stores.get(baseline + 1));
+        assertEquals(store2, stores.get(baseline + 1));
     }
 
     @Test
@@ -558,6 +578,8 @@ public class XMLConfigurationTest {
         config = new XMLConfiguration(null, resourceProvider);
         config.setGridSetBroker(gridSetBroker);
 
+        int initialCount = config.getBlobStoreCount();
+
         FileBlobStoreInfo store1 = new FileBlobStoreInfo();
         store1.setName("store1");
         store1.setDefault(true);
@@ -566,9 +588,9 @@ public class XMLConfigurationTest {
         store1.setBaseDirectory("/tmp/test");
 
         assertThrows(ConfigurationPersistenceException.class, () -> config.addBlobStore(store1));
-        assertEquals(0, config.getBlobStoreCount());
-        GeoWebCacheConfiguration configuration = config.loadConfiguration();
-        assertTrue("store shouldn't be saved", configuration.getBlobStores().isEmpty());
+        assertEquals(1, config.getBlobStoreCount());
+        config.loadConfiguration();
+        assertEquals("store shouldn't be saved", initialCount, config.getBlobStoreCount());
     }
 
     /**
@@ -606,12 +628,20 @@ public class XMLConfigurationTest {
 
     private void assertAddBlobStoreFails(FileBlobStoreInfo store, Class<? extends Exception> expectedCause)
             throws ConfigurationException {
+
         ConfigurationPersistenceException expected;
+
+        int baseline = config.getBlobStoreCount();
+
         expected = assertThrows(ConfigurationPersistenceException.class, () -> config.addBlobStore(store));
         assertThat(expected.getCause(), instanceOf(expectedCause));
-        assertEquals(0, config.getBlobStoreCount());
+
+        assertEquals(baseline, config.getBlobStoreCount());
         GeoWebCacheConfiguration configuration = config.loadConfiguration();
-        assertTrue("store shouldn't be saved", configuration.getBlobStores().isEmpty());
+        assertEquals(
+                "store shouldn't be saved",
+                baseline,
+                configuration.getBlobStores().size());
     }
 
     /**
@@ -643,9 +673,10 @@ public class XMLConfigurationTest {
 
         // note, I'm not sure why XMLConfiguration.addBlobStore() only rolls-back on UnsuitableStorageException and not
         // on IOException or GeoWebCacheException
+
         // doThrow(new IOException("fake")).when(listener).handleModifyBlobStore(Mockito.any());
         // assertModifyBlobStoreFails(original, IOException.class);
-        //
+
         // doThrow(new GeoWebCacheException("fake")).when(listener).handleModifyBlobStore(Mockito.any());
         // assertModifyBlobStoreFails(original, GeoWebCacheException.class);
     }
@@ -653,18 +684,20 @@ public class XMLConfigurationTest {
     private void assertModifyBlobStoreFails(FileBlobStoreInfo original, Class<? extends Exception> expectedCause)
             throws ConfigurationException {
 
+        int baseline = config.getBlobStoreCount();
+
         FileBlobStoreInfo modified = (FileBlobStoreInfo) original.clone();
         modified.setBaseDirectory("/tmp/test2");
 
-        assertEquals(1, config.getBlobStoreCount());
+        assertEquals(baseline, config.getBlobStoreCount());
 
         ConfigurationPersistenceException expected;
         expected = assertThrows(ConfigurationPersistenceException.class, () -> config.modifyBlobStore(modified));
         assertThat(expected.getCause(), instanceOf(expectedCause));
         GeoWebCacheConfiguration reloaded = config.loadConfiguration();
-        assertEquals(1, reloaded.getBlobStores().size());
+        assertEquals(baseline, reloaded.getBlobStores().size());
 
-        BlobStoreInfo stored = reloaded.getBlobStores().get(0);
+        BlobStoreInfo stored = reloaded.getBlobStores().get(baseline - 1);
         assertEquals("store shouldn't be saved", original, stored);
     }
 

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache-config-env.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache-config-env.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns="http://geowebcache.org/schema/1.25.0"
-                  xsi:schemaLocation="http://geowebcache.org/schema/1.25.0 https://raw.githubusercontent.com/GeoWebCache/geowebcache/refs/heads/main/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_1250.xsd">
+                  xmlns="http://geowebcache.org/schema/2.0.0"
+                  xsi:schemaLocation="http://geowebcache.org/schema/2.0.0 https://raw.githubusercontent.com/GeoWebCache/geowebcache/refs/heads/main/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_200.xsd">
 <!-- 
 Sample configuration with environmant variable placeholders
 for the global and per-layer http username and password 

--- a/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_200.xml
+++ b/geowebcache/core/src/test/resources/org/geowebcache/config/geowebcache_200.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://geowebcache.org/schema/1.9.0"
-  xsi:schemaLocation="http://geowebcache.org/schema/1.9.0 http://geowebcache.org/schema/1.9.0/geowebcache.xsd">
-  <version>1.9.0</version>
+  xmlns="http://geowebcache.org/schema/2.0.0"
+  xsi:schemaLocation="http://geowebcache.org/schema/2.0.0 https://raw.githubusercontent.com/GeoWebCache/geowebcache/refs/heads/main/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache_200.xsd">
+  <version>2.0.0</version>
   <backendTimeout>120</backendTimeout>
   <serviceInformation>
     <title>GeoWebCache</title>
     <description>GeoWebCache is an advanced tile cache for WMS servers. It supports a large variety of protocols and
       formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</description>
     <keywords>
-      <string>WFS</string>
       <string>WMS</string>
       <string>WMTS</string>
       <string>GEOWEBCACHE</string>
@@ -43,7 +42,24 @@
       <baseDirectory>/tmp/defaultCache</baseDirectory>
       <fileSystemBlockSize>4096</fileSystemBlockSize>
     </FileBlobStore>
-    <!-- A sample AWS S3 blob store configuration.   -->
+
+    <!-- A sample Swift blob store configuration.   
+    <SwiftBlobStore default="true">
+        <id>ObjectStorageCache</id>
+        <enabled>true</enabled>
+        <container>put-your-actual-container-name-here</container>
+        <prefix>test-cache</prefix>
+        <endpoint>endpoint</endpoint>
+        <provider>openstack-swift</provider>
+        <region>put-region-here</region>
+        <keystoneVersion>3</keystoneVersion>
+        <keystoneScope>project</keystoneScope>
+        <keystoneDomainName>Default</keystoneDomainName>
+        <identity>tenant-name-here:put-username-here</identity>
+        <password>put-password-here</password>
+    </SwiftBlobStore> -->
+
+   <!-- A sample AWS S3 blob store configuration.   -->
     <!-- 
     <S3BlobStore>
       <id>myS3Cache</id>
@@ -63,12 +79,29 @@
       <useGzip>true</useGzip>
     </S3BlobStore>
      -->
+    <!-- A sample MBTiles blob store configuration.   -->
+    <!--
+    <MbtilesBlobStore default="true">
+      <id>mbtiles-store</id>
+      <enabled>true</enabled>
+      <rootDirectory>/tmp/gwc-mbtiles</rootDirectory>
+      <templatePath>{layer}{grid}{format}{params}/{z}-{x}-{y}.sqlite</templatePath>
+      <poolSize>1000</poolSize>
+      <poolReaperIntervalMs>500</poolReaperIntervalMs>
+      <rowRangeCount>250</rowRangeCount>
+      <columnRangeCount>250</columnRangeCount>
+      <eagerDelete>false</eagerDelete>
+      <useCreateTime>true</useCreateTime>
+      <executorConcurrency>5</executorConcurrency>
+      <mbtilesMetadataDirectory>/tmp/gwc-mbtiles/layersMetadata</mbtilesMetadataDirectory>
+    </MbtilesBlobStore>
+    -->
+
   </blobStores>
 
   <gridSets>
     <!-- Grid Set Example, by default EPSG:900913 and EPSG:4326 are defined -->
     <gridSet>
-      <!-- This does not have to be an EPSG code, you can also have multiple gridSet elements per SRS -->
       <name>EPSG:2163</name>
       <srs>
         <number>2163</number>
@@ -90,15 +123,36 @@
       <tileHeight>200</tileHeight>
       <tileWidth>200</tileWidth>
     </gridSet>
+    <gridSet>
+      <name>CanadaAtlasNonotree</name>
+      <srs>
+        <number>3979</number>
+      </srs>
+      <extent>
+        <coords>
+          <double>-2441613</double>
+          <double>-861451</double>
+          <double>3176326</double>
+          <double>3969977</double>
+        </coords>
+      </extent>
+      <resolutions>
+        <double>21945.0742188</double>
+        <double>7315.02473958</double>
+        <double>2438.34157986</double>
+        <double>812.78052662</double>
+        <double>270.926842207</double>
+      </resolutions>
+    </gridSet> 
   </gridSets>
 
   <layers>
-
+    
     <wmsLayer>
       <!-- 
       <blobStoreId>myS3Cache</blobStoreId>
       -->
-      <name>topp:states</name>
+      <name>states</name>
       <mimeFormats>
         <string>image/gif</string>
         <string>image/jpeg</string>
@@ -133,8 +187,17 @@
         </stringParameterFilter>
       </parameterFilters>
       <wmsUrl>
+        <!-- Use of workspace 'topp' web map service, allows name 'states' (rather than 'topp:states') -->
         <string>http://localhost:8080/geoserver/topp/wms</string>
       </wmsUrl>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -145,10 +208,21 @@
         <string>image/png</string>
         <string>image/png8</string>
       </mimeFormats>
+      <gridSubsets>
+        <gridSubset>
+          <gridSetName>EPSG:4326</gridSetName>
+        </gridSubset>
+        <gridSubset>
+          <gridSetName>CanadaAtlasNonotree</gridSetName>
+        </gridSubset>
+      </gridSubsets>
       <wmsUrl>
         <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
-      <wmsLayers>nurc:Img_Sample</wmsLayers>
+      <wmsLayers>nurc:Arc_Sample</wmsLayers>
+      <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
+        <legend style=""/>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -183,12 +257,28 @@
       <expireClientsList>
         <expirationRule minZoom="0" expiration="500" />
       </expireClientsList>
+      <!-- global geoserver wms service allows layers different workspaces -->
       <wmsUrl>
         <string>http://localhost:8080/geoserver/wms</string>
       </wmsUrl>
+      <!-- layers from several workspaces -->
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>
       <bgColor>0x0066FF</bgColor>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+          <minScale>5000</minScale>
+          <maxScale>10000</maxScale>
+        </legend>
+        <legend style="raster">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
   </layers>
 

--- a/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
+++ b/geowebcache/diskquota/bdb/src/test/java/org/geowebcache/diskquota/BDBQuotaStoreTest.java
@@ -142,7 +142,7 @@ public class BDBQuotaStoreTest {
             xmlConfig = new XMLConfiguration(
                     context.getContextProvider(),
                     new MockConfigurationResourceProvider(() -> XMLConfiguration.class.getResourceAsStream(
-                            XMLConfigurationBackwardsCompatibilityTest.LATEST_FILENAME)));
+                            XMLConfigurationBackwardsCompatibilityTest.GWC_130_CONFIG_FILE)));
         } catch (Exception e) {
             // Do nothing
         }

--- a/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
+++ b/geowebcache/diskquota/jdbc/src/test/java/org/geowebcache/diskquota/jdbc/JDBCQuotaStoreTest.java
@@ -281,7 +281,7 @@ public abstract class JDBCQuotaStoreTest {
         return new XMLConfiguration(
                 null,
                 new MockConfigurationResourceProvider(() -> XMLConfiguration.class.getResourceAsStream(
-                        XMLConfigurationBackwardsCompatibilityTest.LATEST_FILENAME)));
+                        XMLConfigurationBackwardsCompatibilityTest.GWC_130_CONFIG_FILE)));
     }
 
     @Test

--- a/geowebcache/georss/src/main/java/org/geowebcache/georss/StaxGeoRSSReader.java
+++ b/geowebcache/georss/src/main/java/org/geowebcache/georss/StaxGeoRSSReader.java
@@ -33,6 +33,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geowebcache.georss.GML31ParsingUtils.GML;
 import org.locationtech.jts.geom.Geometry;
 
@@ -77,7 +78,7 @@ class StaxGeoRSSReader implements GeoRSSReader {
     private final GML31ParsingUtils gmlParser;
 
     public StaxGeoRSSReader(final Reader feed) throws XMLStreamException, FactoryConfigurationError {
-        XMLInputFactory factory = XMLInputFactory.newInstance();
+        XMLInputFactory factory = XMLUtils.newXMLInputFactory();
         reader = factory.createXMLStreamReader(feed);
 
         reader.nextTag();

--- a/geowebcache/pmd-ruleset.xml
+++ b/geowebcache/pmd-ruleset.xml
@@ -270,4 +270,24 @@ GeoWebCache ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.
     </properties>
   </rule>
 
+  <rule name="AvoidSchemaFactory"
+        language="java"
+        message="Do not use SchemaFactory.newInstance(String) directly; recommend XMLUtils.newSchemaFactory(String)"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SchemaFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newInstance(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.validation.SchemaFactory#newInstance(java.lang.String)")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  
 </ruleset>

--- a/geowebcache/pmd-ruleset.xml
+++ b/geowebcache/pmd-ruleset.xml
@@ -114,5 +114,140 @@ GeoWebCache ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.
     <properties>
       <property name="reportLevel" value="140"/>
     </properties>
-  </rule>	 
+  </rule>
+  
+  <rule name="AvoidDocumentBuilderFactory"
+        language="java"
+        message="Do not use DocumentBuildeFactory instance directly; recommend XMLUtils.newDocumentBuilderFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of DocumentBuilderFactory.newInstance() which should be avoided in favor of
+      XMLUtils.DocumentBuilderFactory(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.DocumentBuilderFactory#newInstance()")]
+              ]]>
+          </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidDocumentBuilder"
+        language="java"
+        message="Do not use DocumentBuilder directly; recommend XMLUtils.newDocumentBuilder()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of DocumentBuilderFactory.newDocumentBuilder() which should be avoided in favor of
+      XMLUtils.newDocumentBuilder(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.DocumentBuilderFactory#newDocumentBuilder()")]
+              ]]>
+          </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidTransformFactory"
+        language="java"
+        message="Do not use TransformerFactory directly; recommend XMLUtils.newInstance()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newTransformerFactory(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newInstance()")]
+              ]]>
+          </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidTransformer"
+        language="java"
+        message="Do not use TransformerFactory.newTransformer() directly; recommend XMLUtils.newTransformer()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newTransformer() which should be avoided in favor of
+      XMLUtils.newTransformer(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidTransformerSource"
+        language="java"
+        message="Do not use TransformerFactory.newTransformer(source) directly; recommend XMLUtils.newTransformer(source)"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newTransformer(Source) which should be avoided in favor of
+      XMLUtils.newTransformer(Source,Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer(javax.xml.transform.Source)")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidSAXParserFactory"
+        language="java"
+        message="Do not use ParserFactory.newInstance() directly; recommend XMLUtils.newSAXParserFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newSAXParserFactory(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.SAXParserFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidSaxParser"
+        language="java"
+        message="Do not use SAXParserFactory.newSAXParser() directly; recommend XMLUtils.newSAXParser()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newSAXParser() which should be avoided in favor of
+      XMLUtils.newSAXParser(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.SAXParserFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  
 </ruleset>

--- a/geowebcache/pmd-ruleset.xml
+++ b/geowebcache/pmd-ruleset.xml
@@ -249,5 +249,25 @@ GeoWebCache ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.
       </property>
     </properties>
   </rule>
-  
+
+  <rule name="AvoidXMLInputFactory"
+        language="java"
+        message="Do not use XMLInputFactory.newInstance() directly; recommend XMLUtils.newXMLInputFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newSAXParser() which should be avoided in favor of
+      XMLUtils.newSAXParser(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.stream.XMLInputFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+
 </ruleset>

--- a/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/service/wms/WMSGetCapabilitiesTest.java
@@ -16,8 +16,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.easymock.EasyMock;
+import org.geotools.xml.XMLUtils;
 import org.geowebcache.config.DefaultGridsets;
 import org.geowebcache.config.legends.LegendRawInfo;
 import org.geowebcache.config.legends.LegendsRawInfo;
@@ -120,8 +120,7 @@ public class WMSGetCapabilitiesTest {
 
         String xml = capabilities.generateGetCapabilities(StandardCharsets.UTF_8);
 
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
+        DocumentBuilder builder = XMLUtils.newDocumentBuilder();
         InputSource is = new InputSource();
         is.setCharacterStream(new StringReader(xml));
         Document document = builder.parse(is);


### PR DESCRIPTION
Makes use of the new XMLUtils utility methods introduced following PR:

* https://github.com/geotools/geotools/pull/5639  
  Contains API Change to XMLUtils
* https://github.com/geoserver/geoserver/pull/9502

This will need to be merged at the same time. I have named the branches the same, perhaps we can adjust the "downstream integration workflow" to look for same branch to check out.

Before merging this PR please re-run integration test upstream on https://github.com/geotools/geotools/pull/5639 (it looks for branches with the same name `default-entity-resolver-check`.)

This PR supersedes https://github.com/GeoWebCache/geowebcache/pull/1533 