### PR TITLE
Improve dispatcher error logging for client errors

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/GeoWebCacheDispatcher.java
@@ -316,6 +316,9 @@ public class GeoWebCacheDispatcher extends AbstractController {
                     CacheResult.OTHER,
                     runtimeStats);
             LOG.warning(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            ResponseUtils.writeErrorPage(response, 400, e.getMessage(), runtimeStats);
+            LOG.log(Level.WARNING, e.getMessage());
         } catch (Exception e) {
             if (!(e instanceof BadTileException) || LOG.isLoggable(Level.FINE)) {
                 LOG.severe(e.getMessage() + " " + request.getRequestURL().toString());


### PR DESCRIPTION
Catch IllegalArgumentException separately in GeoWebCacheDispatcher and log at WARNING level with message only (no stack trace).

These are client errors (e.g. requesting an unsupported format like 'image/png is not a supported format for layer_name') that do not warrant a full stack trace at SEVERE level. The client still receives a proper 400 response with the error message.