### PR TITLE
Allow parameter filters to be private and not exposed in capabilities OL preview and the like

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/demo/Demo.java
@@ -406,6 +406,9 @@ public class Demo {
         doc.append("<table>\n");
         for (ParameterFilter pf : parameterFilters) {
             Assert.notNull(pf, "The parameter filter must be non null");
+            if (!pf.isUserVisible()) {
+                continue;
+            }
             String key = pf.getKey();
             String defaultValue = pf.getDefaultValue();
             List<String> legalValues = pf.getLegalValues();

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -56,6 +56,17 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
         return key;
     }
 
+    /**
+     * Whether this filter should be shown to clients in user-facing surfaces (preview, seed form, WMS/WMTS
+     * capabilities). Synthetic filters that exist only to partition the cache should return {@code false} so they stay
+     * out of those surfaces while still taking part in cache key computation. One example of such parameter is an
+     * internal filter matching the current security setup, or whatever other machinery migth change the contents of a
+     * tile (e.g., a dispatcher callback clipping rasters as a home-grown security system)
+     */
+    public boolean isUserVisible() {
+        return true;
+    }
+
     /** Get the default value to use if the parameter is not specified. */
     public String getDefaultValue() {
         if (defaultValue == null) return "";

--- a/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/filter/parameters/ParameterFilter.java
@@ -59,9 +59,9 @@ public abstract class ParameterFilter implements Serializable, Cloneable {
     /**
      * Whether this filter should be shown to clients in user-facing surfaces (preview, seed form, WMS/WMTS
      * capabilities). Synthetic filters that exist only to partition the cache should return {@code false} so they stay
-     * out of those surfaces while still taking part in cache key computation. One example of such parameter is an
-     * internal filter matching the current security setup, or whatever other machinery migth change the contents of a
-     * tile (e.g., a dispatcher callback clipping rasters as a home-grown security system)
+     * out of those surfaces while still taking part in cache key computation. One example of such a parameter is an
+     * internal filter matching the current security setup, or whatever other machinery might change the contents of a
+     * tile (e.g., a dispatcher callback clipping rasters as a home-grown security system).
      */
     public boolean isUserVisible() {
         return true;

--- a/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
+++ b/geowebcache/rest/src/main/java/org/geowebcache/rest/service/FormService.java
@@ -337,6 +337,9 @@ public class FormService {
         doc.append("<table>");
         for (ParameterFilter pf : parameterFilters) {
             Assert.notNull(pf, "Parameter filter must be non null");
+            if (!pf.isUserVisible()) {
+                continue;
+            }
             String key = pf.getKey();
             String defaultValue = pf.getDefaultValue();
             List<String> legalValues = pf.getLegalValues();

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSGetCapabilities.java
@@ -542,6 +542,9 @@ public class WMSGetCapabilities {
             StringBuilder dims = new StringBuilder();
             StringBuilder extents = new StringBuilder();
             for (ParameterFilter parameterFilter : layer.getParameterFilters()) {
+                if (!parameterFilter.isUserVisible()) {
+                    continue;
+                }
                 if (parameterFilter instanceof WMSDimensionProvider provider) {
                     provider.appendDimensionElement(dims, "      ");
                     provider.appendExtentElement(extents, "      ");

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -470,8 +470,11 @@ public class WMTSGetCapabilities {
             }
         }
 
-        // We need the filters for styles and dimensions
+        // We need the filters for styles and dimensions; drop synthetic, non user-visible ones (e.g. security)
         List<ParameterFilter> filters = layer.getParameterFilters();
+        if (filters != null) {
+            filters = filters.stream().filter(ParameterFilter::isUserVisible).toList();
+        }
 
         layerStyles(xml, layer, filters);
 

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -755,6 +755,7 @@ public class WMTSServiceTest {
             List<String> gridSetNames = Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
 
             ParameterFilter styleFilter = mock(ParameterFilter.class);
+            when(styleFilter.isUserVisible()).thenReturn(true);
             when(styleFilter.getKey()).thenReturn("STYLES");
             when(styleFilter.getDefaultValue()).thenReturn("Foo");
             when(styleFilter.getLegalValues()).thenReturn(null);
@@ -813,6 +814,7 @@ public class WMTSServiceTest {
             List<String> gridSetNames = Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
 
             ParameterFilter styleFilter = mock(ParameterFilter.class);
+            when(styleFilter.isUserVisible()).thenReturn(true);
             when(styleFilter.getKey()).thenReturn("STYLES");
             when(styleFilter.getDefaultValue()).thenReturn("Foo");
             when(styleFilter.getLegalValues()).thenReturn(Collections.emptyList());
@@ -871,6 +873,7 @@ public class WMTSServiceTest {
             List<String> gridSetNames = Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
 
             ParameterFilter styleFilter = mock(ParameterFilter.class);
+            when(styleFilter.isUserVisible()).thenReturn(true);
             when(styleFilter.getKey()).thenReturn("STYLES");
             when(styleFilter.getDefaultValue()).thenReturn("Foo");
             when(styleFilter.getLegalValues()).thenReturn(Arrays.asList("Foo", "Bar", "Baz"));
@@ -972,16 +975,19 @@ public class WMTSServiceTest {
             List<String> gridSetNames = Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
 
             ParameterFilter styleFilter = mock(ParameterFilter.class);
+            when(styleFilter.isUserVisible()).thenReturn(true);
             when(styleFilter.getKey()).thenReturn("STYLES");
             when(styleFilter.getDefaultValue()).thenReturn("Foo");
             when(styleFilter.getLegalValues()).thenReturn(Arrays.asList("Foo", "Bar", "Baz"));
 
             ParameterFilter elevationDimension = mock(ParameterFilter.class);
+            when(elevationDimension.isUserVisible()).thenReturn(true);
             when(elevationDimension.getKey()).thenReturn("elevation");
             when(elevationDimension.getDefaultValue()).thenReturn("0");
             when(elevationDimension.getLegalValues()).thenReturn(Arrays.asList("0", "200", "400", "600"));
 
             ParameterFilter timeDimension = mock(ParameterFilter.class);
+            when(timeDimension.isUserVisible()).thenReturn(true);
             when(timeDimension.getKey()).thenReturn("time");
             when(timeDimension.getDefaultValue()).thenReturn("2016-02-23T03:00:00.00");
             when(timeDimension.getLegalValues()).thenReturn(Collections.emptyList());
@@ -1049,6 +1055,7 @@ public class WMTSServiceTest {
             List<String> gridSetNames = Arrays.asList("GlobalCRS84Pixel", "GlobalCRS84Scale", "EPSG:4326");
 
             ParameterFilter styleFilter = mock(ParameterFilter.class);
+            when(styleFilter.isUserVisible()).thenReturn(true);
             when(styleFilter.getKey()).thenReturn("STYLES");
             when(styleFilter.getDefaultValue()).thenReturn("Foo");
             when(styleFilter.getLegalValues()).thenReturn(Arrays.asList("Foo", "Bar", "Baz"));


### PR DESCRIPTION
In preparation for https://github.com/geoserver/geoserver/wiki/GSIP-241, which is adding on the fly a couple of of such parameters (the security rules summary and the security tags)