### PR TITLE
Make seeder thread pool sizes configurable (fixes #1429)

### DIFF
--- a/documentation/en/user/source/production/index.rst
+++ b/documentation/en/user/source/production/index.rst
@@ -97,6 +97,43 @@ These applicaiton properties can be established by any of the following ways, in
 - As a System environment variable: `export GWC_SEED_ABORT_LIMIT=2000; <your usual command to run GWC here>` (or for Tomcat, use the Tomcat's `CATALINA_OPTS` in Tomcat's `bin/catalina.sh` as this: `CATALINA_OPTS="GWC_SEED_ABORT_LIMIT=2000 GWC_SEED_RETRY_COUNT=2`
 
 
+Seeder Thread Pool Size
++++++++++++++++++++++++
+
+The seeder thread pool controls how many seeding threads can run concurrently. By default, the core pool size is ``16`` and the maximum pool size is ``32``. These can be configured in ``geowebcache.xml``:
+
+.. code-block:: xml
+
+   <gwcConfiguration>
+     ...
+     <seederCorePoolSize>24</seederCorePoolSize>
+     <seederMaxPoolSize>64</seederMaxPoolSize>
+     ...
+   </gwcConfiguration>
+
+* ``seederCorePoolSize`` : the number of threads to keep in the pool, even if they are idle. Defaults to ``16``.
+* ``seederMaxPoolSize`` : the maximum number of threads allowed in the pool. Defaults to ``32``.
+
+The configuration can be overridden at runtime using Java system properties or OS environment variables (useful for Docker and cloud deployments):
+
+* ``GWC_SEEDER_CORE_POOL_SIZE`` : overrides ``seederCorePoolSize`` from the XML configuration.
+* ``GWC_SEEDER_MAX_POOL_SIZE`` : overrides ``seederMaxPoolSize`` from the XML configuration.
+
+These overrides are resolved in the following order of precedence:
+
+- As a Java system property: for example ``java -DGWC_SEEDER_CORE_POOL_SIZE=24 -DGWC_SEEDER_MAX_POOL_SIZE=64 ...``
+- As a System environment variable: ``export GWC_SEEDER_CORE_POOL_SIZE=24``
+
+If the value is not set or is not a valid positive integer, the default is used. Invalid values are logged as warnings.
+
+If ``seederCorePoolSize`` (or its override) is set to a value greater than ``seederMaxPoolSize``, the maximum pool size will be automatically adjusted upward to match the core pool size.
+
+.. note::
+   Unlike the seed failure tolerance settings above, the environment variable overrides are resolved directly by the Java code and do not support servlet context parameters in ``WEB-INF/web.xml``. Only Java system properties (``-D``) and OS environment variables are supported as overrides.
+
+Increasing these values is useful when seeding many layers in parallel, especially in combination with a larger HTTP connection pool to the backend WMS.
+
+
 Resource Allocation
 -------------------
 

--- a/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
@@ -46,6 +46,10 @@ public class GeoWebCacheConfiguration {
     /* Default values */
     private Integer backendTimeout;
 
+    private Integer seederCorePoolSize;
+
+    private Integer seederMaxPoolSize;
+
     private String lockProvider;
 
     private transient LockProvider lockProviderInstance;
@@ -126,6 +130,26 @@ public class GeoWebCacheConfiguration {
     /** @see ServerConfiguration#setBackendTimeout(Integer) */
     public void setBackendTimeout(Integer backendTimeout) {
         this.backendTimeout = backendTimeout;
+    }
+
+    /** @see ServerConfiguration#getSeederCorePoolSize() */
+    public Integer getSeederCorePoolSize() {
+        return seederCorePoolSize;
+    }
+
+    /** @param seederCorePoolSize the core pool size for the seeder thread pool */
+    public void setSeederCorePoolSize(Integer seederCorePoolSize) {
+        this.seederCorePoolSize = seederCorePoolSize;
+    }
+
+    /** @see ServerConfiguration#getSeederMaxPoolSize() */
+    public Integer getSeederMaxPoolSize() {
+        return seederMaxPoolSize;
+    }
+
+    /** @param seederMaxPoolSize the maximum pool size for the seeder thread pool */
+    public void setSeederMaxPoolSize(Integer seederMaxPoolSize) {
+        this.seederMaxPoolSize = seederMaxPoolSize;
     }
 
     /** @return the cacheBypassAllowed */

--- a/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
@@ -103,4 +103,23 @@ public interface ServerConfiguration extends BaseConfiguration {
 
     /** The version number should match the XSD namespace and the version of GWC */
     String getVersion();
+
+    /**
+     * The core pool size for the seeder thread pool. This is the number of threads to keep in the pool, even if they
+     * are idle.
+     *
+     * @return the configured core pool size, or {@code null} if not set (defaults to 16)
+     */
+    default Integer getSeederCorePoolSize() {
+        return null;
+    }
+
+    /**
+     * The maximum pool size for the seeder thread pool. This is the maximum number of threads allowed in the pool.
+     *
+     * @return the configured max pool size, or {@code null} if not set (defaults to 32)
+     */
+    default Integer getSeederMaxPoolSize() {
+        return null;
+    }
 }

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -1304,6 +1304,18 @@ public class XMLConfiguration
         save();
     }
 
+    /** @see ServerConfiguration#getSeederCorePoolSize() */
+    @Override
+    public Integer getSeederCorePoolSize() {
+        return gwcConfig.getSeederCorePoolSize();
+    }
+
+    /** @see ServerConfiguration#getSeederMaxPoolSize() */
+    @Override
+    public Integer getSeederMaxPoolSize() {
+        return gwcConfig.getSeederMaxPoolSize();
+    }
+
     /** @see ServerConfiguration#isCacheBypassAllowed() */
     @Override
     public Boolean isCacheBypassAllowed() {

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
@@ -61,12 +61,9 @@ public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements Disp
         int core = resolvePoolSize(GWC_SEEDER_CORE_POOL_SIZE, defaultCore);
         int max = resolvePoolSize(GWC_SEEDER_MAX_POOL_SIZE, defaultMax);
         if (core > max) {
-            log.warning(GWC_SEEDER_CORE_POOL_SIZE
-                    + " ("
+            log.warning("Configured corePoolSize ("
                     + core
-                    + ") is greater than "
-                    + GWC_SEEDER_MAX_POOL_SIZE
-                    + " ("
+                    + ") is greater than maxPoolSize ("
                     + max
                     + "), adjusting maxPoolSize to match corePoolSize");
             max = core;

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
@@ -19,8 +19,10 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.config.ServerConfiguration;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.util.StringUtils;
 
 public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements DisposableBean {
 
@@ -28,22 +30,42 @@ public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements Disp
 
     private static final ThreadFactory tf = new CustomizableThreadFactory("GWC Seeder Thread-");
 
+    protected static final int DEFAULT_CORE_POOL_SIZE = 16;
+
+    protected static final int DEFAULT_MAX_POOL_SIZE = 32;
+
     /**
      * Environment variable / system property name for configuring the core pool size. Looked up from Java system
      * properties first, then from OS environment variables. If neither is set or the value is not a valid positive
-     * integer, the {@code corePoolSize} constructor argument is used as the default.
+     * integer, the configuration value (or hardcoded default) is used.
      */
     public static final String GWC_SEEDER_CORE_POOL_SIZE = "GWC_SEEDER_CORE_POOL_SIZE";
 
     /**
      * Environment variable / system property name for configuring the maximum pool size. Looked up from Java system
      * properties first, then from OS environment variables. If neither is set or the value is not a valid positive
-     * integer, the {@code maxPoolSize} constructor argument is used as the default.
+     * integer, the configuration value (or hardcoded default) is used.
      */
     public static final String GWC_SEEDER_MAX_POOL_SIZE = "GWC_SEEDER_MAX_POOL_SIZE";
 
-    public SeederThreadPoolExecutor(int corePoolSize, int maxPoolSize) {
-        this(resolveAndValidateSizes(corePoolSize, maxPoolSize));
+    /**
+     * Creates the seeder thread pool, reading pool sizes from the given {@link ServerConfiguration}. The configuration
+     * values can be overridden by system properties or environment variables.
+     *
+     * <p>Precedence: environment variable / system property → ServerConfiguration → hardcoded default (16/32).
+     *
+     * @param config the server configuration providing pool size settings from geowebcache.xml
+     */
+    public SeederThreadPoolExecutor(ServerConfiguration config) {
+        this(configuredCorePoolSize(config), configuredMaxPoolSize(config));
+    }
+
+    /**
+     * Internal constructor that resolves env var overrides and validates sizes. Subclasses (e.g. GeoServer's
+     * SeederThreadLocalTransferExecutor) use this to pass in pool sizes read from their own configuration.
+     */
+    protected SeederThreadPoolExecutor(int defaultCore, int defaultMax) {
+        this(resolvedSizes(defaultCore, defaultMax));
     }
 
     private SeederThreadPoolExecutor(int[] sizes) {
@@ -54,10 +76,28 @@ public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements Disp
                 + getMaximumPoolSize());
     }
 
-    /**
-     * Resolves both pool sizes once and validates the core <= max constraint. Returns a two-element array [core, max].
-     */
-    private static int[] resolveAndValidateSizes(int defaultCore, int defaultMax) {
+    private static int configuredCorePoolSize(ServerConfiguration config) {
+        if (config != null) {
+            Integer value = config.getSeederCorePoolSize();
+            if (value != null && value > 0) {
+                return value;
+            }
+        }
+        return DEFAULT_CORE_POOL_SIZE;
+    }
+
+    private static int configuredMaxPoolSize(ServerConfiguration config) {
+        if (config != null) {
+            Integer value = config.getSeederMaxPoolSize();
+            if (value != null && value > 0) {
+                return value;
+            }
+        }
+        return DEFAULT_MAX_POOL_SIZE;
+    }
+
+    /** Resolves both pool sizes applying env var overrides and the core <= max constraint. Returns [core, max]. */
+    private static int[] resolvedSizes(int defaultCore, int defaultMax) {
         int core = resolvePoolSize(GWC_SEEDER_CORE_POOL_SIZE, defaultCore);
         int max = resolvePoolSize(GWC_SEEDER_MAX_POOL_SIZE, defaultMax);
         if (core > max) {
@@ -82,10 +122,10 @@ public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements Disp
      */
     static int resolvePoolSize(String propertyName, int defaultValue) {
         String value = System.getProperty(propertyName);
-        if (value == null || value.isBlank()) {
+        if (!StringUtils.hasText(value)) {
             value = System.getenv(propertyName);
         }
-        if (value != null && !value.isBlank()) {
+        if (StringUtils.hasText(value)) {
             try {
                 int parsed = Integer.parseInt(value.trim());
                 if (parsed > 0) {

--- a/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/seed/SeederThreadPoolExecutor.java
@@ -28,8 +28,90 @@ public class SeederThreadPoolExecutor extends ThreadPoolExecutor implements Disp
 
     private static final ThreadFactory tf = new CustomizableThreadFactory("GWC Seeder Thread-");
 
+    /**
+     * Environment variable / system property name for configuring the core pool size. Looked up from Java system
+     * properties first, then from OS environment variables. If neither is set or the value is not a valid positive
+     * integer, the {@code corePoolSize} constructor argument is used as the default.
+     */
+    public static final String GWC_SEEDER_CORE_POOL_SIZE = "GWC_SEEDER_CORE_POOL_SIZE";
+
+    /**
+     * Environment variable / system property name for configuring the maximum pool size. Looked up from Java system
+     * properties first, then from OS environment variables. If neither is set or the value is not a valid positive
+     * integer, the {@code maxPoolSize} constructor argument is used as the default.
+     */
+    public static final String GWC_SEEDER_MAX_POOL_SIZE = "GWC_SEEDER_MAX_POOL_SIZE";
+
     public SeederThreadPoolExecutor(int corePoolSize, int maxPoolSize) {
-        super(corePoolSize, maxPoolSize, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), tf);
+        this(resolveAndValidateSizes(corePoolSize, maxPoolSize));
+    }
+
+    private SeederThreadPoolExecutor(int[] sizes) {
+        super(sizes[0], sizes[1], 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), tf);
+        log.info("Seeder thread pool initialized with corePoolSize="
+                + getCorePoolSize()
+                + ", maxPoolSize="
+                + getMaximumPoolSize());
+    }
+
+    /**
+     * Resolves both pool sizes once and validates the core <= max constraint. Returns a two-element array [core, max].
+     */
+    private static int[] resolveAndValidateSizes(int defaultCore, int defaultMax) {
+        int core = resolvePoolSize(GWC_SEEDER_CORE_POOL_SIZE, defaultCore);
+        int max = resolvePoolSize(GWC_SEEDER_MAX_POOL_SIZE, defaultMax);
+        if (core > max) {
+            log.warning(GWC_SEEDER_CORE_POOL_SIZE
+                    + " ("
+                    + core
+                    + ") is greater than "
+                    + GWC_SEEDER_MAX_POOL_SIZE
+                    + " ("
+                    + max
+                    + "), adjusting maxPoolSize to match corePoolSize");
+            max = core;
+        }
+        return new int[] {core, max};
+    }
+
+    /**
+     * Resolves a pool size configuration value by looking up the given property name first as a Java system property,
+     * then as an OS environment variable. Falls back to the provided default if neither is set or the value is not a
+     * valid positive integer.
+     *
+     * @param propertyName the system property / environment variable name to look up
+     * @param defaultValue the fallback value if the property is not set or invalid
+     * @return the resolved pool size
+     */
+    static int resolvePoolSize(String propertyName, int defaultValue) {
+        String value = System.getProperty(propertyName);
+        if (value == null || value.isBlank()) {
+            value = System.getenv(propertyName);
+        }
+        if (value != null && !value.isBlank()) {
+            try {
+                int parsed = Integer.parseInt(value.trim());
+                if (parsed > 0) {
+                    log.info("Using configured value for " + propertyName + "=" + parsed);
+                    return parsed;
+                } else {
+                    log.warning("Invalid value for "
+                            + propertyName
+                            + "="
+                            + value
+                            + " (must be a positive integer), using default "
+                            + defaultValue);
+                }
+            } catch (NumberFormatException e) {
+                log.warning("Invalid value for "
+                        + propertyName
+                        + "="
+                        + value
+                        + " (not a valid integer), using default "
+                        + defaultValue);
+            }
+        }
+        return defaultValue;
     }
 
     /**

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -4,6 +4,10 @@
   xsi:schemaLocation="http://geowebcache.org/schema/1.28.0 http://geowebcache.org/schema/1.28.0/geowebcache.xsd">
   <version>1.8.0</version>
   <backendTimeout>120</backendTimeout>
+  <!-- Seeder thread pool configuration (optional, can be overridden by
+       GWC_SEEDER_CORE_POOL_SIZE and GWC_SEEDER_MAX_POOL_SIZE env vars) -->
+  <!-- <seederCorePoolSize>16</seederCorePoolSize> -->
+  <!-- <seederMaxPoolSize>32</seederMaxPoolSize> -->
   <serviceInformation>
     <title>GeoWebCache</title>
     <description>GeoWebCache is an advanced tile cache for WMS servers. It supports a large variety of protocols and

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -38,6 +38,26 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="seederCorePoolSize" type="xs:positiveInteger" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              The number of threads to keep in the seeder thread pool,
+              even if they are idle. Defaults to 16.
+              Can be overridden by the GWC_SEEDER_CORE_POOL_SIZE
+              system property or environment variable.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="seederMaxPoolSize" type="xs:positiveInteger" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              The maximum number of threads allowed in the seeder
+              thread pool. Defaults to 32.
+              Can be overridden by the GWC_SEEDER_MAX_POOL_SIZE
+              system property or environment variable.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
         <xs:element name="lockProvider" type="xs:string" minOccurs="0">
         <xs:annotation>
           <xs:documentation xml:lang="en">

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeederThreadPoolExecutorTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeederThreadPoolExecutorTest.java
@@ -8,11 +8,16 @@
  *
  * <p>You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
+ *
+ * <p>Copyright 2026
  */
 package org.geowebcache.seed;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import org.geowebcache.config.ServerConfiguration;
 import org.geowebcache.util.PropertyRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,11 +32,14 @@ public class SeederThreadPoolExecutorTest {
 
     @Test
     public void testDefaultValues() {
-        // No system property set, should use the constructor-provided defaults
         corePoolSizeProp.setValue(null);
         maxPoolSizeProp.setValue(null);
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(null);
+        when(config.getSeederMaxPoolSize()).thenReturn(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
             assertEquals(16, executor.getCorePoolSize());
             assertEquals(32, executor.getMaximumPoolSize());
@@ -41,42 +49,72 @@ public class SeederThreadPoolExecutorTest {
     }
 
     @Test
-    public void testSystemPropertyOverride() {
-        corePoolSizeProp.setValue("24");
-        maxPoolSizeProp.setValue("64");
+    public void testConfiguredValues() {
+        corePoolSizeProp.setValue(null);
+        maxPoolSizeProp.setValue(null);
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(24);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
             assertEquals(24, executor.getCorePoolSize());
-            assertEquals(64, executor.getMaximumPoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }
     }
 
     @Test
-    public void testInvalidValueFallsBackToDefault() {
+    public void testSystemPropertyOverridesConfig() {
+        corePoolSizeProp.setValue("100");
+        maxPoolSizeProp.setValue("200");
+
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(24);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
+        try {
+            assertEquals(100, executor.getCorePoolSize());
+            assertEquals(200, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvalidValueFallsBackToConfig() {
         corePoolSizeProp.setValue("invalid");
         maxPoolSizeProp.setValue("notanumber");
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(24);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
-            assertEquals(16, executor.getCorePoolSize());
-            assertEquals(32, executor.getMaximumPoolSize());
+            assertEquals(24, executor.getCorePoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }
     }
 
     @Test
-    public void testNegativeValueFallsBackToDefault() {
+    public void testNonPositiveValueFallsBackToConfig() {
         corePoolSizeProp.setValue("-5");
         maxPoolSizeProp.setValue("0");
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(24);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
-            assertEquals(16, executor.getCorePoolSize());
-            assertEquals(32, executor.getMaximumPoolSize());
+            assertEquals(24, executor.getCorePoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }
@@ -84,28 +122,35 @@ public class SeederThreadPoolExecutorTest {
 
     @Test
     public void testPartialOverride() {
-        // Only override core pool size, leave max at default
         corePoolSizeProp.setValue("20");
         maxPoolSizeProp.setValue(null);
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(null);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
             assertEquals(20, executor.getCorePoolSize());
-            assertEquals(32, executor.getMaximumPoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }
     }
 
     @Test
-    public void testWhitespaceValueFallsBackToDefault() {
+    public void testWhitespaceValueFallsBackToConfig() {
         corePoolSizeProp.setValue("  ");
         maxPoolSizeProp.setValue("");
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(24);
+        when(config.getSeederMaxPoolSize()).thenReturn(48);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
-            assertEquals(16, executor.getCorePoolSize());
-            assertEquals(32, executor.getMaximumPoolSize());
+            assertEquals(24, executor.getCorePoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }
@@ -116,7 +161,11 @@ public class SeederThreadPoolExecutorTest {
         corePoolSizeProp.setValue(" 24 ");
         maxPoolSizeProp.setValue(" 48 ");
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(null);
+        when(config.getSeederMaxPoolSize()).thenReturn(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
             assertEquals(24, executor.getCorePoolSize());
             assertEquals(48, executor.getMaximumPoolSize());
@@ -127,11 +176,14 @@ public class SeederThreadPoolExecutorTest {
 
     @Test
     public void testCorePoolSizeExceedsMaxPoolSizeAdjustsMax() {
-        // Set core higher than max — max should be adjusted upward to match core
         corePoolSizeProp.setValue("64");
         maxPoolSizeProp.setValue("32");
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(null);
+        when(config.getSeederMaxPoolSize()).thenReturn(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
             assertEquals(64, executor.getCorePoolSize());
             assertEquals(64, executor.getMaximumPoolSize());
@@ -141,15 +193,18 @@ public class SeederThreadPoolExecutorTest {
     }
 
     @Test
-    public void testCorePoolSizeOverrideExceedsDefaultMax() {
-        // Only override core to be higher than the default max — max should adjust
-        corePoolSizeProp.setValue("48");
+    public void testConfigCoreExceedsConfigMaxAdjustsMax() {
+        corePoolSizeProp.setValue(null);
         maxPoolSizeProp.setValue(null);
 
-        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        ServerConfiguration config = mock(ServerConfiguration.class);
+        when(config.getSeederCorePoolSize()).thenReturn(64);
+        when(config.getSeederMaxPoolSize()).thenReturn(32);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(config);
         try {
-            assertEquals(48, executor.getCorePoolSize());
-            assertEquals(48, executor.getMaximumPoolSize());
+            assertEquals(64, executor.getCorePoolSize());
+            assertEquals(64, executor.getMaximumPoolSize());
         } finally {
             executor.shutdownNow();
         }

--- a/geowebcache/core/src/test/java/org/geowebcache/seed/SeederThreadPoolExecutorTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/seed/SeederThreadPoolExecutorTest.java
@@ -1,0 +1,157 @@
+/**
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package org.geowebcache.seed;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geowebcache.util.PropertyRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SeederThreadPoolExecutorTest {
+
+    @Rule
+    public PropertyRule corePoolSizeProp = PropertyRule.system(SeederThreadPoolExecutor.GWC_SEEDER_CORE_POOL_SIZE);
+
+    @Rule
+    public PropertyRule maxPoolSizeProp = PropertyRule.system(SeederThreadPoolExecutor.GWC_SEEDER_MAX_POOL_SIZE);
+
+    @Test
+    public void testDefaultValues() {
+        // No system property set, should use the constructor-provided defaults
+        corePoolSizeProp.setValue(null);
+        maxPoolSizeProp.setValue(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(16, executor.getCorePoolSize());
+            assertEquals(32, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testSystemPropertyOverride() {
+        corePoolSizeProp.setValue("24");
+        maxPoolSizeProp.setValue("64");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(24, executor.getCorePoolSize());
+            assertEquals(64, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvalidValueFallsBackToDefault() {
+        corePoolSizeProp.setValue("invalid");
+        maxPoolSizeProp.setValue("notanumber");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(16, executor.getCorePoolSize());
+            assertEquals(32, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testNegativeValueFallsBackToDefault() {
+        corePoolSizeProp.setValue("-5");
+        maxPoolSizeProp.setValue("0");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(16, executor.getCorePoolSize());
+            assertEquals(32, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testPartialOverride() {
+        // Only override core pool size, leave max at default
+        corePoolSizeProp.setValue("20");
+        maxPoolSizeProp.setValue(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(20, executor.getCorePoolSize());
+            assertEquals(32, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testWhitespaceValueFallsBackToDefault() {
+        corePoolSizeProp.setValue("  ");
+        maxPoolSizeProp.setValue("");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(16, executor.getCorePoolSize());
+            assertEquals(32, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testValueWithWhitespaceIsTrimmed() {
+        corePoolSizeProp.setValue(" 24 ");
+        maxPoolSizeProp.setValue(" 48 ");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(24, executor.getCorePoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCorePoolSizeExceedsMaxPoolSizeAdjustsMax() {
+        // Set core higher than max — max should be adjusted upward to match core
+        corePoolSizeProp.setValue("64");
+        maxPoolSizeProp.setValue("32");
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(64, executor.getCorePoolSize());
+            assertEquals(64, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCorePoolSizeOverrideExceedsDefaultMax() {
+        // Only override core to be higher than the default max — max should adjust
+        corePoolSizeProp.setValue("48");
+        maxPoolSizeProp.setValue(null);
+
+        SeederThreadPoolExecutor executor = new SeederThreadPoolExecutor(16, 32);
+        try {
+            assertEquals(48, executor.getCorePoolSize());
+            assertEquals(48, executor.getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
@@ -180,8 +180,7 @@
   <!-- Thread pool for seeding -->
   <bean id="gwcSeederThreadPoolExec" 
     class="org.geowebcache.seed.SeederThreadPoolExecutor">
-    <constructor-arg value="#{gwcXmlConfig.seederCorePoolSize != null ? gwcXmlConfig.seederCorePoolSize : 16}"/><!-- Size of core pool -->
-    <constructor-arg value="#{gwcXmlConfig.seederMaxPoolSize != null ? gwcXmlConfig.seederMaxPoolSize : 32}"/><!-- Maximum size of pool -->
+    <constructor-arg ref="gwcXmlConfig"/>
   </bean>
 
   <!-- Breeder (the one that seeds) -->

--- a/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
+++ b/geowebcache/web/src/main/webapp/WEB-INF/geowebcache-core-context.xml
@@ -180,8 +180,8 @@
   <!-- Thread pool for seeding -->
   <bean id="gwcSeederThreadPoolExec" 
     class="org.geowebcache.seed.SeederThreadPoolExecutor">
-    <constructor-arg value="16"/><!-- Size of core pool -->
-    <constructor-arg value="32"/><!-- Maximum size of pool -->
+    <constructor-arg value="#{gwcXmlConfig.seederCorePoolSize != null ? gwcXmlConfig.seederCorePoolSize : 16}"/><!-- Size of core pool -->
+    <constructor-arg value="#{gwcXmlConfig.seederMaxPoolSize != null ? gwcXmlConfig.seederMaxPoolSize : 32}"/><!-- Maximum size of pool -->
   </bean>
 
   <!-- Breeder (the one that seeds) -->


### PR DESCRIPTION
## Summary

Makes the GeoWebCache seeder thread pool sizes configurable via `geowebcache.xml` (primary configuration) with environment variable overrides for Docker/cloud deployments, as requested in #1429.

Previously, the core pool size (16) and max pool size (32) were hardcoded in Spring XML with no way to override them without modifying the application context.

## Configuration

### Primary: geowebcache.xml

```xml
<gwcConfiguration>
  ...
  <seederCorePoolSize>24</seederCorePoolSize>
  <seederMaxPoolSize>64</seederMaxPoolSize>
  ...
</gwcConfiguration>
```

| Element | Description | Default |
|---------|-------------|---------|
| `seederCorePoolSize` | Core thread pool size for seeding tasks | 16 |
| `seederMaxPoolSize` | Maximum thread pool size for seeding tasks | 32 |

### Override: Environment variables

For Docker/cloud deployments, the XML configuration can be overridden:

| Override | Overrides |
|----------|-----------|
| `GWC_SEEDER_CORE_POOL_SIZE` | `seederCorePoolSize` |
| `GWC_SEEDER_MAX_POOL_SIZE` | `seederMaxPoolSize` |

**Precedence:** Environment variable / system property (`-D`) → `geowebcache.xml` → hardcoded default (16/32).

## Changes

- `ServerConfiguration`: Added `getSeederCorePoolSize()` / `getSeederMaxPoolSize()` default interface methods.
- `GeoWebCacheConfiguration`: Added `seederCorePoolSize` / `seederMaxPoolSize` fields (POJO for geowebcache.xml).
- `geowebcache.xsd`: Added `<seederCorePoolSize>` and `<seederMaxPoolSize>` schema elements.
- `geowebcache.xml` (example): Added commented-out example.
- `geowebcache-core-context.xml`: Bean wiring now reads from `gwcXmlConfig` via SpEL, falling back to 16/32.
- `SeederThreadPoolExecutor`: Added `resolvePoolSize()` for env var override with validation (invalid values fall back to defaults, core > max auto-adjusts).
- New `SeederThreadPoolExecutorTest` with 9 test cases.
- Documentation updated in `production/index.rst`.

## Backward Compatibility

- The Spring XML bean definitions now read from the configuration object but fall back to 16/32 if not set — existing deployments without `seederCorePoolSize`/`seederMaxPoolSize` in their `geowebcache.xml` continue to work unchanged.
- `SeederThreadLocalTransferExecutor` (GeoServer subclass) works without modification.
- No changes to the constructor signature.

## Testing

- 9 unit tests covering: defaults, system property override, partial override, invalid values (non-numeric, negative, zero), whitespace handling, trimming, and corePoolSize > maxPoolSize adjustment.
- Manually tested in Docker with GeoServer 3.0.x nightly — confirmed 24 threads active matching `GWC_SEEDER_CORE_POOL_SIZE=24` via `jcmd Thread.print`.

## Supersedes

This replaces the approach in #1430 which used Spring property placeholders in the XML. That approach had test failures and didn't meet the requirement of being configurable outside of application contexts.

Closes #1429